### PR TITLE
Promote audit protection and AI WIP navigation

### DIFF
--- a/docs/learning-unit-refactor-next-steps.md
+++ b/docs/learning-unit-refactor-next-steps.md
@@ -514,7 +514,8 @@ rollback, the focused cleanup release can remove the temporary workflow.
 This cleanup removes or simplifies:
 
 - `src/app/api/admin/learning-path/migration/route.ts`;
-- the `learningPathMigrations` collection constant and server-only rule;
+- the application-level `learningPathMigrations` collection constant while
+  retaining its deny-only Firestore rule for the archived production record;
 - migration action, source, manifest, and cutover schemas/types;
 - manifest hashing, source comparison, apply, verify, rollback, and retire
   service methods;
@@ -527,6 +528,8 @@ This cleanup removes or simplifies:
 Preserve:
 
 - `learningPaths/default` as the canonical revisioned aggregate;
+- the retired `learningPathMigrations` records and their server-only Firestore
+  rule as the permanent cutover audit trail;
 - ordinary complete-sequence save validation and stale-revision protection;
 - student and admin projection behavior;
 - deletion, lesson-validity, test-rotation, and ownership safety guards;

--- a/docs/learning-unit-refactor.md
+++ b/docs/learning-unit-refactor.md
@@ -752,8 +752,8 @@ Keep the existing Firestore `lessons` collection for learning units during the i
 
 ```text
 lessons/{learningUnitId}       LessonUnit or TestUnit during migration
-learningPaths/default          Revisioned ordered normal-flow aggregate and cutover state
-learningPathMigrations/{id}    Immutable manifest plus resumable lifecycle audit events
+learningPaths/default          Canonical revisioned ordered normal-flow aggregate
+learningPathMigrations/{id}    Retained server-only cutover audit record
 testVersions/{versionId}       Separately stored version pages and scoring
 mockTests/{mockTestId}         Mock Tests category containers
 testAttempts/{attemptId}       Attempt lifecycle and frozen statistics

--- a/firestore.rules
+++ b/firestore.rules
@@ -24,6 +24,12 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    // The migration runtime is retired, but its immutable production audit
+    // records remain server-only for operational history and incident review.
+    match /learningPathMigrations/{document=**} {
+      allow read, write: if false;
+    }
+
     // Assessment content, attempts, and gate-controlling progress are available
     // only through authenticated server routes. The Admin SDK bypasses rules.
     match /testVersions/{document=**} {
@@ -91,6 +97,7 @@ service cloud.firestore {
       allow read, write: if collection != 'diagramming_attempts'
         && collection != 'lessons'
         && collection != 'learningPaths'
+        && collection != 'learningPathMigrations'
         && collection != 'practiceCategories'
         && collection != 'practiceCategoryMemberships'
         && collection != 'testVersions'

--- a/src/components/admin/shell/AdminSidebar.tsx
+++ b/src/components/admin/shell/AdminSidebar.tsx
@@ -58,7 +58,7 @@ const navigationGroups: NavigationGroup[] = [
   {
     label: 'System',
     items: [
-      { href: '/admin/ai-evaluations', label: 'AI Evaluations', icon: Sparkles },
+      { href: '/admin/ai-evaluations', label: 'AI Evaluations', icon: Sparkles, disabled: true },
       { href: '/admin/diagramming-attempts', label: 'Diagramming Attempts', icon: ClipboardList },
     ],
   },
@@ -139,28 +139,52 @@ export function AdminSidebar({ onNavigate, collapsed = false, onToggleCollapse, 
                 const isActive = item.href === activeHref;
                 return (
                   <li key={item.href}>
-                    <Link
-                      href={item.href}
-                      onClick={onNavigate}
-                      aria-current={isActive ? 'page' : undefined}
-                      title={collapsed ? item.label : undefined}
-                      className={cn(
-                        'group/link flex min-h-9 items-center gap-2 rounded-r-lg border-l-2 px-3 py-1.5 text-sm transition-[background-color,color] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                        collapsed && 'justify-center gap-0 rounded-lg border-l-0 px-2',
-                        isActive
-                          ? 'border-primary bg-primary/[0.09] font-medium text-primary'
-                          : 'border-transparent text-foreground/70 hover:bg-roman-parchment/80 hover:text-foreground'
-                      )}>
-                      <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
-                      <span
+                    {item.disabled ? (
+                      <div
+                        aria-disabled="true"
+                        title={collapsed ? `${item.label} (WIP)` : undefined}
                         className={cn(
-                          'min-w-0 flex-1 truncate whitespace-nowrap transition-[max-width,opacity,transform] duration-150 ease-out motion-reduce:transition-none',
-                          collapsed ? 'max-w-0 -translate-x-1 opacity-0' : 'max-w-48 translate-x-0 opacity-100'
+                          'group/link flex min-h-9 cursor-not-allowed items-center gap-2 rounded-r-lg border-l-2 border-transparent px-3 py-1.5 text-sm text-foreground/35',
+                          collapsed && 'justify-center gap-0 rounded-lg border-l-0 px-2'
                         )}>
-                        {item.label}
-                      </span>
-                      {isActive && !collapsed && <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />}
-                    </Link>
+                        <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                        <span
+                          className={cn(
+                            'min-w-0 flex-1 truncate whitespace-nowrap transition-[max-width,opacity,transform] duration-150 ease-out motion-reduce:transition-none',
+                            collapsed ? 'max-w-0 -translate-x-1 opacity-0' : 'max-w-48 translate-x-0 opacity-100'
+                          )}>
+                          {item.label}
+                        </span>
+                        {!collapsed && (
+                          <span className="shrink-0 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.08em] text-foreground/45">
+                            WIP
+                          </span>
+                        )}
+                      </div>
+                    ) : (
+                      <Link
+                        href={item.href}
+                        onClick={onNavigate}
+                        aria-current={isActive ? 'page' : undefined}
+                        title={collapsed ? item.label : undefined}
+                        className={cn(
+                          'group/link flex min-h-9 items-center gap-2 rounded-r-lg border-l-2 px-3 py-1.5 text-sm transition-[background-color,color] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                          collapsed && 'justify-center gap-0 rounded-lg border-l-0 px-2',
+                          isActive
+                            ? 'border-primary bg-primary/[0.09] font-medium text-primary'
+                            : 'border-transparent text-foreground/70 hover:bg-roman-parchment/80 hover:text-foreground'
+                        )}>
+                        <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                        <span
+                          className={cn(
+                            'min-w-0 flex-1 truncate whitespace-nowrap transition-[max-width,opacity,transform] duration-150 ease-out motion-reduce:transition-none',
+                            collapsed ? 'max-w-0 -translate-x-1 opacity-0' : 'max-w-48 translate-x-0 opacity-100'
+                          )}>
+                          {item.label}
+                        </span>
+                        {isActive && !collapsed && <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />}
+                      </Link>
+                    )}
                   </li>
                 );
               })}

--- a/src/components/admin/shell/navigation-utils.ts
+++ b/src/components/admin/shell/navigation-utils.ts
@@ -3,6 +3,7 @@ import { routeMatchesTemplate } from './breadcrumb-utils';
 export interface AdminNavigationItem {
   href: string;
   label: string;
+  disabled?: boolean;
 }
 
 const EDITOR_NAVIGATION_TARGETS = [

--- a/tests/aiEvaluationsPage.test.tsx
+++ b/tests/aiEvaluationsPage.test.tsx
@@ -36,10 +36,13 @@ describe('AI evaluation admin workspace', () => {
     mockedDeleteEvaluationCaseInFirebase.mockReset();
   });
 
-  it('exposes the workspace in admin navigation and breadcrumbs', () => {
+  it('keeps the workspace route labeled while marking its navigation entry as WIP', () => {
     expect(getAdminBreadcrumbs('/admin/ai-evaluations')).toEqual(['Admin', 'AI Evaluations']);
     render(<AdminSidebar />);
-    expect(screen.getByRole('link', { name: 'AI Evaluations' })).toHaveAttribute('aria-current', 'page');
+    const disabledItem = screen.getByText('AI Evaluations').closest('[aria-disabled="true"]');
+    expect(disabledItem).toBeInTheDocument();
+    expect(disabledItem).toHaveTextContent('WIP');
+    expect(screen.queryByRole('link', { name: 'AI Evaluations' })).not.toBeInTheDocument();
   });
 
   it('asks before a load retry replaces edits made after the initial request failed', async () => {

--- a/tests/firestoreRules.test.ts
+++ b/tests/firestoreRules.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('Firestore server-only collection rules', () => {
+  const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
+
+  it('keeps retired Learning Path migration audit records inaccessible to clients', () => {
+    expect(rules).toMatch(/match \/learningPathMigrations\/\{document=\*\*\} \{\s*allow read, write: if false;\s*\}/);
+    expect(rules).toContain("collection != 'learningPathMigrations'");
+  });
+});


### PR DESCRIPTION
## Summary

Promote the tested post-retirement corrections from `edge` to `production`.

- keep retained Learning Path migration audit records server-only
- prevent future removal of their explicit deny and catch-all exclusion with a regression test
- gray out the AI Evaluations navigation entry and label it `WIP`
- align navigation tests and retirement documentation

## Validation

- edge PR #161 passed all Netlify checks
- `npm test -- --runInBand` — 80 suites / 494 tests passed
- `npm run lint -- --max-warnings=0`
- `npx next typegen && npx tsc --noEmit`
- `npm run build`
- `git diff --check`

This promotion contains code and rule-source changes only. No Firebase or Firestore command was run, no rules were deployed, and no Firebase data was read or written as part of the fix.
