### PR TITLE
Dimokritos/exercise-error-handling

### DIFF
--- a/src/app/admin/vocabulary/page.tsx
+++ b/src/app/admin/vocabulary/page.tsx
@@ -13,6 +13,7 @@ import {
   useUpdateWordMutation,
   useCreateWordMutation,
   useDeleteWordMutation,
+  type DeleteWordResponse,
 } from '@/src/store/api/vocabularyApi';
 import {
   updateFilters as updateFiltersAction,
@@ -24,6 +25,7 @@ import { WordEditPanel } from '@/src/components/ui/admin/vocabulary/WordEditPane
 import { VocabularyFiltersComponent } from '@/src/components/ui/admin/vocabulary/VocabularyFilters';
 import { VocabularyList } from '@/src/components/ui/admin/vocabulary/VocabularyList';
 import { withAdminAuth } from '@/src/components/auth/withAdminAuth';
+import { ConfirmationDialog } from '@/src/components/ui/core/ConfirmationDialog';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/src/components/ui/select';
 import { PartOfSpeechSchema, type PartOfSpeech } from '@/shared/types/vocabulary/schemas/enums';
 import { buildEmptyWord, isPlaceholderWord } from '@/src/utils/vocabulary-defaults';
@@ -42,6 +44,10 @@ function AdminVocabularyPage() {
   const [selectedWordId, setSelectedWordId] = useState<string | null>(null);
   const [creatingWord, setCreatingWord] = useState<VocabularyWordWithId | null>(null);
   const [deletingWordId, setDeletingWordId] = useState<string | null>(null);
+  const [poolWarning, setPoolWarning] = useState<{
+    word: VocabularyWordWithId;
+    pools: { id: string; name: string }[];
+  } | null>(null);
   const TARGET_COLLECTION = VOCABULARY_WORDS_COLLECTION;
 
   const queryArgs = {
@@ -199,21 +205,32 @@ function AdminVocabularyPage() {
     setSelectedWordId(null);
   };
 
-  const handleDeleteWord = async (word: VocabularyWordWithId) => {
+  const handleDeleteWord = async (word: VocabularyWordWithId, confirm = false) => {
     setDeletingWordId(word.id);
     try {
-      await deleteWord(word.id).unwrap();
+      await deleteWord({ wordId: word.id, confirm }).unwrap();
       toast.success(`Word "${word.word}" deleted successfully`);
       if (selectedWordId === word.id) {
         setSelectedWordId(null);
       }
     } catch (error) {
+      const fetchError = error as { status?: number; data?: DeleteWordResponse };
+      if (fetchError.status === 409 && fetchError.data?.warning && fetchError.data.referencedPools) {
+        setPoolWarning({ word, pools: fetchError.data.referencedPools });
+        return;
+      }
       console.error('Delete word error:', error);
       const message = error instanceof Error ? error.message : 'Error deleting word';
       toast.error(message);
     } finally {
       setDeletingWordId(null);
     }
+  };
+
+  const handleConfirmDeleteWithPools = async () => {
+    if (!poolWarning) return;
+    setPoolWarning(null);
+    await handleDeleteWord(poolWarning.word, true);
   };
 
   const handleBackup = () => {
@@ -304,6 +321,20 @@ function AdminVocabularyPage() {
           />
         </div>
       </main>
+
+      <ConfirmationDialog
+        isOpen={!!poolWarning}
+        onClose={() => setPoolWarning(null)}
+        onConfirm={handleConfirmDeleteWithPools}
+        title="Word Used in Vocabulary Pools"
+        description={
+          poolWarning
+            ? `The word "${poolWarning.word.word}" is used in the following pool(s): ${poolWarning.pools.map(p => p.name).join(', ')}. Deleting it will remove it from those pools. Continue?`
+            : ''
+        }
+        confirmText="Delete & Remove from Pools"
+        cancelText="Cancel"
+      />
     </div>
   );
 }

--- a/src/app/api/admin/vocabulary-pools/[poolId]/route.ts
+++ b/src/app/api/admin/vocabulary-pools/[poolId]/route.ts
@@ -87,6 +87,19 @@ export async function GET(request: NextRequest, { params }: { params: { poolId: 
         }
       });
 
+      if (missingWordIds.length > 0) {
+        // Fire-and-forget cleanup - don't block the response
+        adminDb
+          .collection('vocabulary_pools')
+          .doc(poolId)
+          .update({
+            wordDocIds: orderedWords.map(w => w.id),
+            'metadata.wordCount': orderedWords.length,
+            'metadata.updatedAt': new Date(),
+          })
+          .catch(err => console.error('Auto-cleanup of dangling word references failed:', err));
+      }
+
       return NextResponse.json({
         success: true,
         data: {

--- a/src/app/api/admin/words/[wordId]/route.ts
+++ b/src/app/api/admin/words/[wordId]/route.ts
@@ -2,11 +2,24 @@ import { NextRequest, NextResponse } from 'next/server';
 import { adminDb } from '@/src/services/firebase-admin';
 import { VOCABULARY_WORDS_COLLECTION } from '@/shared/constants/firestore';
 
+async function findPoolsReferencingWord(wordId: string) {
+  const poolsSnapshot = await adminDb
+    .collection('vocabulary_pools')
+    .where('wordDocIds', 'array-contains', wordId)
+    .get();
+
+  return poolsSnapshot.docs.map(doc => ({
+    id: doc.id,
+    name: doc.data().name as string,
+  }));
+}
+
 export async function DELETE(request: NextRequest, { params }: { params: { wordId: string } }): Promise<NextResponse> {
   try {
     const { wordId } = params;
     const { searchParams } = new URL(request.url);
     const collection = searchParams.get('collection') || VOCABULARY_WORDS_COLLECTION;
+    const confirm = searchParams.get('confirm') === 'true';
 
     if (!wordId) {
       return NextResponse.json(
@@ -16,6 +29,48 @@ export async function DELETE(request: NextRequest, { params }: { params: { wordI
         },
         { status: 400 }
       );
+    }
+
+    const referencedPools = await findPoolsReferencingWord(wordId);
+
+    if (referencedPools.length > 0 && !confirm) {
+      return NextResponse.json(
+        {
+          success: false,
+          warning: true,
+          referencedPools,
+          message: `This word is referenced by ${referencedPools.length} vocabulary pool(s). Deleting it will remove it from those pools.`,
+        },
+        { status: 409 }
+      );
+    }
+
+    if (referencedPools.length > 0 && confirm) {
+      const batch = adminDb.batch();
+
+      batch.delete(adminDb.collection(collection).doc(wordId));
+
+      for (const pool of referencedPools) {
+        const poolRef = adminDb.collection('vocabulary_pools').doc(pool.id);
+        const poolDoc = await poolRef.get();
+        const poolData = poolDoc.data();
+        if (poolData) {
+          const updatedWordIds = (poolData.wordDocIds || []).filter((id: string) => id !== wordId);
+          batch.update(poolRef, {
+            wordDocIds: updatedWordIds,
+            'metadata.wordCount': updatedWordIds.length,
+            'metadata.updatedAt': new Date(),
+          });
+        }
+      }
+
+      await batch.commit();
+
+      return NextResponse.json({
+        success: true,
+        message: 'Word deleted and removed from referencing pools',
+        cleanedPools: referencedPools.map(p => p.name),
+      });
     }
 
     await adminDb.collection(collection).doc(wordId).delete();

--- a/src/components/ui/lesson/VocabularyPoolViewer.tsx
+++ b/src/components/ui/lesson/VocabularyPoolViewer.tsx
@@ -34,7 +34,11 @@ export function VocabularyPoolViewer({ content }: VocabularyPoolViewerProps) {
   const poolIdToUse = poolIdFromEditor || poolIdFromLesson;
   const isResolvingPoolId = !poolIdFromEditor && Boolean(lessonId) && lessonsLoading;
 
-  const { data: vocabularyPool, isLoading: poolLoading } = useGetPoolQuery(poolIdToUse, { skip: !poolIdToUse });
+  const {
+    data: vocabularyPool,
+    isLoading: poolLoading,
+    error: poolError,
+  } = useGetPoolQuery(poolIdToUse, { skip: !poolIdToUse });
 
   if (!poolIdToUse) {
     if (isResolvingPoolId) {
@@ -67,6 +71,23 @@ export function VocabularyPoolViewer({ content }: VocabularyPoolViewerProps) {
           <RomanCardContent className="p-8 text-center">
             <BookOpen className="h-12 w-12 mx-auto text-gray-300 mb-4" />
             <p className="text-gray-500">No vocabulary pool assigned to this lesson.</p>
+          </RomanCardContent>
+        </RomanCard>
+      </div>
+    );
+  }
+
+  if (poolError) {
+    return (
+      <div className="space-y-6">
+        <RomanCard>
+          <RomanCardContent className="p-8 text-center">
+            <BookOpen className="h-12 w-12 mx-auto text-red-300 mb-4" />
+            <p className="text-red-600 font-medium">Failed to load vocabulary pool</p>
+            <p className="text-roman-stone text-sm mt-2">
+              The vocabulary pool for this lesson could not be loaded. It may have been removed or is temporarily
+              unavailable.
+            </p>
           </RomanCardContent>
         </RomanCard>
       </div>

--- a/src/components/ui/lesson/exercise-error-boundary.tsx
+++ b/src/components/ui/lesson/exercise-error-boundary.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import { RomanCard, RomanCardContent } from '@/src/components/ui/core/roman-card';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/src/components/ui/button';
+
+interface ExerciseErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ExerciseErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ExerciseErrorBoundary extends React.Component<ExerciseErrorBoundaryProps, ExerciseErrorBoundaryState> {
+  constructor(props: ExerciseErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ExerciseErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('Exercise rendering error:', error, errorInfo);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <RomanCard>
+          <RomanCardContent className="p-8 text-center">
+            <AlertTriangle className="h-12 w-12 mx-auto text-roman-red/60 mb-4" />
+            <p className="text-roman-red font-medium">This exercise failed to load</p>
+            <p className="text-roman-stone text-sm mt-2">
+              An error occurred while rendering this content. You can try again or skip to the next item.
+            </p>
+            <Button variant="outline" className="mt-4" onClick={this.handleReset}>
+              Try Again
+            </Button>
+          </RomanCardContent>
+        </RomanCard>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/ui/lesson/page-template.tsx
+++ b/src/components/ui/lesson/page-template.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { Page } from '@/src/types/lesson';
 import ContentRenderer from './content-renderer';
+import { ExerciseErrorBoundary } from './exercise-error-boundary';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
 import { isExerciseType } from '@/src/utils/lessonUtils';
 
@@ -67,12 +68,14 @@ export const PageTemplate: React.FC<PageTemplateProps> = ({ page, pageIndex, onE
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3, delay: index * 0.1 }}
           className="space-y-4">
-          <ContentRenderer
-            content={item}
-            pageIndex={pageIndex}
-            itemIndex={index}
-            onComplete={(score: number) => handleItemComplete(index, score)}
-          />
+          <ExerciseErrorBoundary key={item.id}>
+            <ContentRenderer
+              content={item}
+              pageIndex={pageIndex}
+              itemIndex={index}
+              onComplete={(score: number) => handleItemComplete(index, score)}
+            />
+          </ExerciseErrorBoundary>
         </motion.div>
       ))}
     </motion.div>

--- a/src/store/api/vocabularyApi.ts
+++ b/src/store/api/vocabularyApi.ts
@@ -22,6 +22,14 @@ interface WordsResponse {
   };
 }
 
+export interface DeleteWordResponse {
+  success: boolean;
+  warning?: boolean;
+  referencedPools?: { id: string; name: string }[];
+  message?: string;
+  cleanedPools?: string[];
+}
+
 export interface VocabularySearchResult {
   id: string;
   word: string;
@@ -208,16 +216,20 @@ export const vocabularyApi = createApi({
         response.data.words,
     }),
 
-    deleteWord: builder.mutation<void, string>({
-      query: wordId => ({
-        url: `/admin/words/${wordId}`,
+    deleteWord: builder.mutation<DeleteWordResponse, { wordId: string; confirm?: boolean }>({
+      query: ({ wordId, confirm }) => ({
+        url: `/admin/words/${wordId}${confirm ? '?confirm=true' : ''}`,
         method: 'DELETE',
       }),
-      invalidatesTags: (result, error, wordId) => [
-        { type: 'Word', id: wordId },
-        { type: 'WordList', id: 'LIST' },
-        { type: 'WordCounts', id: 'COUNTS' },
-      ],
+      transformResponse: (response: DeleteWordResponse) => response,
+      invalidatesTags: result =>
+        result?.success
+          ? [
+              { type: 'Word', id: 'LIST' },
+              { type: 'WordList', id: 'LIST' },
+              { type: 'WordCounts', id: 'COUNTS' },
+            ]
+          : [],
     }),
 
     bulkDeleteWords: builder.mutation<{ deletedCount: number }, string[]>({


### PR DESCRIPTION
Fix #1: Word Deletion Protection (Cascade Clean)

  - src/app/api/admin/words/[wordId]/route.ts — Before deleting, queries vocabulary_pools for any pool whose wordDocIds contains the word. Returns 409 with pool names if found. On ?confirm=true, deletes the word and   
  batch-updates all referencing pools to remove the word ID.
  - src/store/api/vocabularyApi.ts — Updated deleteWord mutation to accept { wordId, confirm? } and added DeleteWordResponse type.
  - src/app/admin/vocabulary/page.tsx — handleDeleteWord now catches 409 warning responses and shows a ConfirmationDialog listing affected pools. User can confirm to proceed with cascade deletion.

  Fix #2: VocabularyPoolViewer Error Handling

  - src/components/ui/lesson/VocabularyPoolViewer.tsx — Extracts error from useGetPoolQuery and displays a styled error card instead of spinning forever when the pool fails to load.

  Fix #4: Exercise Error Boundary

  - src/components/ui/lesson/exercise-error-boundary.tsx (new) — React class component ExerciseErrorBoundary that catches render errors and shows a styled error card with a "Try Again" button.
  - src/components/ui/lesson/page-template.tsx — Each ContentRenderer is wrapped with ExerciseErrorBoundary so a single broken exercise doesn't crash the whole page.

  Fix #5: Auto-Cleanup Dangling References

  - src/app/api/admin/vocabulary-pools/[poolId]/route.ts — When missingWordIds are detected during GET, fires a non-blocking update to clean the pool's wordDocIds and metadata.wordCount.