### PR TITLE
Fix legacy learning unit persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ public/*.pdf
 public/*.json
 
 firebase-debug.log
+
+# Local before-images created by guarded production repair commands
+/.prod-repair-backups/

--- a/docs/operations/legacy-learning-unit-field-repair.md
+++ b/docs/operations/legacy-learning-unit-field-repair.md
@@ -1,0 +1,137 @@
+# Legacy learning-unit field repair runbook
+
+This is a one-time production repair for three known lesson documents. The endpoint is intentionally restricted to `latin-app-prod` and accepts only a short-lived OAuth access token from a Google identity that already has these IAM permissions on that project:
+
+- `datastore.entities.get`
+- `datastore.entities.list`
+- `datastore.entities.update`
+
+The operation can delete only `published`, `introduction`, `introduction_backup`, `exercises`, and `exercises_backup` from the three hard-coded targets. It does not replace lesson content.
+
+## Prerequisites
+
+- Deploy the PR to the production application.
+- Install and authenticate `gcloud`, `curl`, and `jq` on the operator machine.
+- Set `PROD_BASE_URL` to the production application's origin, without a trailing slash.
+- Confirm `gcloud auth list --filter=status:ACTIVE` shows the intended operator.
+
+No static migration secret or Firebase password is needed. Each request uses a short-lived token from `gcloud auth print-access-token`; the endpoint independently checks the token identity and its production IAM permissions.
+
+## 1. Dry run
+
+```bash
+PROD_BASE_URL='https://replace-with-production-origin.example'
+access_token="$(gcloud auth print-access-token)"
+dry_run="$(curl --fail-with-body --silent --show-error \
+  --request POST \
+  --header "Authorization: Bearer ${access_token}" \
+  --header 'Content-Type: application/json' \
+  --data '{"mode":"dry-run"}' \
+  "${PROD_BASE_URL}/api/admin/lessons/repair-legacy-fields")"
+
+printf '%s\n' "${dry_run}" | jq .
+printf '%s\n' "${dry_run}" | jq --exit-status '
+  .mode == "dry-run"
+  and (.planHash | test("^[a-f0-9]{64}$"))
+  and (.targets | length == 3)
+  and ([.targets[].status] | all(. == "repair-required" or . == "clean"))
+  and (.projectedVerification.allUnitCount == .projectedVerification.validUnitCount)
+  and (.projectedVerification.pathUnitCount == .projectedVerification.validPathUnitCount)
+'
+```
+
+Review every target ID, update time, status, and removed-field list. A dry run projects the field deletions in memory and then validates every learning-unit document and every active Learning Path unit with the production application schema. It performs no write and creates no backup.
+
+## 2. Apply the reviewed plan
+
+The apply call requires the exact `planHash` returned by the dry run. Any target update between the two calls changes the hash and aborts the migration. Apply also creates a durable before-image in the protected production Storage bucket before opening the Firestore transaction.
+
+```bash
+plan_hash="$(printf '%s\n' "${dry_run}" | jq --exit-status --raw-output '.planHash')"
+access_token="$(gcloud auth print-access-token)"
+apply_result="$(curl --fail-with-body --silent --show-error \
+  --request POST \
+  --header "Authorization: Bearer ${access_token}" \
+  --header 'Content-Type: application/json' \
+  --data "$(jq --null-input --compact-output \
+    --arg planHash "${plan_hash}" \
+    '{mode:"apply", planHash:$planHash, confirmation:"APPLY_LEGACY_LEARNING_UNIT_FIELD_REPAIR"}')" \
+  "${PROD_BASE_URL}/api/admin/lessons/repair-legacy-fields")"
+
+printf '%s\n' "${apply_result}" | jq .
+printf '%s\n' "${apply_result}" | jq --exit-status '
+  .mode == "apply"
+  and (.applied == true or .reason == "All target documents were already clean")
+  and (.verification.allUnitCount == .verification.validUnitCount)
+  and (.verification.pathUnitCount == .verification.validPathUnitCount)
+'
+```
+
+Record the returned snapshot path and the complete JSON response in the incident or deployment record.
+
+## 3. Verify through the application
+
+This call is read-only. It returns HTTP 409 while any target still needs repair, so `curl --fail-with-body` also makes it useful in an automated check.
+
+```bash
+access_token="$(gcloud auth print-access-token)"
+verify_result="$(curl --fail-with-body --silent --show-error \
+  --request POST \
+  --header "Authorization: Bearer ${access_token}" \
+  --header 'Content-Type: application/json' \
+  --data '{"mode":"verify"}' \
+  "${PROD_BASE_URL}/api/admin/lessons/repair-legacy-fields")"
+
+printf '%s\n' "${verify_result}" | jq .
+printf '%s\n' "${verify_result}" | jq --exit-status '
+  .verified == true
+  and ([.targets[].status] | all(. == "clean"))
+  and (.verification.allUnitCount == .verification.validUnitCount)
+  and (.verification.pathUnitCount == .verification.validPathUnitCount)
+'
+```
+
+## 4. Verify the production database independently
+
+This does not use the application endpoint or its Firebase Admin credentials. `gcloud` supplies the current operator's OAuth token directly to the Firestore REST API. The field mask requests only the five retired fields; the final `jq` command fails if any lesson still contains one of them or if the response was paginated.
+
+```bash
+gcloud firestore databases describe \
+  --project=latin-app-prod \
+  --database='(default)' \
+  --format='yaml(name,locationId,type)'
+
+access_token="$(gcloud auth print-access-token)"
+legacy_scan="$(curl --fail-with-body --silent --show-error \
+  --header "Authorization: Bearer ${access_token}" \
+  'https://firestore.googleapis.com/v1/projects/latin-app-prod/databases/(default)/documents/lessons?pageSize=300&mask.fieldPaths=published&mask.fieldPaths=introduction&mask.fieldPaths=introduction_backup&mask.fieldPaths=exercises&mask.fieldPaths=exercises_backup')"
+
+printf '%s\n' "${legacy_scan}" | jq '{
+  documentsScanned: (.documents | length),
+  documentsWithLegacyFields: [
+    .documents[]
+    | select((.fields // {} | length) > 0)
+    | {id: (.name | split("/") | last), legacyFields: (.fields | keys), updateTime}
+  ]
+}'
+
+printf '%s\n' "${legacy_scan}" | jq --exit-status '
+  (has("nextPageToken") | not)
+  and ([.documents[] | select((.fields // {} | length) > 0)] | length == 0)
+'
+```
+
+The current collection has fewer than 300 documents. If it grows beyond that before execution, replace the single list call with a paginated check rather than weakening the `nextPageToken` assertion.
+
+## Cleanup plan
+
+1. Save the dry-run, apply, application verification, and independent Firestore verification outputs with the deployment record. Keep the returned Storage snapshot path.
+2. Exercise a normal Learning Path save and one edit of a formerly affected lesson.
+3. Immediately after those checks and successful verification, open and deploy a cleanup PR that removes:
+   - `/api/admin/lessons/repair-legacy-fields`;
+   - `verifyGcloudProjectAccess.ts` if no other operation adopted it;
+   - `legacy-field-repair-operation.ts` and its route/auth tests;
+   - the local `repair:legacy-learning-units` command, its script, the migration-only planner/test, the `.prod-repair-backups` ignore entry, and `tsx` if it has no other consumer.
+4. Keep the canonical learning-unit write boundary and its authoring/recovery/snapshot regression tests. Those are the permanent persistence fix. Monitor server errors for one business day after the migration and cleanup deployment.
+5. Retain the protected before-image for 30 days. After a second independent Firestore verification and confirmation that no rollback investigation is open, delete that one explicit Storage object or retain it under the project's normal incident-retention policy.
+6. Close the migration record with the cleanup deployment SHA, verification output, snapshot disposition, and confirmation that no long-lived migration secret was created.

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.2.5",
+        "tsx": "^4.23.5",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.21.0",
         "whatwg-fetch": "^3.6.20"
@@ -1245,6 +1246,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -11211,6 +11654,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -22065,6 +22550,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "functions:prod": "firebase use prod && firebase deploy --only functions",
     "functions:all": "npm run functions:dev && npm run functions:staging && npm run functions:prod",
     "functions:serve": "firebase emulators:start --only functions",
-    "firebase:emulators:e2e": "node tests/e2e/start-emulators.mjs"
+    "firebase:emulators:e2e": "node tests/e2e/start-emulators.mjs",
+    "repair:legacy-learning-units": "tsx scripts/repair-legacy-learning-unit-fields.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",
@@ -128,6 +129,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.2.5",
     "typescript": "^5.3.3",
+    "tsx": "^4.23.5",
     "typescript-eslint": "^8.21.0",
     "whatwg-fetch": "^3.6.20"
   },

--- a/scripts/repair-legacy-learning-unit-fields.ts
+++ b/scripts/repair-legacy-learning-unit-fields.ts
@@ -1,0 +1,229 @@
+import { deepStrictEqual } from 'node:assert';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { applicationDefault, deleteApp, initializeApp } from 'firebase-admin/app';
+import { FieldValue, getFirestore, type DocumentData, type DocumentSnapshot } from 'firebase-admin/firestore';
+import {
+  LEGACY_LEARNING_UNIT_FIELDS,
+  planLegacyLearningUnitFieldRepair,
+} from '../src/lib/learning-units/legacy-field-repair';
+import { normalizeLearningUnit } from '../src/lib/learning-units/domain';
+import { validateLessonProgression } from '../src/utils/lessonProgress';
+
+const PRODUCTION_PROJECT_ID = 'latin-app-prod';
+const TARGET_DOCUMENT_IDS = ['lesson-1757796411836', 'lesson-1753896166956', 'lesson-1752695094203'] as const;
+
+type CommandOptions = {
+  apply: boolean;
+  backupDir: string;
+  projectId: string;
+};
+
+type BeforeImage = {
+  id: string;
+  path: string;
+  createTime: string;
+  updateTime: string;
+  data: DocumentData;
+};
+
+function usage() {
+  return [
+    'Usage:',
+    '  npm run repair:legacy-learning-units -- --project latin-app-prod [--backup-dir PATH] [--apply]',
+    '',
+    'Without --apply, the command is read-only and prints the proposed field deletions.',
+  ].join('\n');
+}
+
+export function parseCommandOptions(argv: string[]): CommandOptions {
+  let apply = false;
+  let backupDir = path.resolve('.prod-repair-backups');
+  let projectId: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--apply') {
+      apply = true;
+      continue;
+    }
+    if (argument === '--project' || argument === '--backup-dir') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value\n\n${usage()}`);
+      if (argument === '--project') projectId = value;
+      else backupDir = path.resolve(value);
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith('--project=')) {
+      projectId = argument.slice('--project='.length);
+      continue;
+    }
+    if (argument.startsWith('--backup-dir=')) {
+      backupDir = path.resolve(argument.slice('--backup-dir='.length));
+      continue;
+    }
+    if (argument === '--help' || argument === '-h') throw new Error(usage());
+    throw new Error(`Unknown argument: ${argument}\n\n${usage()}`);
+  }
+
+  if (projectId !== PRODUCTION_PROJECT_ID) {
+    throw new Error(`Refusing to run: --project must explicitly equal ${PRODUCTION_PROJECT_ID}`);
+  }
+  return { apply, backupDir, projectId };
+}
+
+function timestampForFilename() {
+  return new Date().toISOString().replaceAll(':', '-');
+}
+
+function toBeforeImage(snapshot: DocumentSnapshot): BeforeImage {
+  if (!snapshot.exists || !snapshot.createTime || !snapshot.updateTime) {
+    throw new Error(`Required document ${snapshot.ref.path} does not exist`);
+  }
+  return {
+    id: snapshot.id,
+    path: snapshot.ref.path,
+    createTime: snapshot.createTime.toDate().toISOString(),
+    updateTime: snapshot.updateTime.toDate().toISOString(),
+    data: snapshot.data()!,
+  };
+}
+
+function assertJsonRoundTrip(beforeImages: BeforeImage[]) {
+  const serialized = JSON.stringify(beforeImages);
+  deepStrictEqual(JSON.parse(serialized), beforeImages);
+}
+
+async function verifyProductionCollection(
+  db: ReturnType<typeof getFirestore>,
+  projectedDocuments: ReadonlyMap<string, DocumentData> = new Map()
+) {
+  const [allUnits, pathSnapshot] = await Promise.all([
+    db.collection('lessons').get(),
+    db.collection('learningPaths').doc('default').get(),
+  ]);
+  const failures: string[] = [];
+  for (const snapshot of allUnits.docs) {
+    try {
+      normalizeLearningUnit(projectedDocuments.get(snapshot.id) ?? snapshot.data(), snapshot.id);
+    } catch (error) {
+      failures.push(`${snapshot.id}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(`Post-repair collection validation failed:\n${failures.join('\n')}`);
+  }
+
+  if (!pathSnapshot.exists) throw new Error('The production Learning Path does not exist');
+  const unitIds = pathSnapshot.data()?.unitIds;
+  if (!Array.isArray(unitIds)) throw new Error('The production Learning Path unitIds field is invalid');
+  const unitSnapshots = unitIds.length
+    ? await db.getAll(...unitIds.map(unitId => db.collection('lessons').doc(unitId)))
+    : [];
+  for (const snapshot of unitSnapshots) {
+    if (!snapshot.exists) throw new Error(`Placed learning unit ${snapshot.id} does not exist`);
+    const unit = normalizeLearningUnit(projectedDocuments.get(snapshot.id) ?? snapshot.data(), snapshot.id);
+    if (unit.kind === 'lesson') {
+      if (unit.type !== 'normal') throw new Error(`Placed lesson ${unit.id} is not a normal lesson`);
+      const progressionErrors = validateLessonProgression(unit);
+      if (progressionErrors.length > 0) {
+        throw new Error(`Placed lesson ${unit.id} is incomplete: ${progressionErrors.join(' ')}`);
+      }
+    }
+  }
+  return { allUnitCount: allUnits.size, pathUnitCount: unitIds.length };
+}
+
+export async function runRepairCommand(options: CommandOptions) {
+  const app = initializeApp(
+    { credential: applicationDefault(), projectId: options.projectId },
+    `legacy-learning-unit-repair-${Date.now()}`
+  );
+  try {
+    const db = getFirestore(app);
+    const refs = TARGET_DOCUMENT_IDS.map(id => db.collection('lessons').doc(id));
+    const snapshots = await db.getAll(...refs);
+    const beforeImages = snapshots.map(toBeforeImage);
+    const plans = beforeImages.map(beforeImage => ({
+      id: beforeImage.id,
+      ...planLegacyLearningUnitFieldRepair(beforeImage.data, beforeImage.id),
+    }));
+    const summary = plans.map(plan => ({
+      id: plan.id,
+      status: plan.status,
+      removedFields: plan.removedFields,
+    }));
+    const projectedDocuments = new Map(plans.map(plan => [plan.id, plan.repairedData]));
+    const projectedVerification = await verifyProductionCollection(db, projectedDocuments);
+
+    console.log(
+      JSON.stringify(
+        {
+          mode: options.apply ? 'apply' : 'dry-run',
+          projectId: options.projectId,
+          summary,
+          projectedVerification,
+        },
+        null,
+        2
+      )
+    );
+    if (!options.apply) return { applied: false, summary };
+
+    assertJsonRoundTrip(beforeImages);
+    await mkdir(options.backupDir, { recursive: true, mode: 0o700 });
+    const backupPath = path.join(options.backupDir, `legacy-learning-unit-fields-${timestampForFilename()}.json`);
+    await writeFile(
+      backupPath,
+      `${JSON.stringify(
+        {
+          formatVersion: 1,
+          projectId: options.projectId,
+          createdAt: new Date().toISOString(),
+          approvedFields: LEGACY_LEARNING_UNIT_FIELDS,
+          documents: beforeImages,
+        },
+        null,
+        2
+      )}\n`,
+      { encoding: 'utf8', flag: 'wx', mode: 0o600 }
+    );
+
+    await db.runTransaction(async transaction => {
+      const currentSnapshots = await transaction.getAll(...refs);
+      for (let index = 0; index < currentSnapshots.length; index += 1) {
+        const current = currentSnapshots[index];
+        const beforeImage = beforeImages[index];
+        if (!current.exists || current.updateTime?.toDate().toISOString() !== beforeImage.updateTime) {
+          throw new Error(`Document ${beforeImage.path} changed after backup; aborting without writes`);
+        }
+        deepStrictEqual(current.data(), beforeImage.data);
+        const plan = planLegacyLearningUnitFieldRepair(current.data(), current.id);
+        if (plan.status === 'clean') continue;
+        transaction.update(
+          current.ref,
+          Object.fromEntries(plan.removedFields.map(field => [field, FieldValue.delete()]))
+        );
+      }
+    });
+
+    const verification = await verifyProductionCollection(db);
+    console.log(JSON.stringify({ applied: true, backupPath, verification }, null, 2));
+    return { applied: true, backupPath, summary, verification };
+  } finally {
+    await deleteApp(app);
+  }
+}
+
+const isMainModule = Boolean(process.argv[1]) && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isMainModule) {
+  Promise.resolve()
+    .then(() => runRepairCommand(parseCommandOptions(process.argv.slice(2))))
+    .catch(error => {
+      console.error(error instanceof Error ? (error.stack ?? error.message) : error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/repair-legacy-learning-unit-fields.ts
+++ b/scripts/repair-legacy-learning-unit-fields.ts
@@ -3,16 +3,21 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { applicationDefault, deleteApp, initializeApp } from 'firebase-admin/app';
-import { FieldValue, getFirestore, type DocumentData, type DocumentSnapshot } from 'firebase-admin/firestore';
+import {
+  FieldValue,
+  getFirestore,
+  type DocumentData,
+  type DocumentSnapshot,
+  type Timestamp,
+} from 'firebase-admin/firestore';
 import {
   LEGACY_LEARNING_UNIT_FIELDS,
+  LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID,
+  LEGACY_LEARNING_UNIT_REPAIR_TARGET_IDS,
   planLegacyLearningUnitFieldRepair,
 } from '../src/lib/learning-units/legacy-field-repair';
 import { normalizeLearningUnit } from '../src/lib/learning-units/domain';
 import { validateLessonProgression } from '../src/utils/lessonProgress';
-
-const PRODUCTION_PROJECT_ID = 'latin-app-prod';
-const TARGET_DOCUMENT_IDS = ['lesson-1757796411836', 'lesson-1753896166956', 'lesson-1752695094203'] as const;
 
 type CommandOptions = {
   apply: boolean;
@@ -68,14 +73,19 @@ export function parseCommandOptions(argv: string[]): CommandOptions {
     throw new Error(`Unknown argument: ${argument}\n\n${usage()}`);
   }
 
-  if (projectId !== PRODUCTION_PROJECT_ID) {
-    throw new Error(`Refusing to run: --project must explicitly equal ${PRODUCTION_PROJECT_ID}`);
+  if (projectId !== LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID) {
+    throw new Error(`Refusing to run: --project must explicitly equal ${LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID}`);
   }
   return { apply, backupDir, projectId };
 }
 
 function timestampForFilename() {
   return new Date().toISOString().replaceAll(':', '-');
+}
+
+function exactTimestamp(timestamp: Timestamp) {
+  const wholeSecond = new Date(timestamp.seconds * 1000).toISOString().replace('.000Z', '');
+  return `${wholeSecond}.${String(timestamp.nanoseconds).padStart(9, '0')}Z`;
 }
 
 function toBeforeImage(snapshot: DocumentSnapshot): BeforeImage {
@@ -85,8 +95,8 @@ function toBeforeImage(snapshot: DocumentSnapshot): BeforeImage {
   return {
     id: snapshot.id,
     path: snapshot.ref.path,
-    createTime: snapshot.createTime.toDate().toISOString(),
-    updateTime: snapshot.updateTime.toDate().toISOString(),
+    createTime: exactTimestamp(snapshot.createTime),
+    updateTime: exactTimestamp(snapshot.updateTime),
     data: snapshot.data()!,
   };
 }
@@ -143,7 +153,7 @@ export async function runRepairCommand(options: CommandOptions) {
   );
   try {
     const db = getFirestore(app);
-    const refs = TARGET_DOCUMENT_IDS.map(id => db.collection('lessons').doc(id));
+    const refs = LEGACY_LEARNING_UNIT_REPAIR_TARGET_IDS.map(id => db.collection('lessons').doc(id));
     const snapshots = await db.getAll(...refs);
     const beforeImages = snapshots.map(toBeforeImage);
     const plans = beforeImages.map(beforeImage => ({
@@ -196,7 +206,7 @@ export async function runRepairCommand(options: CommandOptions) {
       for (let index = 0; index < currentSnapshots.length; index += 1) {
         const current = currentSnapshots[index];
         const beforeImage = beforeImages[index];
-        if (!current.exists || current.updateTime?.toDate().toISOString() !== beforeImage.updateTime) {
+        if (!current.exists || !current.updateTime || exactTimestamp(current.updateTime) !== beforeImage.updateTime) {
           throw new Error(`Document ${beforeImage.path} changed after backup; aborting without writes`);
         }
         deepStrictEqual(current.data(), beforeImage.data);

--- a/src/app/api/admin/lessons/recovery/[id]/route.ts
+++ b/src/app/api/admin/lessons/recovery/[id]/route.ts
@@ -14,6 +14,7 @@ import {
   assertLegacyNormalPlacementChangeAllowedInTransaction,
   assertPlacedLessonReplacementAllowedInTransaction,
 } from '@/src/lib/learning-units/learning-path-service';
+import { lessonAuthoringInputSchema, lessonUnitDocumentSchema } from '@/src/lib/learning-units/schemas';
 
 interface RouteParams {
   params: Promise<{
@@ -66,9 +67,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       if (rawLesson.showWordSearch !== undefined && typeof rawLesson.showWordSearch !== 'boolean') {
         throw new RecoveryRouteError('showWordSearch must be a boolean', 400);
       }
-      if (!rawLesson?.id || !rawLesson.title || !rawLesson.type) {
-        throw new RecoveryRouteError('Recovery lesson ID, title, and type are required', 400);
-      }
       const fallbackCategoryIds = rawLesson.practiceCategories?.map(category => category.id);
       const practiceCategorySelections = optionalPracticeCategorySelectionsSchema.parse(
         rawLesson.practiceCategorySelections
@@ -76,13 +74,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       const practiceCategoryIds = optionalPracticeCategoryIdsSchema.parse(
         rawLesson.practiceCategoryIds ?? fallbackCategoryIds
       );
-      const {
-        practiceCategorySelections: _practiceCategorySelections,
-        practiceCategoryIds: _practiceCategoryIds,
-        practiceCategories: _practiceCategories,
-        practiceCategoryPlacements: _practiceCategoryPlacements,
-        ...lesson
-      } = rawLesson;
+      const lesson = lessonAuthoringInputSchema.parse(rawLesson);
       const lessonRef = adminDb.collection('lessons').doc(lesson.id);
       const existingLessonDoc = await transaction.get(lessonRef);
       const lessonExists = existingLessonDoc.exists;
@@ -92,43 +84,45 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
       const { totalPages, totalItems, totalExercises } = getLessonContentCounts(lesson);
       const now = new Date().toISOString();
-      const lessonData = lessonExists
-        ? {
-            ...lesson,
-            kind: 'lesson' as const,
-            totalPages,
-            totalItems,
-            totalExercises,
-            createdAt: existingLesson?.createdAt || now,
-            createdBy: existingLesson?.createdBy || user.uid,
-            updatedAt: now,
-            updatedBy: user.uid,
-            version: (existingLesson?.version || 0) + 1,
-            showWordSearch:
-              rawLesson.showWordSearch ??
-              (typeof existingLesson?.showWordSearch === 'boolean' ? existingLesson.showWordSearch : true),
-            isLive: existingLesson?.isLive ?? false,
-            liveOrder: existingLesson?.liveOrder ?? null,
-            publishedAt: existingLesson?.publishedAt || null,
-            publishedBy: existingLesson?.publishedBy || null,
-          }
-        : {
-            ...lesson,
-            kind: 'lesson' as const,
-            totalPages,
-            totalItems,
-            totalExercises,
-            createdAt: now,
-            createdBy: user.uid,
-            updatedAt: now,
-            updatedBy: user.uid,
-            version: 1,
-            showWordSearch: rawLesson.showWordSearch ?? false,
-            isLive: false,
-            liveOrder: null,
-            publishedAt: null,
-            publishedBy: null,
-          };
+      const lessonData = lessonUnitDocumentSchema.parse(
+        lessonExists
+          ? {
+              ...lesson,
+              kind: 'lesson' as const,
+              totalPages,
+              totalItems,
+              totalExercises,
+              createdAt: existingLesson?.createdAt || now,
+              createdBy: existingLesson?.createdBy || user.uid,
+              updatedAt: now,
+              updatedBy: user.uid,
+              version: (existingLesson?.version || 0) + 1,
+              showWordSearch:
+                rawLesson.showWordSearch ??
+                (typeof existingLesson?.showWordSearch === 'boolean' ? existingLesson.showWordSearch : true),
+              isLive: existingLesson?.isLive ?? false,
+              liveOrder: existingLesson?.liveOrder ?? null,
+              publishedAt: existingLesson?.publishedAt || null,
+              publishedBy: existingLesson?.publishedBy || null,
+            }
+          : {
+              ...lesson,
+              kind: 'lesson' as const,
+              totalPages,
+              totalItems,
+              totalExercises,
+              createdAt: now,
+              createdBy: user.uid,
+              updatedAt: now,
+              updatedBy: user.uid,
+              version: 1,
+              showWordSearch: rawLesson.showWordSearch ?? false,
+              isLive: false,
+              liveOrder: null,
+              publishedAt: null,
+              publishedBy: null,
+            }
+      );
 
       await assertLegacyNormalPlacementChangeAllowedInTransaction(
         transaction,

--- a/src/app/api/admin/lessons/repair-legacy-fields/route.ts
+++ b/src/app/api/admin/lessons/repair-legacy-fields/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { adminDb, adminStorage } from '@/src/services/firebase-admin';
+import {
+  LegacyLearningUnitRepairOperationError,
+  runLegacyLearningUnitRepairOperation,
+} from '@/src/lib/learning-units/legacy-field-repair-operation';
+import { LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID } from '@/src/lib/learning-units/legacy-field-repair';
+import { GcloudProjectAccessError, verifyGcloudProjectAccess } from '@/src/lib/verifyGcloudProjectAccess';
+
+const requestSchema = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('dry-run') }).strict(),
+  z.object({ mode: z.literal('verify') }).strict(),
+  z
+    .object({
+      mode: z.literal('apply'),
+      planHash: z.string().regex(/^[a-f0-9]{64}$/),
+      confirmation: z.literal('APPLY_LEGACY_LEARNING_UNIT_FIELD_REPAIR'),
+    })
+    .strict(),
+]);
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  try {
+    const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+    if (projectId !== LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID) {
+      throw new LegacyLearningUnitRepairOperationError(
+        `Refusing to run outside ${LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID}`,
+        503
+      );
+    }
+
+    const operator = await verifyGcloudProjectAccess(request, projectId);
+    const input = requestSchema.parse((await request.json().catch(() => ({}))) as unknown);
+    const result = await runLegacyLearningUnitRepairOperation({
+      db: adminDb,
+      storage: adminStorage,
+      projectId,
+      operator,
+      request: input,
+    });
+
+    return NextResponse.json(result, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Invalid migration request', issues: error.issues },
+        { status: 400, headers: { 'Cache-Control': 'no-store' } }
+      );
+    }
+    if (error instanceof GcloudProjectAccessError || error instanceof LegacyLearningUnitRepairOperationError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status, headers: { 'Cache-Control': 'no-store' } }
+      );
+    }
+
+    console.error('Legacy learning-unit field repair failed:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Legacy learning-unit field repair failed' },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+}

--- a/src/app/api/admin/lessons/restore-snapshot/route.ts
+++ b/src/app/api/admin/lessons/restore-snapshot/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { adminDb, adminStorage } from '@/src/services/firebase-admin';
 import { verifyAdminAccess } from '@/src/lib/verifyAdminAccess';
-import { isLessonDocumentData } from '@/src/lib/learning-units/domain';
+import { isLessonDocumentData, normalizeLessonDocumentForWrite } from '@/src/lib/learning-units/domain';
 import { PracticeCategoryError, practiceCategoryService } from '@/src/lib/practice-categories/service';
 import {
   assertLegacyNormalPlacementChangeAllowedInTransaction,
@@ -71,15 +71,8 @@ function isSnapshotLesson(value: unknown): value is SnapshotLesson {
 }
 
 async function restoreSnapshotLesson(lesson: SnapshotLesson, actorId: string) {
-  const {
-    id,
-    practiceCategorySelections: _practiceCategorySelections,
-    practiceCategoryIds: _practiceCategoryIds,
-    practiceCategories: _practiceCategories,
-    practiceCategoryPlacements: _practiceCategoryPlacements,
-    ...lessonData
-  } = lesson;
-  lessonData.kind = 'lesson';
+  const { id } = lesson;
+  const lessonData = normalizeLessonDocumentForWrite(lesson, id);
   const lessonRef = adminDb.collection('lessons').doc(id);
 
   await adminDb.runTransaction(async transaction => {

--- a/src/app/api/admin/lessons/route.ts
+++ b/src/app/api/admin/lessons/route.ts
@@ -15,6 +15,7 @@ import {
   assertLegacyNormalPlacementChangeAllowedInTransaction,
   assertPlacedLessonReplacementAllowedInTransaction,
 } from '@/src/lib/learning-units/learning-path-service';
+import { lessonAuthoringInputSchema, lessonUnitDocumentSchema } from '@/src/lib/learning-units/schemas';
 
 const LESSON_SUMMARY_FIELDS = [
   'title',
@@ -98,7 +99,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const rawLesson = (await request.json()) as Lesson;
+    const rawLesson = await request.json();
     if (!isLessonDocumentData(rawLesson)) {
       return NextResponse.json({ error: 'Only lesson documents can use the lesson endpoint' }, { status: 400 });
     }
@@ -109,21 +110,11 @@ export async function POST(request: NextRequest) {
       rawLesson.practiceCategorySelections
     );
     const practiceCategoryIds = optionalPracticeCategoryIdsSchema.parse(rawLesson.practiceCategoryIds);
-    const {
-      practiceCategorySelections: _practiceCategorySelections,
-      practiceCategoryIds: _practiceCategoryIds,
-      practiceCategories: _practiceCategories,
-      practiceCategoryPlacements: _practiceCategoryPlacements,
-      ...lesson
-    } = rawLesson;
-
-    if (!lesson.id || !lesson.title || !lesson.type) {
-      return NextResponse.json({ error: 'Lesson ID, title, and type are required' }, { status: 400 });
-    }
+    const lesson = lessonAuthoringInputSchema.parse(rawLesson);
 
     const { totalPages, totalItems, totalExercises } = getLessonContentCounts(lesson);
     const now = new Date().toISOString();
-    const lessonData = {
+    const lessonData = lessonUnitDocumentSchema.parse({
       ...lesson,
       kind: 'lesson' as const,
       totalPages,
@@ -139,7 +130,7 @@ export async function POST(request: NextRequest) {
       liveOrder: null,
       publishedAt: null,
       publishedBy: null,
-    };
+    });
 
     const lessonRef = adminDb.collection('lessons').doc(lesson.id);
     const assignments = await adminDb.runTransaction(async transaction => {
@@ -184,7 +175,7 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const rawLesson = (await request.json()) as Lesson;
+    const rawLesson = await request.json();
     if (!isLessonDocumentData(rawLesson)) {
       return NextResponse.json({ error: 'Only lesson documents can use the lesson endpoint' }, { status: 400 });
     }
@@ -195,17 +186,7 @@ export async function PUT(request: NextRequest) {
       rawLesson.practiceCategorySelections
     );
     const practiceCategoryIds = optionalPracticeCategoryIdsSchema.parse(rawLesson.practiceCategoryIds);
-    const {
-      practiceCategorySelections: _practiceCategorySelections,
-      practiceCategoryIds: _practiceCategoryIds,
-      practiceCategories: _practiceCategories,
-      practiceCategoryPlacements: _practiceCategoryPlacements,
-      ...lesson
-    } = rawLesson;
-
-    if (!lesson.id || !lesson.title || !lesson.type) {
-      return NextResponse.json({ error: 'Lesson ID, title, and type are required' }, { status: 400 });
-    }
+    const lesson = lessonAuthoringInputSchema.parse(rawLesson);
 
     const { totalPages, totalItems, totalExercises } = getLessonContentCounts(lesson);
     const lessonRef = adminDb.collection('lessons').doc(lesson.id);
@@ -237,7 +218,7 @@ export async function PUT(request: NextRequest) {
         }
       }
 
-      const updatedLessonData = {
+      const updatedLessonData = lessonUnitDocumentSchema.parse({
         ...lesson,
         kind: 'lesson' as const,
         totalPages,
@@ -255,7 +236,7 @@ export async function PUT(request: NextRequest) {
         liveOrder: existingLesson?.liveOrder ?? null,
         publishedAt: existingLesson?.publishedAt || null,
         publishedBy: existingLesson?.publishedBy || null,
-      };
+      });
       const assignments = await practiceCategoryService.reconcileLessonCategoriesInTransaction(transaction, {
         lessonId: lesson.id,
         lesson: updatedLessonData,

--- a/src/lib/learning-units/domain.ts
+++ b/src/lib/learning-units/domain.ts
@@ -1,5 +1,28 @@
-import type { LearningUnit } from '@/src/types/learning-unit';
+import type { LearningUnit, LessonUnit } from '@/src/types/learning-unit';
 import { learningUnitDocumentSchema } from './schemas';
+
+const LESSON_DOCUMENT_FIELDS = [
+  'id',
+  'kind',
+  'title',
+  'description',
+  'createdAt',
+  'createdBy',
+  'updatedAt',
+  'updatedBy',
+  'type',
+  'pages',
+  'vocabulary_pool',
+  'showWordSearch',
+  'isLive',
+  'liveOrder',
+  'publishedAt',
+  'publishedBy',
+  'version',
+  'totalPages',
+  'totalItems',
+  'totalExercises',
+] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -41,4 +64,31 @@ export function normalizeLearningUnit(value: unknown, snapshotId?: string): Lear
   };
 
   return learningUnitDocumentSchema.parse(normalized) as unknown as LearningUnit;
+}
+
+/**
+ * Canonicalizes a lesson for a whole-document write. This is intentionally
+ * separate from normal reads: stale persisted documents must still fail closed,
+ * while explicit recovery/restore operations may safely shed obsolete fields.
+ */
+export function normalizeLessonDocumentForWrite(value: unknown, snapshotId?: string): LessonUnit {
+  if (!isLessonDocumentData(value)) {
+    throw new Error('Learning unit is not a lesson');
+  }
+  const canonicalFields = Object.fromEntries(
+    LESSON_DOCUMENT_FIELDS.filter(field => Object.prototype.hasOwnProperty.call(value, field)).map(field => [
+      field,
+      value[field],
+    ])
+  );
+  const unit = normalizeLearningUnit(
+    {
+      ...canonicalFields,
+      ...(snapshotId ? { id: snapshotId } : {}),
+      kind: 'lesson',
+    },
+    snapshotId
+  );
+  if (unit.kind !== 'lesson') throw new Error('Learning unit is not a lesson');
+  return unit;
 }

