### PR TITLE
Dimokritos/ disable progression locking and exerice reset after question failures option

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
       NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
       NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
       NEXT_PUBLIC_APP_URL: ${{ secrets.APP_URL }}
+      NEXT_PUBLIC_DISABLE_PROGRESSION_LOCK: 'true' # Temporary: remove when re-enabling lesson locking
 
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +54,7 @@ jobs:
       NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
       NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
       NEXT_PUBLIC_APP_URL: ${{ secrets.APP_URL }}
+      NEXT_PUBLIC_DISABLE_PROGRESSION_LOCK: 'true' # Temporary: remove when re-enabling lesson locking
 
     steps:
       - uses: actions/checkout@v4

--- a/src/app/api/lessons/route.ts
+++ b/src/app/api/lessons/route.ts
@@ -70,24 +70,37 @@ export async function GET(request: NextRequest) {
     const diagrammingLessons = allLessons.filter(l => l.type === 'sentence-diagramming');
     const listeningLessons = allLessons.filter(l => l.type === 'listening');
 
+    const isLockingDisabled = process.env.NEXT_PUBLIC_DISABLE_PROGRESSION_LOCK === 'true';
+
+    const getStatusFromProgress = (
+      userProgress: UserProgress | undefined,
+      lesson: (typeof allLessons)[number]
+    ): { status: string; progress: number } => {
+      if (userProgress) {
+        const currentPageIndex = userProgress.currentPageIndex || 0;
+        const totalPages = lesson.pages.length;
+        const progress = calculateProgressFromPageIndex(currentPageIndex, totalPages);
+        const isComplete = isLessonComplete(currentPageIndex, totalPages);
+        const status = isComplete ? 'completed' : currentPageIndex > 0 ? 'in-progress' : 'available';
+        return { status, progress };
+      }
+      return { status: 'available', progress: 0 };
+    };
+
     const processNormalLessons = (lessons: typeof allLessons): LessonWithProgress[] => {
       return lessons.map((lesson, index) => {
         const userProgress = userProgressMap[lesson.id];
         let status = 'locked';
         let progress = 0;
 
-        if (!currentUser) {
-          status = 'available';
+        if (!currentUser || isLockingDisabled) {
+          const result = getStatusFromProgress(userProgress, lesson);
+          status = result.status;
+          progress = result.progress;
         } else if (index === 0) {
-          if (userProgress) {
-            const currentPageIndex = userProgress.currentPageIndex || 0;
-            const totalPages = lesson.pages.length;
-            progress = calculateProgressFromPageIndex(currentPageIndex, totalPages);
-            const isComplete = isLessonComplete(currentPageIndex, totalPages);
-            status = isComplete ? 'completed' : currentPageIndex > 0 ? 'in-progress' : 'available';
-          } else {
-            status = 'available';
-          }
+          const result = getStatusFromProgress(userProgress, lesson);
+          status = result.status;
+          progress = result.progress;
         } else {
           const previousLesson = lessons[index - 1];
           const previousProgress = userProgressMap[previousLesson.id];
@@ -98,15 +111,9 @@ export async function GET(request: NextRequest) {
             const isPreviousComplete = isLessonComplete(prevCurrentPageIndex, prevTotalPages);
 
             if (isPreviousComplete) {
-              if (userProgress) {
-                const currentPageIndex = userProgress.currentPageIndex || 0;
-                const totalPages = lesson.pages.length;
-                progress = calculateProgressFromPageIndex(currentPageIndex, totalPages);
-                const isComplete = isLessonComplete(currentPageIndex, totalPages);
-                status = isComplete ? 'completed' : currentPageIndex > 0 ? 'in-progress' : 'available';
-              } else {
-                status = 'available';
-              }
+              const result = getStatusFromProgress(userProgress, lesson);
+              status = result.status;
+              progress = result.progress;
             }
           }
         }

--- a/src/components/ui/admin/content-editor/FeedbackConfigEditor.tsx
+++ b/src/components/ui/admin/content-editor/FeedbackConfigEditor.tsx
@@ -175,6 +175,31 @@ export const FeedbackConfigEditor: React.FC<FeedbackConfigEditorProps> = ({
               <Plus className="h-4 w-4 mr-2" />
               Add Escalation Level
             </Button>
+
+            {feedbackConfig.escalationLevels.length > 0 && (
+              <div className="pt-4 border-t border-gray-200">
+                <label className="block text-sm font-medium mb-1">Max failures at last level before reset</label>
+                <input
+                  type="number"
+                  value={feedbackConfig.maxLevelFailures ?? ''}
+                  onChange={e => {
+                    const val = e.target.value;
+                    onChange({
+                      ...feedbackConfig,
+                      maxLevelFailures: val === '' ? undefined : Math.max(1, parseInt(val) || 1),
+                    });
+                  }}
+                  className="w-full p-2 border rounded-md text-sm"
+                  placeholder="Disabled"
+                  min="1"
+                  step="1"
+                />
+                <div className="text-xs text-gray-500 mt-1">
+                  Number of wrong answers at the last escalation level before the exercise resets. Leave empty to
+                  disable.
+                </div>
+              </div>
+            )}
           </CardContent>
         )}
       </Card>

--- a/src/components/ui/exercises/click-on-multiple-words.tsx
+++ b/src/components/ui/exercises/click-on-multiple-words.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ClickOnMultipleWordsExercise } from '@/src/types/exercise';
 import { useExerciseFeedback } from '@/src/hooks/useExerciseFeedback';
 import { FeedbackDisplay } from '../feedback';
@@ -9,6 +9,7 @@ import { Button } from '@/src/components/ui/button';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
 import { MultiClickableRichDisplay } from '../core/multi-clickable-rich-display';
+import { toast } from 'sonner';
 
 interface Props {
   exercise: ClickOnMultipleWordsExercise;
@@ -23,9 +24,28 @@ const ClickOnMultipleWordsComponent: React.FC<Props> = ({ exercise, onComplete }
     null
   );
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect, reset } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    reset,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setSelectedIndices(new Set());
+      setHasSubmitted(false);
+      setValidationResult(null);
+      setIsProcessing(false);
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetExercise]);
 
   const handleWordClick = (wordIndex: number) => {
     if (hasSubmitted || isProcessing) return;

--- a/src/components/ui/exercises/fill-embolded-text-exercise.tsx
+++ b/src/components/ui/exercises/fill-embolded-text-exercise.tsx
@@ -9,6 +9,7 @@ import { validateFillEmboldedTextExercise } from '@/src/utils/exercises/fillEmbo
 import { ExerciseProgress } from './exercise-progress';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
+import { toast } from 'sonner';
 
 interface Props {
   exercise: FillEmboldedTextExercise;
@@ -21,16 +22,36 @@ const FillEmboldedTextExerciseComponent: React.FC<Props> = ({ exercise, onComple
   const [isProcessing, setIsProcessing] = useState(false);
   const [correctAnswers, setCorrectAnswers] = useState(0);
 
-  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance } =
+  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance, resetIndex } =
     useExerciseProgression({
       totalItems: exercise.data.words.length,
       itemProgressionDelay: exercise.itemProgressionDelay,
       progressionRules: exercise.feedbackConfig.progressionRules,
     });
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect, reset } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    reset,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setUserAnswer('');
+      setSelectedWordIndex(null);
+      setCorrectAnswers(0);
+      setIsProcessing(false);
+      resetIndex();
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetIndex, resetExercise]);
 
   const currentWord = exercise.data.words[currentIndex];
 

--- a/src/components/ui/exercises/fill-exercise.tsx
+++ b/src/components/ui/exercises/fill-exercise.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { FillExercise } from '@/src/types/exercise';
 import { useExerciseFeedback } from '@/src/hooks/useExerciseFeedback';
 import { useExerciseProgression } from '@/src/hooks/useExerciseProgression';
@@ -9,6 +9,7 @@ import { validateFillExercise } from '@/src/utils/exercises/fillExercise';
 import { ExerciseProgress } from './exercise-progress';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
+import { toast } from 'sonner';
 
 interface Props {
   exercise: FillExercise;
@@ -21,16 +22,35 @@ const FillExerciseComponent: React.FC<Props> = ({ exercise, onComplete }) => {
 
   const [correctAnswers, setCorrectAnswers] = useState(0);
 
-  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance } =
+  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance, resetIndex } =
     useExerciseProgression({
       totalItems: exercise.data.items.length,
       itemProgressionDelay: exercise.itemProgressionDelay,
       progressionRules: exercise.feedbackConfig.progressionRules,
     });
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect, reset } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    reset,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setUserAnswer('');
+      setCorrectAnswers(0);
+      setIsProcessing(false);
+      resetIndex();
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetIndex, resetExercise]);
 
   const handleSubmit = () => {
     if (isProcessing) return;

--- a/src/components/ui/exercises/generated-form-identification-exercise.tsx
+++ b/src/components/ui/exercises/generated-form-identification-exercise.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { GeneratedFormIdentificationExercise } from '@/src/types/exercises/generated-form-identification';
 import { useExerciseFeedback } from '@/src/hooks/useExerciseFeedback';
 import { useExerciseProgression } from '@/src/hooks/useExerciseProgression';
@@ -43,6 +43,7 @@ import {
 import { hasSelectedForm } from '@/src/utils/exercises/formSelection';
 import { formatLabel } from '@/src/utils/label-formatter';
 import { normalizeCollection, buildLegacyParadigmConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
+import { toast } from 'sonner';
 
 interface Props {
   exercise: GeneratedFormIdentificationExercise;
@@ -294,16 +295,37 @@ const GeneratedFormIdentificationExerciseComponent: React.FC<Props> = ({ exercis
       .map(result => result.data);
   }, [items, isSingleField, isMultiAnswerMode]);
 
-  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance } =
+  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance, resetIndex } =
     useExerciseProgression({
       totalItems: validatedItems.length,
       itemProgressionDelay: exercise.itemProgressionDelay,
       progressionRules: exercise.feedbackConfig.progressionRules,
     });
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect, reset } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    reset,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setUserAnswer('');
+      setCorrectAnswers(0);
+      setWordAnswers({});
+      setMultiAnswerSlots({});
+      setIsProcessing(false);
+      resetIndex();
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetIndex, resetExercise]);
 
   const handleSubmit = () => {
     if (isProcessing || validatedItems.length === 0) return;

--- a/src/components/ui/exercises/generated-translation-exercise.tsx
+++ b/src/components/ui/exercises/generated-translation-exercise.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { GeneratedTranslationExercise } from '@/src/types/exercises';
 import { useExerciseFeedback } from '@/src/hooks/useExerciseFeedback';
 import { useExerciseProgression } from '@/src/hooks/useExerciseProgression';
@@ -18,6 +18,7 @@ import {
 } from '@/src/utils/exercises/generatedTranslationExercise';
 import { getExerciseDisplayForm, hasSelectedForm } from '@/src/utils/exercises/formSelection';
 import { normalizeCollection, buildLegacyPosConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
+import { toast } from 'sonner';
 
 interface Props {
   exercise: GeneratedTranslationExercise;
@@ -96,16 +97,35 @@ const GeneratedTranslationExerciseComponent: React.FC<Props> = ({ exercise, onCo
     return mapped.filter((item): item is GeneratedTranslationItem => item !== null);
   }, [data, translationDirection]);
 
-  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance } =
+  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance, resetIndex } =
     useExerciseProgression({
       totalItems: items.length,
       itemProgressionDelay: exercise.itemProgressionDelay,
       progressionRules: exercise.feedbackConfig.progressionRules,
     });
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect, reset } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    reset,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setUserAnswer('');
+      setCorrectAnswers(0);
+      setIsProcessing(false);
+      resetIndex();
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetIndex, resetExercise]);
 
   const handleSubmit = () => {
     if (isProcessing || items.length === 0) return;

--- a/src/components/ui/exercises/matching-table.tsx
+++ b/src/components/ui/exercises/matching-table.tsx
@@ -9,6 +9,7 @@ import { validateMatchingExercise } from '@/src/utils/exercises/matchingExercise
 import { ExerciseProgress } from './exercise-progress';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
+import { toast } from 'sonner';
 
 interface MatchingItem {
   id: string;
@@ -36,9 +37,33 @@ export const MatchingTable: React.FC<MatchingTableProps> = ({ exercise, onComple
   const [currentRound, setCurrentRound] = useState(1);
   const [roundScores, setRoundScores] = useState<number[]>([]);
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect, reset } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    reset,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setShuffledLeftColumn(leftColumn);
+      setShuffledRightColumn(rightColumn);
+      setSelectedLeft(null);
+      setSelectedRight(null);
+      setMatches({});
+      setMatchedLeftIds(new Set());
+      setShowIncorrectFlash(false);
+      setCurrentRound(1);
+      setRoundScores([]);
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetExercise, leftColumn, rightColumn]);
 
   // this is for the live preview :/
   useEffect(() => {

--- a/src/components/ui/exercises/multiple-choice-exercise.tsx
+++ b/src/components/ui/exercises/multiple-choice-exercise.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { MultipleChoiceExercise } from '@/src/types/exercise';
 import { useExerciseFeedback } from '@/src/hooks/useExerciseFeedback';
 import { FeedbackDisplay } from '../feedback';
@@ -9,6 +9,7 @@ import { Button } from '@/src/components/ui/button';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
 import { cn } from '@/src/lib/utils';
+import { toast } from 'sonner';
 
 interface Props {
   exercise: MultipleChoiceExercise;
@@ -20,9 +21,26 @@ const MultipleChoiceExerciseComponent: React.FC<Props> = ({ exercise, onComplete
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setSelectedOptionIds([]);
+      setHasSubmitted(false);
+      setIsProcessing(false);
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetExercise]);
 
   const handleOptionSelect = (optionId: string) => {
     if (hasSubmitted || isProcessing) return;

--- a/src/components/ui/exercises/odd-one-out-exercise.tsx
+++ b/src/components/ui/exercises/odd-one-out-exercise.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { OddOneOutExercise } from '@/src/types/exercise';
 import { useExerciseFeedback } from '@/src/hooks/useExerciseFeedback';
 import { FeedbackDisplay } from '../feedback';
@@ -10,6 +10,7 @@ import { SimpleRichDisplay } from '../core/simple-rich-display';
 import { SimpleRichEditor } from '../core/simple-rich-editor';
 import { Button } from '../button';
 import { CheckCircle2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 interface Props {
   exercise: OddOneOutExercise;
@@ -22,9 +23,27 @@ const OddOneOutExerciseComponent: React.FC<Props> = ({ exercise, onComplete }) =
   const [isProcessing, setIsProcessing] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(false);
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setSelectedItemId(null);
+      setUserExplanation('');
+      setHasSubmitted(false);
+      setIsProcessing(false);
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetExercise]);
 
   const handleItemSelect = (itemId: string) => {
     if (hasSubmitted) return;

--- a/src/components/ui/exercises/table-fill-exercise.tsx
+++ b/src/components/ui/exercises/table-fill-exercise.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { TableFillExercise } from '@/src/types/exercise';
 import { useExerciseFeedback } from '@/src/hooks/useExerciseFeedback';
 import { FeedbackDisplay } from '../feedback';
@@ -17,6 +17,7 @@ import {
   RomanTableCell,
 } from '../core/roman-table';
 import { cn } from '@/src/lib/utils';
+import { toast } from 'sonner';
 
 interface Props {
   exercise: TableFillExercise;
@@ -29,9 +30,28 @@ const TableFillExerciseComponent: React.FC<Props> = ({ exercise, onComplete }) =
   const [isProcessing, setIsProcessing] = useState(false);
   const [cellResults, setCellResults] = useState<Record<string, boolean>>({});
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect, reset } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    reset,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setUserAnswers({});
+      setHasSubmitted(false);
+      setCellResults({});
+      setIsProcessing(false);
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetExercise]);
 
   const handleInputChange = (cellKey: string, value: string) => {
     if (hasSubmitted || isProcessing) return;

--- a/src/components/ui/exercises/text-selection-exercise.tsx
+++ b/src/components/ui/exercises/text-selection-exercise.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { TextSelectionExercise } from '@/src/types/exercise';
 import { useExerciseFeedback } from '@/src/hooks/useExerciseFeedback';
 import { useExerciseProgression } from '@/src/hooks/useExerciseProgression';
@@ -10,6 +10,7 @@ import { ExerciseProgress } from './exercise-progress';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
 import { ClickableRichDisplay } from '../core/clickable-rich-display';
+import { toast } from 'sonner';
 
 interface Props {
   exercise: TextSelectionExercise;
@@ -21,16 +22,35 @@ const TextSelectionExerciseComponent: React.FC<Props> = ({ exercise, onComplete 
   const [isProcessing, setIsProcessing] = useState(false);
   const [correctAnswers, setCorrectAnswers] = useState(0);
 
-  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance } =
+  const { currentIndex, isLastItem, isAwaitingConfirmation, autoAdvanceIfEnabled, confirmAdvance, resetIndex } =
     useExerciseProgression({
       totalItems: exercise.data.questions.length,
       itemProgressionDelay: exercise.itemProgressionDelay,
       progressionRules: exercise.feedbackConfig.progressionRules,
     });
 
-  const { isCorrect, message, level, showExplanation, handleCorrect, handleIncorrect, reset } = useExerciseFeedback(
-    exercise.feedbackConfig
-  );
+  const {
+    isCorrect,
+    message,
+    level,
+    showExplanation,
+    handleCorrect,
+    handleIncorrect,
+    reset,
+    shouldResetExercise,
+    resetExercise,
+  } = useExerciseFeedback(exercise.feedbackConfig);
+
+  useEffect(() => {
+    if (shouldResetExercise) {
+      toast.info('Too many mistakes. Starting over...');
+      setSelectedWordIndex(null);
+      setCorrectAnswers(0);
+      setIsProcessing(false);
+      resetIndex();
+      resetExercise();
+    }
+  }, [shouldResetExercise, resetIndex, resetExercise]);
 
   const handleWordClick = (wordIndex: number) => {
     if (isProcessing) return; // Prevent multiple rapid clicks

--- a/src/components/ui/lesson/lesson-player.tsx
+++ b/src/components/ui/lesson/lesson-player.tsx
@@ -119,9 +119,9 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({ lesson }) => {
               <h3 className="text-xl font-serif">
                 <SimpleRichDisplay content={lesson.title} />
               </h3>
-              <p className="text-sm text-roman-stone">
+              <div className="text-sm text-roman-stone">
                 <SimpleRichDisplay content={lesson.description || ''} />
-              </p>
+              </div>
             </div>
           </div>
         </RomanCardHeader>

--- a/src/hooks/useExerciseFeedback.ts
+++ b/src/hooks/useExerciseFeedback.ts
@@ -11,6 +11,7 @@ const createInitialState = (): FeedbackState => ({
   shouldShowHint: false,
   shouldShowAnswer: false,
   shouldShowExplanation: false,
+  maxLevelFailureCount: 0,
 });
 
 // Pure reducer function - handles all state transitions
@@ -24,6 +25,9 @@ function feedbackReducer(state: FeedbackState, action: FeedbackAction): Feedback
       const levelIndex = Math.min(nextAttempt - 1, escalationLevels.length - 1);
       const activeLevel = escalationLevels[levelIndex] || null;
 
+      // Count wrong answers at the last escalation level
+      const isAtMaxLevel = escalationLevels.length > 0 && nextAttempt >= escalationLevels.length;
+
       return {
         phase: 'attempting',
         currentAttempt: nextAttempt,
@@ -32,6 +36,7 @@ function feedbackReducer(state: FeedbackState, action: FeedbackAction): Feedback
         shouldShowHint: Boolean(activeLevel?.showHint),
         shouldShowAnswer: Boolean(activeLevel?.showAnswer),
         shouldShowExplanation: false,
+        maxLevelFailureCount: isAtMaxLevel ? state.maxLevelFailureCount + 1 : state.maxLevelFailureCount,
       };
     }
 
@@ -46,10 +51,18 @@ function feedbackReducer(state: FeedbackState, action: FeedbackAction): Feedback
         shouldShowHint: false,
         shouldShowAnswer: false,
         shouldShowExplanation: showExplanation,
+        maxLevelFailureCount: state.maxLevelFailureCount,
       };
     }
 
     case 'RESET': {
+      return {
+        ...createInitialState(),
+        maxLevelFailureCount: state.maxLevelFailureCount,
+      };
+    }
+
+    case 'EXERCISE_RESET': {
       return createInitialState();
     }
 
@@ -101,12 +114,21 @@ export function useExerciseFeedback(config: FeedbackConfig) {
     dispatch({ type: 'RESET' });
   }, []);
 
+  const resetExercise = useCallback(() => {
+    dispatch({ type: 'EXERCISE_RESET' });
+  }, []);
+
   // Derived values for backward compatibility
   const isCorrect = state.phase === 'succeeded' ? true : state.phase === 'attempting' ? false : null;
 
   const level = state.activeLevel;
   const message = state.displayMessage;
   const showExplanation = state.shouldShowExplanation;
+
+  const shouldResetExercise =
+    config.maxLevelFailures != null &&
+    config.maxLevelFailures > 0 &&
+    state.maxLevelFailureCount >= config.maxLevelFailures;
 
   return {
     // New state machine interface
@@ -120,5 +142,9 @@ export function useExerciseFeedback(config: FeedbackConfig) {
     handleCorrect,
     handleIncorrect,
     reset,
+
+    // Exercise reset on max-level failures
+    shouldResetExercise,
+    resetExercise,
   };
 }

--- a/src/types/exercises/base.d.ts
+++ b/src/types/exercises/base.d.ts
@@ -41,6 +41,12 @@ export interface FeedbackConfig {
 
   /** Generic behaviour flags (work for every exercise). */
   progressionRules?: ProgressionRules;
+
+  /**
+   * Number of wrong answers at the last escalation level before the entire
+   * exercise resets. `undefined` or `0` = disabled.
+   */
+  maxLevelFailures?: number;
 }
 
 // New robust state machine types
@@ -54,12 +60,15 @@ export interface FeedbackState {
   readonly shouldShowHint: boolean;
   readonly shouldShowAnswer: boolean;
   readonly shouldShowExplanation: boolean;
+  /** Running count of incorrect submissions while at the last escalation level. Persists across item resets. */
+  readonly maxLevelFailureCount: number;
 }
 
 export type FeedbackAction =
   | { type: 'ANSWER_INCORRECT'; escalationLevels: FeedbackLevel[] }
   | { type: 'ANSWER_CORRECT'; successMessage: string; showExplanation: boolean; isLastItem?: boolean }
-  | { type: 'RESET' };
+  | { type: 'RESET' }
+  | { type: 'EXERCISE_RESET' };
 
 export interface FeedbackMachineConfig {
   escalationLevels: FeedbackLevel[];

--- a/src/utils/feedbackDefaults.ts
+++ b/src/utils/feedbackDefaults.ts
@@ -47,10 +47,12 @@ export function getEffectiveFeedbackConfig(config: FeedbackConfig): {
   escalationLevels: FeedbackLevel[];
   successMessage: SuccessMessageConfig;
   progressionRules: ProgressionRules;
+  maxLevelFailures?: number;
 } {
   return {
     escalationLevels: (config.escalationLevels ?? []).map(normalizeEscalationLevel),
     successMessage: getSuccessMessageWithDefaults(config.successMessage),
     progressionRules: getProgressionRulesWithDefaults(config.progressionRules),
+    maxLevelFailures: config.maxLevelFailures,
   };
 }


### PR DESCRIPTION
This pull request introduces a new exercise reset mechanism that triggers when users make too many mistakes, enhancing the feedback and progression system for various exercise types. It also adds a new admin configuration for customizing escalation level failure limits and temporarily disables lesson progression locking in the CI environment. The most important changes are grouped below:

**Exercise Reset & Feedback Improvements:**

* All major exercise components (`fill-exercise`, `fill-embolded-text-exercise`, `multiple-choice-exercise`, `click-on-multiple-words`, `matching-table`, `generated-form-identification-exercise`, `generated-translation-exercise`) now listen for a reset signal from `useExerciseFeedback` and reset their internal state when users exceed the allowed number of failures. A toast notification ("Too many mistakes. Starting over...") is displayed to inform users when a reset occurs. [[1]](diffhunk://#diff-ae40550cac0e5c19833d764e2321e2e34fa862282584eeef5a96d7846b942975L3-R3) [[2]](diffhunk://#diff-ae40550cac0e5c19833d764e2321e2e34fa862282584eeef5a96d7846b942975R12) [[3]](diffhunk://#diff-ae40550cac0e5c19833d764e2321e2e34fa862282584eeef5a96d7846b942975L24-R53) [[4]](diffhunk://#diff-b3f3291f26f9e203b8bed89285ceebdcb06858a424adb70ad5f9d4481455463dR12) [[5]](diffhunk://#diff-b3f3291f26f9e203b8bed89285ceebdcb06858a424adb70ad5f9d4481455463dL24-R54) [[6]](diffhunk://#diff-83e391ac3fb0f26cd5462966c5c6dff7058c84b7e3c8047529d31ca60bca7699L3-R3) [[7]](diffhunk://#diff-83e391ac3fb0f26cd5462966c5c6dff7058c84b7e3c8047529d31ca60bca7699R12) [[8]](diffhunk://#diff-fb8e4b86518a0f41f09b2739ebcd785e1a7c820765286d6b07136699855eecfdL3-R3) [[9]](diffhunk://#diff-fb8e4b86518a0f41f09b2739ebcd785e1a7c820765286d6b07136699855eecfdR12) [[10]](diffhunk://#diff-fb8e4b86518a0f41f09b2739ebcd785e1a7c820765286d6b07136699855eecfdL26-R48) [[11]](diffhunk://#diff-f33ba22307e22a68ffef7e0c510cdfdb19f6b1f0a4af451e8a2e6534f1ce3396R12) [[12]](diffhunk://#diff-f33ba22307e22a68ffef7e0c510cdfdb19f6b1f0a4af451e8a2e6534f1ce3396L39-R66) [[13]](diffhunk://#diff-c99b1b4594fb3a79de705119cbe4ca854d3771cb7eb6be23fdb4ef3325a430f7L3-R3) [[14]](diffhunk://#diff-c99b1b4594fb3a79de705119cbe4ca854d3771cb7eb6be23fdb4ef3325a430f7R46) [[15]](diffhunk://#diff-c99b1b4594fb3a79de705119cbe4ca854d3771cb7eb6be23fdb4ef3325a430f7L297-R328) [[16]](diffhunk://#diff-acf85cdc506f4fc5cdb4b874fcc483d1ad91e02c77a7550dfbb941ec1df3ba24L3-R3) [[17]](diffhunk://#diff-acf85cdc506f4fc5cdb4b874fcc483d1ad91e02c77a7550dfbb941ec1df3ba24R21) [[18]](diffhunk://#diff-acf85cdc506f4fc5cdb4b874fcc483d1ad91e02c77a7550dfbb941ec1df3ba24L99-R128)

**Admin Configuration Enhancements:**

* The `FeedbackConfigEditor` component now allows admins to set the maximum number of failures at the last escalation level before an exercise resets, providing finer control over feedback escalation and reset behavior.

**Lesson Progression Locking (Temporary CI change):**

* The CI workflow now sets the environment variable `NEXT_PUBLIC_DISABLE_PROGRESSION_LOCK` to `'true'`, temporarily disabling lesson progression locking for testing or development purposes. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R28) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R57)
* The lessons API route (`src/app/api/lessons/route.ts`) respects this environment variable, allowing all lessons to be available regardless of user progress when locking is disabled. [[1]](diffhunk://#diff-fb31a12ea27b46541c01377c3bf1f85650c679a0b9caf70f71b831011fccb17cR73-R103) [[2]](diffhunk://#diff-fb31a12ea27b46541c01377c3bf1f85650c679a0b9caf70f71b831011fccb17cL101-R116)

These changes collectively improve both the user experience for exercises (by providing clear feedback and automatic resets) and the flexibility for admins and developers to configure and test lesson progression and feedback behavior.