### PR TITLE
fix: restore vocab lesson exercises broken by data format migration

### DIFF
--- a/src/app/lesson/[lessonId]/page.tsx
+++ b/src/app/lesson/[lessonId]/page.tsx
@@ -108,7 +108,7 @@ export default function DynamicLessonPage() {
         <main className="flex-1 overflow-y-auto px-6 py-8">
           <div className="max-w-3xl mx-auto">
             <h2 className="text-2xl font-serif text-gray-800 mb-6">{currentLesson.title}</h2>
-            <LessonPlayer lesson={currentLesson} />
+            <LessonPlayer key={currentLesson.id} lesson={currentLesson} />
           </div>
         </main>
         <PracticeSidebar currentLessonId={lessonId} />

--- a/src/components/ui/exercises/generated-form-identification-exercise.tsx
+++ b/src/components/ui/exercises/generated-form-identification-exercise.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/src/utils/exercises/formIdentificationHelpers';
 import { hasSelectedForm } from '@/src/utils/exercises/formSelection';
 import { formatLabel } from '@/src/utils/label-formatter';
+import { normalizeCollection, buildLegacyParadigmConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
 
 interface Props {
   exercise: GeneratedFormIdentificationExercise;
@@ -60,13 +61,24 @@ const GeneratedFormIdentificationExerciseComponent: React.FC<Props> = ({ exercis
   const requireAllPrimaryAnswers = exercise.data.requireAllPrimaryAnswers ?? false;
   const isMultiAnswerMode = !isSingleField && requireAllPrimaryAnswers;
 
+  // Backward compat: old exercises stored filters/formSelection in generatorConfig
+  // with no paradigmConfigs, wordSource, or poolId
+  const hasNewFormatParadigmConfigs =
+    exercise.data.paradigmConfigs &&
+    typeof exercise.data.paradigmConfigs === 'object' &&
+    Object.keys(exercise.data.paradigmConfigs).length > 0;
+
+  const paradigmConfigs = hasNewFormatParadigmConfigs
+    ? exercise.data.paradigmConfigs
+    : buildLegacyParadigmConfigs(config as Parameters<typeof buildLegacyParadigmConfigs>[0]);
+
   const { data, isLoading, isError } = useGetMultiParadigmWordsQuery({
     exerciseType: 'generated-form-identification',
-    collection: config.collection,
-    wordSource: config.wordSource,
-    poolId: config.poolId,
+    collection: normalizeCollection(config.collection),
+    wordSource: config.wordSource || 'filters',
+    poolId: config.poolId ?? null,
     count: config.count,
-    paradigmConfigs: exercise.data.paradigmConfigs ?? {},
+    paradigmConfigs,
   });
 
   type ItemType = FormIdentificationItem | SingleFieldFormIdentificationItem | MultiAnswerFormIdentificationItem;

--- a/src/components/ui/exercises/generated-translation-exercise.tsx
+++ b/src/components/ui/exercises/generated-translation-exercise.tsx
@@ -17,6 +17,7 @@ import {
   type GeneratedTranslationItem,
 } from '@/src/utils/exercises/generatedTranslationExercise';
 import { getExerciseDisplayForm, hasSelectedForm } from '@/src/utils/exercises/formSelection';
+import { normalizeCollection, buildLegacyPosConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
 
 interface Props {
   exercise: GeneratedTranslationExercise;
@@ -31,13 +32,24 @@ const GeneratedTranslationExerciseComponent: React.FC<Props> = ({ exercise, onCo
   const config = exercise.data.generatorConfig;
   const translationDirection = exercise.translationDirection || 'latin-to-english';
 
+  // Backward compat: old exercises stored filters/formSelection in generatorConfig
+  // with no posConfigs, wordSource, or poolId
+  const hasNewFormatPosConfigs =
+    exercise.data.posConfigs &&
+    typeof exercise.data.posConfigs === 'object' &&
+    Object.keys(exercise.data.posConfigs).length > 0;
+
+  const posConfigs = hasNewFormatPosConfigs
+    ? exercise.data.posConfigs
+    : buildLegacyPosConfigs(config as Parameters<typeof buildLegacyPosConfigs>[0]);
+
   const { data, isLoading, isError } = useGetMultiPosWordsQuery({
     exerciseType: 'generated-translation',
-    collection: config.collection,
-    wordSource: config.wordSource,
-    poolId: config.poolId,
+    collection: normalizeCollection(config.collection),
+    wordSource: config.wordSource || 'filters',
+    poolId: config.poolId ?? null,
     count: config.count,
-    posConfigs: exercise.data.posConfigs,
+    posConfigs,
   });
 
   const items: GeneratedTranslationItem[] = useMemo(() => {

--- a/src/store/api/advancedVocabularyApi.ts
+++ b/src/store/api/advancedVocabularyApi.ts
@@ -190,14 +190,48 @@ export const advancedVocabularyApi = createApi({
       async queryFn(arg, _api, _extraOptions, baseQuery) {
         const { exerciseType, collection, wordSource, poolId, count, posConfigs } = arg;
 
-        const enabledEntries = Object.entries(posConfigs).filter(
+        const safePosConfigs = posConfigs && typeof posConfigs === 'object' ? posConfigs : {};
+
+        const enabledEntries = Object.entries(safePosConfigs).filter(
           (entry): entry is [PartOfSpeech, PosGeneratorConfig] => {
             const [, cfg] = entry;
             return cfg?.enabled === true;
           }
         );
 
+        // When using a pool with no POS configured, fetch all words from the pool
         if (enabledEntries.length === 0) {
+          if (wordSource === 'pool' && poolId) {
+            const additionalFields = getExerciseAdditionalFields(exerciseType);
+            const selectFields = composeSelectFields(additionalFields, {});
+            const params = new URLSearchParams();
+            params.append('collection', collection);
+            params.append('fetchAll', 'true');
+            params.append('poolId', poolId);
+            if (selectFields.length > 0) {
+              params.append('select', selectFields.join(','));
+            }
+
+            const result = await baseQuery({ url: `/admin/words?${params.toString()}` });
+            if (result.error) {
+              return { error: result.error };
+            }
+
+            const responseData = result.data as GetAdvancedWordsResponse;
+            const shuffled = shuffleArray(responseData.data.words);
+
+            return {
+              data: {
+                words: shuffled,
+                hasMore: false,
+                lastWordId: null,
+                limit: null,
+                filters: {},
+                collection,
+              },
+            };
+          }
+
           return { data: { words: [], hasMore: false, lastWordId: null, limit: null, filters: {}, collection } };
         }
 
@@ -301,14 +335,48 @@ export const advancedVocabularyApi = createApi({
       async queryFn(arg, _api, _extraOptions, baseQuery) {
         const { exerciseType, collection, wordSource, poolId, count, paradigmConfigs } = arg;
 
-        const enabledEntries = Object.entries(paradigmConfigs).filter(
+        const safeParadigmConfigs = paradigmConfigs && typeof paradigmConfigs === 'object' ? paradigmConfigs : {};
+
+        const enabledEntries = Object.entries(safeParadigmConfigs).filter(
           (entry): entry is [FormParadigm, ParadigmConfig] => {
             const [, cfg] = entry;
             return cfg?.enabled === true;
           }
         );
 
+        // When using a pool with no paradigm configured, fetch all words from the pool
         if (enabledEntries.length === 0) {
+          if (wordSource === 'pool' && poolId) {
+            const additionalFields = getExerciseAdditionalFields(exerciseType);
+            const selectFields = composeSelectFields(additionalFields, {});
+            const params = new URLSearchParams();
+            params.append('collection', collection);
+            params.append('fetchAll', 'true');
+            params.append('poolId', poolId);
+            if (selectFields.length > 0) {
+              params.append('select', selectFields.join(','));
+            }
+
+            const result = await baseQuery({ url: `/admin/words?${params.toString()}` });
+            if (result.error) {
+              return { error: result.error };
+            }
+
+            const responseData = result.data as GetAdvancedWordsResponse;
+            const shuffled = shuffleArray(responseData.data.words);
+
+            return {
+              data: {
+                words: shuffled,
+                hasMore: false,
+                lastWordId: null,
+                limit: null,
+                filters: {},
+                collection,
+              },
+            };
+          }
+
           return { data: { words: [], hasMore: false, lastWordId: null, limit: null, filters: {}, collection } };
         }
 

--- a/src/utils/exercises/legacyExerciseCompat.ts
+++ b/src/utils/exercises/legacyExerciseCompat.ts
@@ -1,0 +1,89 @@
+/**
+ * Backward-compatibility helpers for exercises created before the multi-POS
+ * config system (posConfigs / paradigmConfigs).
+ *
+ * Old format stored filters and formSelection directly in generatorConfig,
+ * with no wordSource, poolId, posConfigs or paradigmConfigs fields.
+ * Collection was vocabulary_words_v4 (now v5).
+ */
+
+import type {
+  PosConfigs,
+  PosGeneratorConfig,
+  GeneratorFilters,
+  FormSelection,
+  GeneratorConfigBase,
+} from '@/src/types/exercises/base';
+import type { ParadigmConfigs, ParadigmConfig, FormParadigm } from '@/src/types/exercises/paradigm';
+import type { PartOfSpeech } from '@/shared/types/vocabulary/schemas/enums';
+import { PARADIGM_STEPS } from '@/src/config/paradigmDefinitions';
+import { VOCABULARY_WORDS_COLLECTION } from '@/shared/constants/firestore';
+
+/**
+ * Old-format generatorConfig stored formSelection at the config level.
+ * This extends GeneratorConfigBase with that legacy field for type safety.
+ */
+type LegacyAwareConfig = GeneratorConfigBase & { formSelection?: FormSelection };
+
+const POS_TO_PARADIGM: Partial<Record<string, FormParadigm>> = {
+  verb: 'verb-conjugation',
+  noun: 'noun-declension',
+  adjective: 'adjective-declension',
+  pronoun: 'pronoun-gendered',
+};
+
+/**
+ * Maps old vocabulary collection names (v4, etc.) to the current v5 collection.
+ */
+export function normalizeCollection(collection?: string): string {
+  if (!collection) return VOCABULARY_WORDS_COLLECTION;
+  if (collection.startsWith('vocabulary_words_v') && collection !== VOCABULARY_WORDS_COLLECTION) {
+    return VOCABULARY_WORDS_COLLECTION;
+  }
+  return collection;
+}
+
+/**
+ * Builds synthetic PosConfigs from a legacy generatorConfig that stored
+ * filters.partOfSpeech and formSelection directly at the config level.
+ */
+export function buildLegacyPosConfigs(config: LegacyAwareConfig): PosConfigs {
+  const pos = config.filters?.partOfSpeech;
+  if (!pos || pos === 'all') return {};
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { partOfSpeech, ...restFilters } = config.filters!;
+
+  const posConfig: PosGeneratorConfig = {
+    enabled: true,
+    filters: restFilters as Omit<GeneratorFilters, 'partOfSpeech'>,
+    formSelection: config.formSelection,
+  };
+
+  return { [pos as PartOfSpeech]: posConfig };
+}
+
+/**
+ * Builds synthetic ParadigmConfigs from a legacy generatorConfig.
+ * Uses all available paradigm steps as defaults since the old format
+ * didn't store step configuration.
+ */
+export function buildLegacyParadigmConfigs(config: LegacyAwareConfig): ParadigmConfigs {
+  const pos = config.filters?.partOfSpeech;
+  if (!pos || pos === 'all') return {};
+
+  const paradigm = POS_TO_PARADIGM[pos];
+  if (!paradigm) return {};
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { partOfSpeech, ...restFilters } = config.filters!;
+
+  const paradigmConfig: ParadigmConfig = {
+    enabled: true,
+    steps: [...PARADIGM_STEPS[paradigm]],
+    filters: restFilters as Omit<GeneratorFilters, 'partOfSpeech'>,
+    formSelection: config.formSelection,
+  };
+
+  return { [paradigm]: paradigmConfig };
+}


### PR DESCRIPTION
Old exercises stored filters and formSelection directly on generatorConfig with no posConfigs/paradigmConfigs, wordSource, or poolId fields, and referenced vocabulary_words_v4. Add backward-compat utilities to synthesize the current config shape at runtime, map old collections to v5, and guard against null posConfigs in advancedVocabularyApi. Also reset LessonPlayer state on lesson switch via key prop.