--- a/src/lib/learning-units/legacy-field-repair-operation.ts
+++ b/src/lib/learning-units/legacy-field-repair-operation.ts
@@ -1,0 +1,356 @@
+import { createHash } from 'node:crypto';
+import { deepStrictEqual } from 'node:assert';
+import {
+  FieldValue,
+  type DocumentData,
+  type DocumentSnapshot,
+  type Firestore,
+  type Timestamp,
+} from 'firebase-admin/firestore';
+import type { Storage } from 'firebase-admin/storage';
+import { normalizeLearningUnit } from './domain';
+import {
+  LEGACY_LEARNING_UNIT_FIELDS,
+  LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID,
+  LEGACY_LEARNING_UNIT_REPAIR_TARGET_IDS,
+  planLegacyLearningUnitFieldRepair,
+} from './legacy-field-repair';
+import { validateLessonProgression } from '@/src/utils/lessonProgress';
+import type { GcloudProjectOperator } from '@/src/lib/verifyGcloudProjectAccess';
+
+const SNAPSHOT_PREFIX = 'lesson-snapshots/legacy-learning-unit-field-repair';
+
+type BeforeImage = {
+  id: string;
+  path: string;
+  createTime: string;
+  updateTime: string;
+  data: DocumentData;
+};
+
+type TargetPlan = ReturnType<typeof planLegacyLearningUnitFieldRepair> & {
+  id: string;
+  path: string;
+  updateTime: string;
+};
+
+export type LegacyLearningUnitRepairRequest =
+  | { mode: 'dry-run' }
+  | { mode: 'verify' }
+  | { mode: 'apply'; planHash: string; confirmation: 'APPLY_LEGACY_LEARNING_UNIT_FIELD_REPAIR' };
+
+export class LegacyLearningUnitRepairOperationError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 409 | 500 | 503,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'LegacyLearningUnitRepairOperationError';
+  }
+}
+
+function toBeforeImage(snapshot: DocumentSnapshot): BeforeImage {
+  if (!snapshot.exists || !snapshot.createTime || !snapshot.updateTime) {
+    throw new LegacyLearningUnitRepairOperationError(`Required document ${snapshot.ref.path} does not exist`, 409);
+  }
+
+  return {
+    id: snapshot.id,
+    path: snapshot.ref.path,
+    createTime: exactTimestamp(snapshot.createTime),
+    updateTime: exactTimestamp(snapshot.updateTime),
+    data: snapshot.data()!,
+  };
+}
+
+function exactTimestamp(timestamp: Timestamp): string {
+  const wholeSecond = new Date(timestamp.seconds * 1000).toISOString().replace('.000Z', '');
+  return `${wholeSecond}.${String(timestamp.nanoseconds).padStart(9, '0')}Z`;
+}
+
+function serializeFirestoreValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(serializeFirestoreValue);
+  if (!value || typeof value !== 'object') return value;
+  if ('toDate' in value && typeof value.toDate === 'function') return value.toDate().toISOString();
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [
+      key,
+      serializeFirestoreValue(nestedValue),
+    ])
+  );
+}
+
+export function createLegacyLearningUnitRepairPlanHash(plans: readonly TargetPlan[]): string {
+  const reviewedState = plans
+    .map(plan => ({
+      id: plan.id,
+      path: plan.path,
+      updateTime: plan.updateTime,
+      status: plan.status,
+      removedFields: [...plan.removedFields].sort(),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  return createHash('sha256').update(JSON.stringify(reviewedState)).digest('hex');
+}
+
+async function readTargetPlans(db: Firestore) {
+  const refs = LEGACY_LEARNING_UNIT_REPAIR_TARGET_IDS.map(id => db.collection('lessons').doc(id));
+  const snapshots = await db.getAll(...refs);
+  const beforeImages = snapshots.map(toBeforeImage);
+  const plans: TargetPlan[] = beforeImages.map(beforeImage => ({
+    id: beforeImage.id,
+    path: beforeImage.path,
+    updateTime: beforeImage.updateTime,
+    ...planLegacyLearningUnitFieldRepair(beforeImage.data, beforeImage.id),
+  }));
+
+  return {
+    refs,
+    beforeImages,
+    plans,
+    planHash: createLegacyLearningUnitRepairPlanHash(plans),
+  };
+}
+
+async function verifyProductionCollection(
+  db: Firestore,
+  projectedDocuments: ReadonlyMap<string, DocumentData> = new Map()
+) {
+  const [allUnits, pathSnapshot] = await Promise.all([
+    db.collection('lessons').get(),
+    db.collection('learningPaths').doc('default').get(),
+  ]);
+  const failures: string[] = [];
+
+  for (const snapshot of allUnits.docs) {
+    try {
+      normalizeLearningUnit(projectedDocuments.get(snapshot.id) ?? snapshot.data(), snapshot.id);
+    } catch (error) {
+      failures.push(`${snapshot.id}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new LegacyLearningUnitRepairOperationError(
+      `Production learning-unit validation failed:\n${failures.join('\n')}`,
+      409
+    );
+  }
+
+  if (!pathSnapshot.exists) {
+    throw new LegacyLearningUnitRepairOperationError('The production Learning Path does not exist', 409);
+  }
+
+  const unitIds = pathSnapshot.data()?.unitIds;
+  if (!Array.isArray(unitIds) || unitIds.some(unitId => typeof unitId !== 'string')) {
+    throw new LegacyLearningUnitRepairOperationError('The production Learning Path unitIds field is invalid', 409);
+  }
+
+  const unitSnapshots = unitIds.length
+    ? await db.getAll(...unitIds.map(unitId => db.collection('lessons').doc(unitId)))
+    : [];
+  for (const snapshot of unitSnapshots) {
+    if (!snapshot.exists) {
+      throw new LegacyLearningUnitRepairOperationError(`Placed learning unit ${snapshot.id} does not exist`, 409);
+    }
+    const unit = normalizeLearningUnit(projectedDocuments.get(snapshot.id) ?? snapshot.data(), snapshot.id);
+    if (unit.kind === 'lesson') {
+      if (unit.type !== 'normal') {
+        throw new LegacyLearningUnitRepairOperationError(`Placed lesson ${unit.id} is not a normal lesson`, 409);
+      }
+      const progressionErrors = validateLessonProgression(unit);
+      if (progressionErrors.length > 0) {
+        throw new LegacyLearningUnitRepairOperationError(
+          `Placed lesson ${unit.id} is incomplete: ${progressionErrors.join(' ')}`,
+          409
+        );
+      }
+    }
+  }
+
+  return {
+    allUnitCount: allUnits.size,
+    validUnitCount: allUnits.size,
+    pathUnitCount: unitIds.length,
+    validPathUnitCount: unitSnapshots.length,
+  };
+}
+
+function targetSummary(plans: readonly TargetPlan[]) {
+  return plans.map(plan => ({
+    id: plan.id,
+    updateTime: plan.updateTime,
+    status: plan.status,
+    removedFields: plan.removedFields,
+  }));
+}
+
+function snapshotId(now = new Date()) {
+  return `legacy-learning-unit-field-repair-${now.toISOString().replace(/[:.]/g, '-')}`;
+}
+
+async function saveBeforeImageSnapshot(
+  storage: Storage,
+  operator: GcloudProjectOperator,
+  beforeImages: readonly BeforeImage[],
+  plans: readonly TargetPlan[],
+  planHash: string
+) {
+  const createdAt = new Date().toISOString();
+  const id = snapshotId(new Date(createdAt));
+  const path = `${SNAPSHOT_PREFIX}/${id}.json`;
+  const payload = {
+    formatVersion: 1,
+    snapshotId: id,
+    createdAt,
+    createdBy: operator.email,
+    authentication: operator.authentication,
+    projectId: LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID,
+    migration: 'legacy-learning-unit-field-repair',
+    planHash,
+    approvedFields: LEGACY_LEARNING_UNIT_FIELDS,
+    targets: targetSummary(plans),
+    lessons: beforeImages.map(beforeImage => ({
+      ...(serializeFirestoreValue(beforeImage.data) as Record<string, unknown>),
+      id: beforeImage.id,
+    })),
+  };
+
+  await storage
+    .bucket()
+    .file(path)
+    .save(JSON.stringify(payload, null, 2), {
+      contentType: 'application/json',
+      resumable: false,
+      preconditionOpts: { ifGenerationMatch: 0 },
+      metadata: { cacheControl: 'no-store' },
+    });
+
+  return { snapshotId: id, path, createdAt, totalLessons: beforeImages.length };
+}
+
+async function runDryRun(db: Firestore) {
+  const state = await readTargetPlans(db);
+  const projectedDocuments = new Map(state.plans.map(plan => [plan.id, plan.repairedData]));
+  const projectedVerification = await verifyProductionCollection(db, projectedDocuments);
+
+  return {
+    mode: 'dry-run' as const,
+    projectId: LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID,
+    planHash: state.planHash,
+    targets: targetSummary(state.plans),
+    projectedVerification,
+  };
+}
+
+async function runVerification(db: Firestore) {
+  const state = await readTargetPlans(db);
+  const repairRequired = state.plans.filter(plan => plan.status === 'repair-required');
+  if (repairRequired.length > 0) {
+    throw new LegacyLearningUnitRepairOperationError(
+      `Verification failed: ${repairRequired.length} target documents still contain approved legacy fields`,
+      409
+    );
+  }
+
+  return {
+    mode: 'verify' as const,
+    projectId: LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID,
+    verified: true,
+    planHash: state.planHash,
+    targets: targetSummary(state.plans),
+    verification: await verifyProductionCollection(db),
+  };
+}
+
+async function runApply(
+  db: Firestore,
+  storage: Storage,
+  operator: GcloudProjectOperator,
+  request: Extract<LegacyLearningUnitRepairRequest, { mode: 'apply' }>
+) {
+  const state = await readTargetPlans(db);
+  if (state.planHash !== request.planHash) {
+    throw new LegacyLearningUnitRepairOperationError(
+      'The production documents changed after dry-run; run a new dry-run and review its planHash',
+      409
+    );
+  }
+
+  const repairRequired = state.plans.filter(plan => plan.status === 'repair-required');
+  if (repairRequired.length === 0) {
+    return {
+      ...(await runVerification(db)),
+      mode: 'apply' as const,
+      applied: false,
+      reason: 'All target documents were already clean',
+      snapshot: null,
+      appliedBy: operator.email,
+    };
+  }
+
+  const projectedDocuments = new Map(state.plans.map(plan => [plan.id, plan.repairedData]));
+  const projectedVerification = await verifyProductionCollection(db, projectedDocuments);
+  const snapshot = await saveBeforeImageSnapshot(storage, operator, state.beforeImages, state.plans, state.planHash);
+
+  await db.runTransaction(async transaction => {
+    const currentSnapshots = await transaction.getAll(...state.refs);
+    for (let index = 0; index < currentSnapshots.length; index += 1) {
+      const current = currentSnapshots[index];
+      const beforeImage = state.beforeImages[index];
+      if (!current.exists || !current.updateTime || exactTimestamp(current.updateTime) !== beforeImage.updateTime) {
+        throw new LegacyLearningUnitRepairOperationError(
+          `Document ${beforeImage.path} changed after the durable backup; aborting without writes`,
+          409
+        );
+      }
+
+      deepStrictEqual(current.data(), beforeImage.data);
+      const plan = planLegacyLearningUnitFieldRepair(current.data(), current.id);
+      if (plan.status === 'clean') continue;
+      transaction.update(
+        current.ref,
+        Object.fromEntries(plan.removedFields.map(field => [field, FieldValue.delete()]))
+      );
+    }
+  });
+
+  return {
+    mode: 'apply' as const,
+    projectId: LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID,
+    applied: true,
+    appliedBy: operator.email,
+    planHash: state.planHash,
+    targets: targetSummary(state.plans),
+    projectedVerification,
+    snapshot,
+    verification: await verifyProductionCollection(db),
+  };
+}
+
+export async function runLegacyLearningUnitRepairOperation(params: {
+  db: Firestore;
+  storage: Storage;
+  projectId: string | undefined;
+  operator: GcloudProjectOperator;
+  request: LegacyLearningUnitRepairRequest;
+}) {
+  if (params.projectId !== LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID) {
+    throw new LegacyLearningUnitRepairOperationError(
+      `Refusing to run outside ${LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID}`,
+      503
+    );
+  }
+
+  switch (params.request.mode) {
+    case 'dry-run':
+      return runDryRun(params.db);
+    case 'verify':
+      return runVerification(params.db);
+    case 'apply':
+      return runApply(params.db, params.storage, params.operator, params.request);
+  }
+}

--- a/src/lib/learning-units/legacy-field-repair.ts
+++ b/src/lib/learning-units/legacy-field-repair.ts
@@ -1,0 +1,83 @@
+import { ZodError } from 'zod';
+import { normalizeLearningUnit } from './domain';
+
+export const LEGACY_LEARNING_UNIT_FIELDS = [
+  'published',
+  'introduction',
+  'introduction_backup',
+  'exercises',
+  'exercises_backup',
+] as const;
+
+export type LegacyLearningUnitField = (typeof LEGACY_LEARNING_UNIT_FIELDS)[number];
+
+export type LegacyLearningUnitRepairPlan = {
+  status: 'clean' | 'repair-required';
+  repairedData: Record<string, unknown>;
+  removedFields: LegacyLearningUnitField[];
+};
+
+export class LegacyLearningUnitRepairError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'LegacyLearningUnitRepairError';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function containsOnlyExpectedLegacyIssues(error: unknown): error is ZodError {
+  if (!(error instanceof ZodError) || error.issues.length === 0) return false;
+  const allowedFields = new Set<string>(LEGACY_LEARNING_UNIT_FIELDS);
+  return error.issues.every(
+    issue =>
+      issue.code === 'unrecognized_keys' &&
+      issue.path.length === 0 &&
+      issue.keys.length > 0 &&
+      issue.keys.every(key => allowedFields.has(key))
+  );
+}
+
+/**
+ * Produces the only repair this incident allows: deleting known legacy
+ * top-level fields from an otherwise valid learning-unit document.
+ */
+export function planLegacyLearningUnitFieldRepair(value: unknown, snapshotId: string): LegacyLearningUnitRepairPlan {
+  if (!isRecord(value)) {
+    throw new LegacyLearningUnitRepairError(`Learning unit ${snapshotId} is not a Firestore document object`);
+  }
+
+  try {
+    normalizeLearningUnit(value, snapshotId);
+    return { status: 'clean', repairedData: { ...value }, removedFields: [] };
+  } catch (error) {
+    if (!containsOnlyExpectedLegacyIssues(error)) {
+      throw new LegacyLearningUnitRepairError(
+        `Learning unit ${snapshotId} has validation failures outside the approved legacy-field repair`,
+        { cause: error }
+      );
+    }
+  }
+
+  const repairedData = { ...value };
+  const removedFields = LEGACY_LEARNING_UNIT_FIELDS.filter(field =>
+    Object.prototype.hasOwnProperty.call(repairedData, field)
+  );
+  if (removedFields.length === 0) {
+    throw new LegacyLearningUnitRepairError(`Learning unit ${snapshotId} has no approved legacy fields to remove`);
+  }
+  for (const field of removedFields) delete repairedData[field];
+
+  try {
+    normalizeLearningUnit(repairedData, snapshotId);
+  } catch (error) {
+    throw new LegacyLearningUnitRepairError(
+      `Learning unit ${snapshotId} would remain invalid after the approved legacy fields were removed`,
+      { cause: error }
+    );
+  }
+
+  return { status: 'repair-required', repairedData, removedFields };
+}

--- a/src/lib/learning-units/legacy-field-repair.ts
+++ b/src/lib/learning-units/legacy-field-repair.ts
@@ -9,6 +9,14 @@ export const LEGACY_LEARNING_UNIT_FIELDS = [
   'exercises_backup',
 ] as const;
 
+export const LEGACY_LEARNING_UNIT_REPAIR_PROJECT_ID = 'latin-app-prod';
+
+export const LEGACY_LEARNING_UNIT_REPAIR_TARGET_IDS = [
+  'lesson-1757796411836',
+  'lesson-1753896166956',
+  'lesson-1752695094203',
+] as const;
+
 export type LegacyLearningUnitField = (typeof LEGACY_LEARNING_UNIT_FIELDS)[number];
 
 export type LegacyLearningUnitRepairPlan = {

--- a/src/lib/learning-units/schemas.ts
+++ b/src/lib/learning-units/schemas.ts
@@ -73,6 +73,26 @@ export const pageSchema = z
   })
   .passthrough();
 
+/**
+ * Client-controlled lesson fields accepted by the authoring routes. Unknown
+ * top-level fields are deliberately stripped so response-only, audit, legacy,
+ * or otherwise untrusted data cannot be round-tripped into Firestore.
+ *
+ * Pages and content items remain passthrough schemas because their specialized
+ * renderers own additional nested authoring fields.
+ */
+export const lessonAuthoringInputSchema = z
+  .object({
+    id: firestoreDocumentIdSchema,
+    title: z.string().trim().min(1),
+    description: z.string().default(''),
+    type: z.enum(LESSON_UNIT_TYPES),
+    pages: z.array(pageSchema).default([]),
+    vocabulary_pool: firestoreDocumentIdSchema.nullable().optional(),
+    showWordSearch: z.boolean().optional(),
+  })
+  .strip();
+
 const rotationVersionReferenceSchema = z
   .object({
     versionId: firestoreDocumentIdSchema,
@@ -120,6 +140,8 @@ function refineLessonUnit(value: z.infer<typeof lessonUnitShapeSchema>, context:
     context.addIssue({ code: 'custom', message, path: ['pages'] });
   }
 }
+
+export const lessonUnitDocumentSchema = lessonUnitShapeSchema.superRefine(refineLessonUnit);
 
 const testUnitShapeSchema = learningUnitBaseSchema
   .extend({
@@ -196,3 +218,4 @@ export const saveLearningPathInputSchema = z
   .superRefine(addLearningPathSizeIssue);
 
 export type SaveLearningPathInput = z.infer<typeof saveLearningPathInputSchema>;
+export type LessonAuthoringInput = z.infer<typeof lessonAuthoringInputSchema>;

--- a/src/lib/verifyGcloudProjectAccess.ts
+++ b/src/lib/verifyGcloudProjectAccess.ts
@@ -1,0 +1,127 @@
+import type { NextRequest } from 'next/server';
+
+const TOKEN_INFO_URL = 'https://oauth2.googleapis.com/tokeninfo';
+const RESOURCE_MANAGER_BASE_URL = 'https://cloudresourcemanager.googleapis.com/v1/projects';
+
+export const LEGACY_REPAIR_REQUIRED_PERMISSIONS = [
+  'datastore.entities.get',
+  'datastore.entities.list',
+  'datastore.entities.update',
+] as const;
+
+export type GcloudProjectOperator = {
+  email: string;
+  authentication: 'gcloud-oauth-access-token';
+  permissions: string[];
+};
+
+export class GcloudProjectAccessError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 401 | 403 | 502
+  ) {
+    super(message);
+    this.name = 'GcloudProjectAccessError';
+  }
+}
+
+type FetchImplementation = typeof fetch;
+
+function bearerToken(request: Pick<NextRequest, 'headers'>): string {
+  const authorization = request.headers.get('authorization');
+  if (!authorization?.startsWith('Bearer ')) {
+    throw new GcloudProjectAccessError('A gcloud OAuth bearer token is required', 401);
+  }
+
+  const token = authorization.slice('Bearer '.length).trim();
+  if (!token) throw new GcloudProjectAccessError('A gcloud OAuth bearer token is required', 401);
+  return token;
+}
+
+async function readTokenIdentity(token: string, fetchImplementation: FetchImplementation) {
+  const response = await fetchImplementation(TOKEN_INFO_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ access_token: token }),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    const status = response.status === 400 || response.status === 401 ? 401 : 502;
+    throw new GcloudProjectAccessError(
+      status === 401 ? 'The gcloud OAuth token is invalid or expired' : 'Unable to verify the gcloud OAuth token',
+      status
+    );
+  }
+
+  const payload = (await response.json()) as { email?: unknown; expires_in?: unknown };
+  const email = typeof payload.email === 'string' ? payload.email.trim().toLowerCase() : '';
+  const expiresIn = Number(payload.expires_in);
+  if (!email || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new GcloudProjectAccessError('The gcloud OAuth token has no valid operator identity', 401);
+  }
+
+  return email;
+}
+
+async function readProjectPermissions(
+  token: string,
+  projectId: string,
+  permissions: readonly string[],
+  fetchImplementation: FetchImplementation
+) {
+  const response = await fetchImplementation(
+    `${RESOURCE_MANAGER_BASE_URL}/${encodeURIComponent(projectId)}:testIamPermissions`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ permissions }),
+      cache: 'no-store',
+    }
+  );
+
+  if (!response.ok) {
+    const status = response.status === 401 ? 401 : response.status === 403 ? 403 : 502;
+    throw new GcloudProjectAccessError("Unable to verify the operator's production IAM permissions", status);
+  }
+
+  const payload = (await response.json()) as { permissions?: unknown };
+  return Array.isArray(payload.permissions)
+    ? payload.permissions.filter((permission): permission is string => typeof permission === 'string')
+    : [];
+}
+
+/**
+ * Authorizes a one-off production operation with a short-lived token from
+ * `gcloud auth print-access-token`. The token must belong to an identity that
+ * already has the exact Firestore permissions needed by the operation.
+ */
+export async function verifyGcloudProjectAccess(
+  request: Pick<NextRequest, 'headers'>,
+  projectId: string,
+  permissions: readonly string[] = LEGACY_REPAIR_REQUIRED_PERMISSIONS,
+  fetchImplementation: FetchImplementation = fetch
+): Promise<GcloudProjectOperator> {
+  const token = bearerToken(request);
+  const [email, grantedPermissions] = await Promise.all([
+    readTokenIdentity(token, fetchImplementation),
+    readProjectPermissions(token, projectId, permissions, fetchImplementation),
+  ]);
+  const missingPermissions = permissions.filter(permission => !grantedPermissions.includes(permission));
+
+  if (missingPermissions.length > 0) {
+    throw new GcloudProjectAccessError(
+      `The gcloud identity lacks required production permissions: ${missingPermissions.join(', ')}`,
+      403
+    );
+  }
+
+  return {
+    email,
+    authentication: 'gcloud-oauth-access-token',
+    permissions: [...grantedPermissions].sort(),
+  };
+}

--- a/tests/legacyLearningUnitFieldRepair.test.ts
+++ b/tests/legacyLearningUnitFieldRepair.test.ts
@@ -1,0 +1,59 @@
+import {
+  LEGACY_LEARNING_UNIT_FIELDS,
+  LegacyLearningUnitRepairError,
+  planLegacyLearningUnitFieldRepair,
+} from '@/src/lib/learning-units/legacy-field-repair';
+
+const canonicalLesson = (overrides: Record<string, unknown> = {}) => ({
+  id: 'lesson-1',
+  kind: 'lesson',
+  title: 'Lesson',
+  description: '',
+  type: 'normal',
+  pages: [{ id: 'page-1', items: [] }],
+  isLive: false,
+  liveOrder: null,
+  publishedAt: null,
+  publishedBy: null,
+  ...overrides,
+});
+
+describe('legacy learning-unit field repair', () => {
+  it('plans deletion of only the approved legacy fields without mutating lesson content', () => {
+    const original = canonicalLesson({
+      published: true,
+      introduction: [{ id: 'old-introduction' }],
+      introduction_backup: [{ id: 'old-introduction-backup' }],
+      exercises: [{ id: 'old-exercise' }],
+      exercises_backup: [{ id: 'old-exercise-backup' }],
+    });
+
+    const plan = planLegacyLearningUnitFieldRepair(original, 'lesson-1');
+
+    expect(plan.status).toBe('repair-required');
+    expect(plan.removedFields).toEqual(LEGACY_LEARNING_UNIT_FIELDS);
+    expect(plan.repairedData).toEqual(canonicalLesson());
+    expect(original).toHaveProperty('published', true);
+    expect(original.pages).toEqual([{ id: 'page-1', items: [] }]);
+  });
+
+  it('is a no-op for a document that already passes canonical normalization', () => {
+    const original = canonicalLesson();
+    const plan = planLegacyLearningUnitFieldRepair(original, 'lesson-1');
+
+    expect(plan).toEqual({ status: 'clean', repairedData: original, removedFields: [] });
+    expect(plan.repairedData).not.toBe(original);
+  });
+
+  it('refuses to repair unapproved unknown fields', () => {
+    expect(() => planLegacyLearningUnitFieldRepair(canonicalLesson({ unknownLegacyField: true }), 'lesson-1')).toThrow(
+      LegacyLearningUnitRepairError
+    );
+  });
+
+  it('refuses to hide canonical validation failures behind legacy-field deletion', () => {
+    expect(() =>
+      planLegacyLearningUnitFieldRepair(canonicalLesson({ title: '', published: true, introduction: [] }), 'lesson-1')
+    ).toThrow(LegacyLearningUnitRepairError);
+  });
+});

--- a/tests/legacyLearningUnitFieldRepairRoute.test.ts
+++ b/tests/legacyLearningUnitFieldRepairRoute.test.ts
@@ -1,0 +1,99 @@
+import { POST } from '@/src/app/api/admin/lessons/repair-legacy-fields/route';
+import { LegacyLearningUnitRepairOperationError } from '@/src/lib/learning-units/legacy-field-repair-operation';
+
+const verifyGcloudProjectAccess = jest.fn();
+const runLegacyLearningUnitRepairOperation = jest.fn();
+
+jest.mock('next/server', () => jest.requireActual('./helpers/routeMocks'));
+jest.mock('@/src/services/firebase-admin', () => ({ adminDb: { name: 'db' }, adminStorage: { name: 'storage' } }));
+jest.mock('@/src/lib/verifyGcloudProjectAccess', () => ({
+  ...jest.requireActual('@/src/lib/verifyGcloudProjectAccess'),
+  verifyGcloudProjectAccess: (...args: unknown[]) => verifyGcloudProjectAccess(...args),
+}));
+jest.mock('@/src/lib/learning-units/legacy-field-repair-operation', () => ({
+  LegacyLearningUnitRepairOperationError: class LegacyLearningUnitRepairOperationError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number
+    ) {
+      super(message);
+      this.name = 'LegacyLearningUnitRepairOperationError';
+    }
+  },
+  runLegacyLearningUnitRepairOperation: (...args: unknown[]) => runLegacyLearningUnitRepairOperation(...args),
+}));
+
+function request(body: unknown) {
+  return {
+    headers: new Headers({ Authorization: 'Bearer gcloud-token' }),
+    json: async () => body,
+  } as never;
+}
+
+describe('legacy learning-unit field repair route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'latin-app-prod';
+    verifyGcloudProjectAccess.mockResolvedValue({
+      email: 'operator@example.com',
+      authentication: 'gcloud-oauth-access-token',
+      permissions: ['datastore.entities.get', 'datastore.entities.list', 'datastore.entities.update'],
+    });
+    runLegacyLearningUnitRepairOperation.mockResolvedValue({ mode: 'dry-run', planHash: 'a'.repeat(64) });
+  });
+
+  it('runs an authenticated, read-only dry run', async () => {
+    const response = (await POST(request({ mode: 'dry-run' }))) as unknown as {
+      status: number;
+      body: Record<string, unknown>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ mode: 'dry-run', planHash: 'a'.repeat(64) });
+    expect(verifyGcloudProjectAccess).toHaveBeenCalledWith(expect.anything(), 'latin-app-prod');
+    expect(runLegacyLearningUnitRepairOperation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'latin-app-prod',
+        request: { mode: 'dry-run' },
+        operator: expect.objectContaining({ email: 'operator@example.com' }),
+      })
+    );
+  });
+
+  it('requires both the reviewed plan hash and exact apply confirmation', async () => {
+    const response = (await POST(
+      request({ mode: 'apply', planHash: 'a'.repeat(64), confirmation: 'yes' })
+    )) as unknown as { status: number; body: { error: string } };
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Invalid migration request');
+    expect(runLegacyLearningUnitRepairOperation).not.toHaveBeenCalled();
+  });
+
+  it('returns a conflict when post-migration verification still finds legacy fields', async () => {
+    runLegacyLearningUnitRepairOperation.mockRejectedValue(
+      new LegacyLearningUnitRepairOperationError('Verification failed', 409)
+    );
+
+    const response = (await POST(request({ mode: 'verify' }))) as unknown as {
+      status: number;
+      body: { error: string };
+    };
+
+    expect(response.status).toBe(409);
+    expect(response.body).toEqual({ error: 'Verification failed' });
+  });
+
+  it('refuses to initialize against a non-production Firebase project', async () => {
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'wellduel-dev';
+
+    const response = (await POST(request({ mode: 'dry-run' }))) as unknown as {
+      status: number;
+      body: { error: string };
+    };
+
+    expect(response.status).toBe(503);
+    expect(response.body.error).toContain('latin-app-prod');
+    expect(verifyGcloudProjectAccess).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lessonWordSearchConfigurationRoute.test.ts
+++ b/tests/lessonWordSearchConfigurationRoute.test.ts
@@ -121,4 +121,51 @@ describe('lesson word-search configuration routes', () => {
     expect(response.body.error).toBe('showWordSearch must be a boolean');
     expect(mockCreate).not.toHaveBeenCalled();
   });
+
+  it('cleans retired top-level fields on update while preserving nested authored content', async () => {
+    existingLessonData = {
+      kind: 'lesson',
+      isLive: false,
+      createdAt: '2026-01-01',
+      createdBy: 'admin-1',
+      version: 1,
+    };
+    await PUT({
+      json: async () =>
+        lessonInput({
+          pages: [
+            {
+              id: 'page-1',
+              items: [{ id: 'item-1', type: 'text', content: 'Keep me', rendererOwnedField: true }],
+              rendererOwnedPageField: true,
+            },
+          ],
+          published: true,
+          introduction: [{ legacy: true }],
+          introduction_backup: [{ legacy: true }],
+          exercises: [{ legacy: true }],
+          exercises_backup: [{ legacy: true }],
+          arbitraryClientField: 'must not persist',
+        }),
+    } as never);
+
+    const persistedLesson = mockSet.mock.calls[0][1] as Record<string, unknown>;
+    for (const field of [
+      'published',
+      'introduction',
+      'introduction_backup',
+      'exercises',
+      'exercises_backup',
+      'arbitraryClientField',
+    ]) {
+      expect(persistedLesson).not.toHaveProperty(field);
+    }
+    expect(persistedLesson.pages).toEqual([
+      expect.objectContaining({
+        id: 'page-1',
+        rendererOwnedPageField: true,
+        items: [expect.objectContaining({ id: 'item-1', content: 'Keep me', rendererOwnedField: true })],
+      }),
+    ]);
+  });
 });

--- a/tests/practiceCategoryLessonAtomicity.test.ts
+++ b/tests/practiceCategoryLessonAtomicity.test.ts
@@ -107,4 +107,29 @@ describe('atomic lesson and practice-category writes', () => {
     expect(persistedLesson).not.toHaveProperty('practiceCategories');
     expect(response.body.lesson.practiceCategorySelections).toEqual([{ categoryId: 'authors', tagIds: ['cicero'] }]);
   });
+
+  it('does not persist unknown or retired top-level lesson fields', async () => {
+    await POST({
+      json: async () => ({
+        id: 'lesson-1',
+        title: 'Vocabulary lesson',
+        type: 'vocab',
+        pages: [],
+        published: true,
+        introduction: [{ legacy: true }],
+        introduction_backup: [{ legacy: true }],
+        exercises: [{ legacy: true }],
+        exercises_backup: [{ legacy: true }],
+        arbitraryClientField: 'must not persist',
+      }),
+    } as never);
+
+    const persistedLesson = mockCreate.mock.calls[0][1] as Record<string, unknown>;
+    expect(persistedLesson).not.toHaveProperty('published');
+    expect(persistedLesson).not.toHaveProperty('introduction');
+    expect(persistedLesson).not.toHaveProperty('introduction_backup');
+    expect(persistedLesson).not.toHaveProperty('exercises');
+    expect(persistedLesson).not.toHaveProperty('exercises_backup');
+    expect(persistedLesson).not.toHaveProperty('arbitraryClientField');
+  });
 });

--- a/tests/practiceCategoryRecoveryRoute.test.ts
+++ b/tests/practiceCategoryRecoveryRoute.test.ts
@@ -129,6 +129,35 @@ describe('practice category recovery retry', () => {
     expect(response.body.lesson.practiceCategorySelections).toEqual([{ categoryId: 'category-1', tagIds: [] }]);
   });
 
+  it('strips retired and arbitrary top-level fields when retrying recovery', async () => {
+    mockRecoveryLessonData = {
+      ...mockRecoveryLessonData,
+      published: true,
+      introduction: [{ legacy: true }],
+      introduction_backup: [{ legacy: true }],
+      exercises: [{ legacy: true }],
+      exercises_backup: [{ legacy: true }],
+      arbitraryClientField: 'must not persist',
+    };
+
+    const response = (await POST({} as never, {
+      params: Promise.resolve({ id: 'recovery-1' }),
+    })) as unknown as { status: number };
+
+    expect(response.status).toBe(200);
+    const persistedLesson = mockTransactionSet.mock.calls[0][1] as Record<string, unknown>;
+    for (const field of [
+      'published',
+      'introduction',
+      'introduction_backup',
+      'exercises',
+      'exercises_backup',
+      'arbitraryClientField',
+    ]) {
+      expect(persistedLesson).not.toHaveProperty(field);
+    }
+  });
+
   it('rejects replaying an item that has already left pending state', async () => {
     mockRecoveryStatus = 'recovered';
 

--- a/tests/snapshotRestoreLearningPathGuard.test.ts
+++ b/tests/snapshotRestoreLearningPathGuard.test.ts
@@ -193,4 +193,50 @@ describe('snapshot restore Learning Path guard', () => {
     expect(response.status).toBe(200);
     expect(mockSet).toHaveBeenCalledTimes(1);
   });
+
+  it('strips retired and arbitrary fields from restored snapshot documents', async () => {
+    mockExistingLessonExists = false;
+    mockExistingLesson = {};
+    mockLearningPath = { ...mockLearningPath, unitIds: [] };
+    mockSnapshotLessons = [
+      {
+        id: 'vocab-1',
+        title: 'Vocabulary',
+        description: '',
+        type: 'vocab',
+        pages: [{ id: 'page-1', items: [] }],
+        isLive: false,
+        liveOrder: null,
+        publishedAt: null,
+        publishedBy: null,
+        published: true,
+        introduction: [],
+        introduction_backup: [],
+        exercises: [],
+        exercises_backup: [],
+        arbitrarySnapshotField: true,
+      },
+    ];
+    mockReconcile.mockResolvedValue({ practiceCategoryIds: [], practiceCategories: [] });
+
+    const response = (await POST({
+      json: async () => ({
+        snapshotPath: 'lesson-snapshots/snapshot-1.json',
+        confirmRestore: true,
+      }),
+    } as never)) as unknown as { status: number };
+
+    expect(response.status).toBe(200);
+    const persistedLesson = mockSet.mock.calls[0][1] as Record<string, unknown>;
+    for (const field of [
+      'published',
+      'introduction',
+      'introduction_backup',
+      'exercises',
+      'exercises_backup',
+      'arbitrarySnapshotField',
+    ]) {
+      expect(persistedLesson).not.toHaveProperty(field);
+    }
+  });
 });

--- a/tests/verifyGcloudProjectAccess.test.ts
+++ b/tests/verifyGcloudProjectAccess.test.ts
@@ -1,0 +1,75 @@
+import { LEGACY_REPAIR_REQUIRED_PERMISSIONS, verifyGcloudProjectAccess } from '@/src/lib/verifyGcloudProjectAccess';
+
+function request(token?: string) {
+  return {
+    headers: new Headers(token ? { Authorization: `Bearer ${token}` } : {}),
+  } as never;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('gcloud project access verification', () => {
+  it('accepts a live token only when the identity has every required production permission', async () => {
+    const fetchImplementation = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ email: 'ADMIN@example.com', expires_in: '3000' }))
+      .mockResolvedValueOnce(jsonResponse({ permissions: [...LEGACY_REPAIR_REQUIRED_PERMISSIONS] }));
+
+    await expect(
+      verifyGcloudProjectAccess(
+        request('short-lived-token'),
+        'latin-app-prod',
+        LEGACY_REPAIR_REQUIRED_PERMISSIONS,
+        fetchImplementation
+      )
+    ).resolves.toEqual({
+      email: 'admin@example.com',
+      authentication: 'gcloud-oauth-access-token',
+      permissions: [...LEGACY_REPAIR_REQUIRED_PERMISSIONS].sort(),
+    });
+
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      2,
+      'https://cloudresourcemanager.googleapis.com/v1/projects/latin-app-prod:testIamPermissions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer short-lived-token' }),
+      })
+    );
+  });
+
+  it('rejects requests without a bearer token before making any network request', async () => {
+    const fetchImplementation = jest.fn();
+
+    await expect(
+      verifyGcloudProjectAccess(request(), 'latin-app-prod', LEGACY_REPAIR_REQUIRED_PERMISSIONS, fetchImplementation)
+    ).rejects.toMatchObject({ status: 401 });
+    expect(fetchImplementation).not.toHaveBeenCalled();
+  });
+
+  it('rejects a valid identity that lacks production update permission', async () => {
+    const fetchImplementation = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ email: 'reader@example.com', expires_in: '3000' }))
+      .mockResolvedValueOnce(jsonResponse({ permissions: ['datastore.entities.get', 'datastore.entities.list'] }));
+
+    await expect(
+      verifyGcloudProjectAccess(
+        request('read-only-token'),
+        'latin-app-prod',
+        LEGACY_REPAIR_REQUIRED_PERMISSIONS,
+        fetchImplementation
+      )
+    ).rejects.toEqual(
+      expect.objectContaining({
+        status: 403,
+        message: expect.stringContaining('datastore.entities.update'),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- enforce a canonical top-level persistence boundary for lesson creation, editing, recovery retry, and snapshot restore
- preserve renderer-owned nested page/item fields while dropping retired or arbitrary top-level fields
- add a guarded, dry-run-first production repair command for the three known malformed lesson documents
- add regression coverage for authoring, recovery, snapshot restore, and repair planning

## Root cause

Three production lesson documents retained fields from the pre-`pages` lesson format. The Learning Path cutover admitted two of those documents without full schema validation, and whole-object lesson writes continued round-tripping the obsolete fields. Learning Path saves now validate all selected units, so the first stale lesson blocked the transaction.

## Production safety

- no lesson document is deleted; the repair can only remove `published`, `introduction`, `introduction_backup`, `exercises`, and `exercises_backup`
- the command refuses any project other than an explicit `latin-app-prod`
- dry-run is the default; writes require `--apply`
- apply mode writes local before-images and uses a Firestore transaction that aborts if any target changed
- the repair has only been run in dry-run mode; production timestamps and Learning Path revision remain unchanged
- projected production verification is 93/93 valid learning-unit documents and 59/59 valid active-path units

## Validation

- `npm run lint`
- `npm test -- --runInBand` — 81 suites, 502 tests passed
- `npm run build`
- `npx tsc --noEmit`
- read-only production repair dry-run against `latin-app-prod`

`npm run build:prod` could not be started locally because the ignored `.env.production` file is not present; the standard optimized Next.js build completed successfully.
