### PR TITLE
feat: restore vocabulary pool usage warnings

### DIFF
--- a/src/app/admin/(shell)/vocabulary-pools/page.tsx
+++ b/src/app/admin/(shell)/vocabulary-pools/page.tsx
@@ -7,12 +7,18 @@ import { Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import Link from 'next/link';
 import { withAdminAuth } from '@/src/components/auth/withAdminAuth';
-import { useGetPoolsQuery, useDeletePoolMutation } from '@/src/store/api/vocabularyPoolApi';
+import {
+  useGetPoolsQuery,
+  useDeletePoolMutation,
+  useGetVocabularyPoolUsagesQuery,
+} from '@/src/store/api/vocabularyPoolApi';
+import { getApiErrorMessage } from '@/src/store/api/baseQuery';
 import { useAppSelector, useAppDispatch } from '@/src/store/hooks';
 import { updateFilters } from '@/src/store/slices/vocabularyPoolSlice';
 import { PoolFilters } from '@/src/components/ui/admin/vocabulary-pools/PoolFilters';
 import { PoolList } from '@/src/components/ui/admin/vocabulary-pools/PoolList';
 import { AdminPage, AdminPageHeader } from '@/src/components/admin/shell';
+import { buildVocabularyPoolDeleteConfirmation } from '@/src/lib/vocabulary-pools/delete-confirmation';
 
 function VocabularyPoolsPage() {
   const router = useRouter();
@@ -20,24 +26,33 @@ function VocabularyPoolsPage() {
   const filters = useAppSelector(state => state.vocabularyPools.filters);
   const [lastPoolId, setLastPoolId] = useState<string | null>(null);
   const { data, isLoading, isFetching, error } = useGetPoolsQuery({ filters, lastPoolId });
+  const {
+    data: usageData,
+    error: usageError,
+    isLoading: usageLoading,
+  } = useGetVocabularyPoolUsagesQuery(undefined, { refetchOnMountOrArgChange: true });
   const [deletePoolMutation] = useDeletePoolMutation();
 
   const pools = data?.pools ?? [];
   const hasMore = data?.hasMore ?? false;
   const loadingMore = isFetching && lastPoolId !== null;
+  const usageStatus = usageData?.status ?? 'unavailable';
+  const usageUnavailable = Boolean(usageError) || (!usageLoading && usageStatus === 'unavailable');
+  const usageUnavailableMessage = `${usageData?.message ?? 'Assignment checks are unavailable.'} You can still delete a pool, but it may break lessons or exercises.`;
 
   useEffect(() => {
     setLastPoolId(null);
   }, [filters]);
 
   const handleDeletePool = async (poolId: string, poolName: string) => {
-    if (confirm(`Are you sure you want to delete "${poolName}"? This action cannot be undone.`)) {
-      try {
-        await deletePoolMutation(poolId).unwrap();
-        toast.success('Pool deleted successfully');
-      } catch {
-        toast.error('Failed to delete pool');
-      }
+    const usages = usageStatus === 'available' ? (usageData?.usagesByPoolId[poolId] ?? []) : [];
+    if (!window.confirm(buildVocabularyPoolDeleteConfirmation(poolName, usages, usageStatus))) return;
+
+    try {
+      await deletePoolMutation(poolId).unwrap();
+      toast.success('Pool deleted successfully');
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, 'Failed to delete pool'));
     }
   };
 
@@ -70,6 +85,12 @@ function VocabularyPoolsPage() {
           </div>
         )}
 
+        {usageUnavailable && (
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4" role="alert">
+            <p className="text-amber-800">{usageUnavailableMessage}</p>
+          </div>
+        )}
+
         <PoolList
           pools={pools}
           loading={isLoading}
@@ -80,6 +101,7 @@ function VocabularyPoolsPage() {
           }}
           onEdit={pool => router.push(`/admin/vocabulary-pools/${pool.id}/edit`)}
           onDelete={handleDeletePool}
+          usagesByPoolId={usageData?.usagesByPoolId ?? {}}
         />
       </div>
     </AdminPage>

--- a/src/app/api/admin/vocabulary-pools/[poolId]/route.ts
+++ b/src/app/api/admin/vocabulary-pools/[poolId]/route.ts
@@ -4,7 +4,6 @@ import { FieldPath } from 'firebase-admin/firestore';
 import type { Word } from '@/src/types/admin-vocabulary';
 import { VOCABULARY_WORDS_COLLECTION } from '@/shared/constants/firestore';
 import { buildPoolSearchTokens } from '@/src/utils/vocabularyPoolSummary';
-import { isLessonDocumentData } from '@/src/lib/learning-units/domain';
 
 export const dynamic = 'force-dynamic';
 
@@ -213,21 +212,6 @@ export async function DELETE(
 ): Promise<NextResponse> {
   try {
     const { poolId } = await params;
-
-    const lessonsQuery = await adminDb.collection('lessons').where('vocabulary_pool', '==', poolId).get();
-    const lessonUsingPool = lessonsQuery.docs.find(doc => isLessonDocumentData(doc.data()));
-
-    if (lessonUsingPool) {
-      const lessonData = lessonUsingPool.data();
-      return NextResponse.json(
-        {
-          success: false,
-          error: `Cannot delete pool that is assigned to lessons. Found in lesson: ${lessonData.title}`,
-        },
-        { status: 400 }
-      );
-    }
-
     await adminDb.runTransaction(async transaction => {
       const poolRef = adminDb.collection('vocabulary_pools').doc(poolId);
       const poolDoc = await transaction.get(poolRef);

--- a/src/app/api/admin/vocabulary-pools/usages/route.ts
+++ b/src/app/api/admin/vocabulary-pools/usages/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { adminDb } from '@/src/services/firebase-admin';
+import { AdminAccessError, verifyAdminAccess } from '@/src/lib/verifyAdminAccess';
+import { scanVocabularyPoolUsages } from '@/src/lib/vocabulary-pools/usage.server';
+import type { VocabularyPoolUsage } from '@/src/types/vocabulary-pool';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    await verifyAdminAccess(request);
+    const result = await scanVocabularyPoolUsages(adminDb);
+    if (result.status === 'unavailable') {
+      return NextResponse.json({
+        success: true,
+        data: { status: 'unavailable', usagesByPoolId: {}, message: result.message },
+      });
+    }
+
+    const usagesByPoolId = result.usages.reduce<Record<string, VocabularyPoolUsage[]>>((byPoolId, usage) => {
+      (byPoolId[usage.poolId] ??= []).push(usage);
+      return byPoolId;
+    }, {});
+    return NextResponse.json({ success: true, data: { status: 'available', usagesByPoolId } });
+  } catch (error) {
+    console.error('Error fetching vocabulary pool usages:', error);
+    const status = error instanceof AdminAccessError ? error.status : 500;
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Failed to fetch vocabulary pool usages' },
+      { status }
+    );
+  }
+}

--- a/src/components/ui/admin/vocabulary-pools/PoolList.tsx
+++ b/src/components/ui/admin/vocabulary-pools/PoolList.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/src/components/ui/button';
 import { Badge } from '@/src/components/ui/badge';
 import { RomanCard, RomanCardContent } from '@/src/components/ui/core/roman-card';
 import { Edit, Trash2, Library, Calendar, Hash, Loader2 } from 'lucide-react';
 import { useInfiniteScroll } from '@/src/hooks/useInfiniteScroll';
-import type { VocabularyPoolSummary } from '@/src/types/vocabulary-pool';
+import type { VocabularyPoolSummary, VocabularyPoolUsage } from '@/src/types/vocabulary-pool';
 
 interface PoolListProps {
   pools: VocabularyPoolSummary[];
@@ -14,6 +14,7 @@ interface PoolListProps {
   onLoadMore: () => void;
   onEdit: (pool: VocabularyPoolSummary) => void;
   onDelete: (poolId: string, poolName: string) => void;
+  usagesByPoolId: Record<string, VocabularyPoolUsage[]>;
 }
 
 export const PoolList: React.FC<PoolListProps> = ({
@@ -24,7 +25,9 @@ export const PoolList: React.FC<PoolListProps> = ({
   onLoadMore,
   onEdit,
   onDelete,
+  usagesByPoolId,
 }) => {
+  const [expandedPoolIds, setExpandedPoolIds] = useState<Set<string>>(() => new Set());
   const sentinelRef = useInfiniteScroll({
     onLoadMore,
     hasMore,
@@ -55,62 +58,109 @@ export const PoolList: React.FC<PoolListProps> = ({
 
   return (
     <div className="space-y-4">
-      {pools.map(pool => (
-        <RomanCard key={pool.id} className="hover:shadow-lg transition-shadow">
-          <RomanCardContent className="p-6">
-            <div className="flex items-start justify-between">
-              <div className="flex-1">
-                <div className="flex items-center gap-3 mb-2">
-                  <h3 className="text-lg font-serif text-gray-900">{pool.name}</h3>
-                  <Badge variant={pool.metadata.isActive ? 'default' : 'secondary'} className="text-xs">
-                    {pool.metadata.isActive ? 'Active' : 'Inactive'}
-                  </Badge>
-                  <Badge variant="outline" className="text-xs">
-                    {pool.metadata.difficulty}
-                  </Badge>
-                </div>
-
-                <p className="text-gray-600 mb-3 line-clamp-2">{pool.description}</p>
-
-                <div className="flex items-center gap-6 text-sm text-gray-500">
-                  <div className="flex items-center gap-1">
-                    <Hash className="h-4 w-4" />
-                    <span>{pool.metadata.wordCount} words</span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <Calendar className="h-4 w-4" />
-                    <span>Created {new Date(pool.metadata.createdAt).toLocaleDateString()}</span>
-                  </div>
-                </div>
-
-                {pool.metadata.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-2 mt-3">
-                    {pool.metadata.tags.map(tag => (
-                      <Badge key={tag} variant="outline" className="text-xs">
-                        {tag}
+      {pools.map(pool => {
+        const usages = usagesByPoolId[pool.id] ?? [];
+        const assigned = usages.length > 0;
+        const expanded = expandedPoolIds.has(pool.id);
+        const visibleUsages = expanded ? usages : usages.slice(0, 2);
+        return (
+          <RomanCard key={pool.id} className="hover:shadow-lg transition-shadow">
+            <RomanCardContent className="p-6">
+              <div className="flex items-start justify-between">
+                <div className="flex-1">
+                  <div className="flex items-center gap-3 mb-2">
+                    <h3 className="text-lg font-serif text-gray-900">{pool.name}</h3>
+                    <Badge variant={pool.metadata.isActive ? 'default' : 'secondary'} className="text-xs">
+                      {pool.metadata.isActive ? 'Active' : 'Inactive'}
+                    </Badge>
+                    <Badge variant="outline" className="text-xs">
+                      {pool.metadata.difficulty}
+                    </Badge>
+                    {assigned && (
+                      <Badge variant="secondary" className="text-xs">
+                        Assigned ({usages.length})
                       </Badge>
-                    ))}
+                    )}
                   </div>
-                )}
-              </div>
 
-              <div className="flex items-center gap-2 ml-4">
-                <Button variant="outline" size="sm" onClick={() => onEdit(pool)}>
-                  <Edit className="h-4 w-4 mr-1" />
-                  Edit
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => onDelete(pool.id, pool.name)}
-                  className="text-red-600 border-red-200 hover:bg-red-50">
-                  <Trash2 className="h-4 w-4" />
-                </Button>
+                  <p className="text-gray-600 mb-3 line-clamp-2">{pool.description}</p>
+
+                  <div className="flex items-center gap-6 text-sm text-gray-500">
+                    <div className="flex items-center gap-1">
+                      <Hash className="h-4 w-4" />
+                      <span>{pool.metadata.wordCount} words</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Calendar className="h-4 w-4" />
+                      <span>Created {new Date(pool.metadata.createdAt).toLocaleDateString()}</span>
+                    </div>
+                  </div>
+
+                  {pool.metadata.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mt-3">
+                      {pool.metadata.tags.map(tag => (
+                        <Badge key={tag} variant="outline" className="text-xs">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+
+                  {assigned && (
+                    <div className="mt-3 text-sm text-gray-600" id={`pool-assignment-${pool.id}`}>
+                      <p className="font-medium text-gray-700">Assigned to</p>
+                      <ul className="mt-1 space-y-1">
+                        {visibleUsages.map(usage => (
+                          <li key={usage.id}>
+                            {usage.editorUrl ? (
+                              <a href={usage.editorUrl} className="text-roman-red hover:underline">
+                                {usage.label}
+                              </a>
+                            ) : (
+                              usage.label
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                      {usages.length > 2 && (
+                        <Button
+                          variant="link"
+                          size="sm"
+                          className="mt-1 h-auto px-0 text-roman-red"
+                          onClick={() =>
+                            setExpandedPoolIds(current => {
+                              const next = new Set(current);
+                              if (next.has(pool.id)) next.delete(pool.id);
+                              else next.add(pool.id);
+                              return next;
+                            })
+                          }>
+                          {expanded ? 'Show less' : `+${usages.length - 2} more`}
+                        </Button>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2 ml-4">
+                  <Button variant="outline" size="sm" onClick={() => onEdit(pool)}>
+                    <Edit className="h-4 w-4 mr-1" />
+                    Edit
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onDelete(pool.id, pool.name)}
+                    title="Delete pool"
+                    className="text-red-600 border-red-200 hover:bg-red-50">
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
-            </div>
-          </RomanCardContent>
-        </RomanCard>
-      ))}
+            </RomanCardContent>
+          </RomanCard>
+        );
+      })}
 
       {(hasMore || loadingMore) && (
         <div ref={sentinelRef} className="flex justify-center py-6">

--- a/src/lib/vocabulary-pools/delete-confirmation.ts
+++ b/src/lib/vocabulary-pools/delete-confirmation.ts
@@ -1,0 +1,32 @@
+import type { VocabularyPoolUsage } from '@/src/types/vocabulary-pool';
+
+const USAGE_LIMIT = 3;
+const LABEL_LIMIT = 120;
+
+function shortenLabel(label: string): string {
+  return label.length > LABEL_LIMIT ? `${label.slice(0, LABEL_LIMIT - 1)}…` : label;
+}
+
+export function buildVocabularyPoolDeleteConfirmation(
+  poolName: string,
+  usages: VocabularyPoolUsage[],
+  usageStatus: 'available' | 'unavailable'
+): string {
+  const opening = `Are you sure you want to delete "${poolName}"?`;
+
+  if (usageStatus !== 'available') {
+    return `${opening}\n\nAssignments could not be checked. Deleting this pool may break lessons or exercises that use it.\n\nThis action cannot be undone.`;
+  }
+
+  if (usages.length === 0) return `${opening} This action cannot be undone.`;
+
+  const usageNames = usages
+    .slice(0, USAGE_LIMIT)
+    .map(usage => `• ${shortenLabel(usage.label)}`)
+    .join('\n');
+  const remaining = usages.length - USAGE_LIMIT;
+  const overflow = remaining > 0 ? `\n• +${remaining} more` : '';
+  const assignment = usages.length === 1 ? 'assignment' : 'assignments';
+
+  return `${opening}\n\nThis pool is assigned to ${usages.length} saved ${assignment}:\n${usageNames}${overflow}\n\nDeleting it may break that saved content. This action cannot be undone.`;
+}

--- a/src/lib/vocabulary-pools/usage.server.ts
+++ b/src/lib/vocabulary-pools/usage.server.ts
@@ -1,0 +1,358 @@
+import type { Firestore } from 'firebase-admin/firestore';
+import {
+  LEARNING_UNITS_COLLECTION,
+  MOCK_TESTS_COLLECTION,
+  TEST_VERSION_DRAFTS_COLLECTION,
+  TEST_VERSIONS_COLLECTION,
+} from '@/shared/constants/firestore';
+import { isLessonDocumentData } from '@/src/lib/learning-units/domain';
+import type { VocabularyPoolUsage, VocabularyPoolUsageKind } from '@/src/types/vocabulary-pool';
+
+const MAX_AUTHORING_DOCUMENTS = 500;
+
+const SCAN_COLLECTIONS = [
+  {
+    name: LEARNING_UNITS_COLLECTION,
+    fields: ['title', 'kind', 'vocabulary_pool', 'pages', 'rotationVersions'],
+  },
+  {
+    name: TEST_VERSIONS_COLLECTION,
+    fields: ['name', 'vocabularyPoolId', 'pages'],
+  },
+  {
+    name: TEST_VERSION_DRAFTS_COLLECTION,
+    fields: ['name', 'testId', 'vocabularyPoolId', 'pages'],
+  },
+  {
+    name: MOCK_TESTS_COLLECTION,
+    fields: ['title', 'versionId', 'parent', 'status'],
+  },
+] as const;
+
+type RecordData = Record<string, unknown>;
+
+export type VocabularyPoolReference = {
+  poolId: string;
+  kind: 'direct' | 'exercise';
+  pageIndex?: number;
+  pageId?: string;
+  pageTitle?: string;
+  itemIndex?: number;
+  itemId?: string;
+  itemTitle?: string;
+};
+
+export type VocabularyPoolUsageScan =
+  | { status: 'available'; usages: VocabularyPoolUsage[]; documentCount: number }
+  | { status: 'unavailable'; message: string; documentCount?: number };
+
+function isRecord(value: unknown): value is RecordData {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function nonBlankString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function displayName(value: unknown, fallback: string): string {
+  return nonBlankString(value) ?? fallback;
+}
+
+/**
+ * Reads pool references from the actual saved authoring shape. This deliberately
+ * does not trust a derived index, so stale copies, recovery writes, and old docs
+ * remain visible in the management UI.
+ */
+export function extractVocabularyPoolReferences(value: unknown): VocabularyPoolReference[] {
+  if (!isRecord(value)) return [];
+
+  const references: VocabularyPoolReference[] = [];
+  const directPoolIds = new Set(
+    [nonBlankString(value.vocabulary_pool), nonBlankString(value.vocabularyPoolId)].filter((poolId): poolId is string =>
+      Boolean(poolId)
+    )
+  );
+  directPoolIds.forEach(poolId => references.push({ poolId, kind: 'direct' }));
+
+  if (!Array.isArray(value.pages)) return references;
+  value.pages.forEach((page, pageIndex) => {
+    if (!isRecord(page) || !Array.isArray(page.items)) return;
+    page.items.forEach((item, itemIndex) => {
+      if (!isRecord(item) || !isRecord(item.data) || !isRecord(item.data.generatorConfig)) return;
+      const generatorConfig = item.data.generatorConfig;
+      const poolId = nonBlankString(generatorConfig.poolId);
+      if (generatorConfig.wordSource !== 'pool' || !poolId) return;
+      references.push({
+        poolId,
+        kind: 'exercise',
+        pageIndex,
+        pageId: nonBlankString(page.id),
+        pageTitle: nonBlankString(page.title),
+        itemIndex,
+        itemId: nonBlankString(item.id),
+        itemTitle: nonBlankString(item.title),
+      });
+    });
+  });
+  return references;
+}
+
+function exerciseLabel(reference: VocabularyPoolReference): string {
+  const page = reference.pageTitle ?? (reference.pageIndex === undefined ? 'Page' : `Page ${reference.pageIndex + 1}`);
+  const exercise =
+    reference.itemTitle ?? (reference.itemIndex === undefined ? 'exercise' : `exercise ${reference.itemIndex + 1}`);
+  return `${page} → ${exercise}`;
+}
+
+function usage(
+  poolId: string,
+  kind: VocabularyPoolUsageKind,
+  sourceId: string,
+  reference: VocabularyPoolReference,
+  label: string,
+  editorUrl?: string
+): VocabularyPoolUsage {
+  const location =
+    reference.kind === 'direct'
+      ? 'direct'
+      : `${reference.pageId ?? reference.pageIndex}-${reference.itemId ?? reference.itemIndex}`;
+  return {
+    id: `${kind}:${sourceId}:${location}:${poolId}`,
+    poolId,
+    kind,
+    label,
+    ...(editorUrl ? { editorUrl } : {}),
+  };
+}
+
+type AuthoringDocument = { id: string; data: RecordData };
+
+type ActiveVersionOwner =
+  | { kind: 'mock'; title: string; editorUrl: string }
+  | { kind: 'test'; title: string; editorUrl: string }
+  | { kind: 'orphan'; title: string };
+
+function isTestDocument(document: AuthoringDocument): boolean {
+  return document.data.kind === 'test';
+}
+
+function rotationContains(document: AuthoringDocument, versionId: string): boolean {
+  const rotations = document.data.rotationVersions;
+  return (
+    Array.isArray(rotations) &&
+    rotations.some(reference => isRecord(reference) && nonBlankString(reference.versionId) === versionId)
+  );
+}
+
+function parentKind(document: AuthoringDocument): string | undefined {
+  return isRecord(document.data.parent) ? nonBlankString(document.data.parent.kind) : undefined;
+}
+
+function activeVersionOwner(
+  version: AuthoringDocument,
+  tests: AuthoringDocument[],
+  mocks: AuthoringDocument[]
+): ActiveVersionOwner {
+  const orderedMocks = [...mocks].sort((left, right) => left.id.localeCompare(right.id));
+  const activeMock = orderedMocks.find(
+    mock => nonBlankString(mock.data.versionId) === version.id && mock.data.status === 'active'
+  );
+  if (activeMock) {
+    return {
+      kind: 'mock',
+      title: displayName(activeMock.data.title, `Mock ${activeMock.id}`),
+      editorUrl: `/admin/mock-tests/${activeMock.id}`,
+    };
+  }
+
+  const rotationOwner = [...tests]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .find(test => rotationContains(test, version.id));
+  if (rotationOwner) {
+    return {
+      kind: 'test',
+      title: displayName(rotationOwner.data.title, `Test ${rotationOwner.id}`),
+      editorUrl: `/admin/tests/edit/${rotationOwner.id}/versions/${version.id}/edit`,
+    };
+  }
+
+  const archivedStandaloneMock = orderedMocks.find(
+    mock =>
+      nonBlankString(mock.data.versionId) === version.id &&
+      mock.data.status === 'archived' &&
+      parentKind(mock) === 'standalone'
+  );
+  if (archivedStandaloneMock) {
+    return {
+      kind: 'mock',
+      title: displayName(archivedStandaloneMock.data.title, `Mock ${archivedStandaloneMock.id}`),
+      editorUrl: `/admin/mock-tests/${archivedStandaloneMock.id}`,
+    };
+  }
+
+  return { kind: 'orphan', title: 'Orphaned version' };
+}
+
+function appendReferences(
+  usages: VocabularyPoolUsage[],
+  source: AuthoringDocument,
+  references: VocabularyPoolReference[],
+  directKind: VocabularyPoolUsageKind,
+  exerciseKind: VocabularyPoolUsageKind,
+  directLabel: string,
+  exerciseLabelPrefix: string,
+  editorUrl?: string
+) {
+  references.forEach(reference => {
+    usages.push(
+      usage(
+        reference.poolId,
+        reference.kind === 'direct' ? directKind : exerciseKind,
+        source.id,
+        reference,
+        reference.kind === 'direct' ? directLabel : `${exerciseLabelPrefix} → ${exerciseLabel(reference)}`,
+        editorUrl
+      )
+    );
+  });
+}
+
+/** Projects the canonical documents into display-safe, per-assignment usages. */
+export function projectVocabularyPoolUsages(input: {
+  learningUnits: AuthoringDocument[];
+  versions: AuthoringDocument[];
+  drafts: AuthoringDocument[];
+  mocks: AuthoringDocument[];
+}): VocabularyPoolUsage[] {
+  const usages: VocabularyPoolUsage[] = [];
+  const lessons = input.learningUnits.filter(document => isLessonDocumentData(document.data));
+  const tests = input.learningUnits.filter(isTestDocument);
+
+  lessons.forEach(lesson => {
+    const title = displayName(lesson.data.title, `Lesson ${lesson.id}`);
+    appendReferences(
+      usages,
+      lesson,
+      extractVocabularyPoolReferences(lesson.data),
+      'lesson',
+      'lesson-exercise',
+      `Lesson: ${title}`,
+      `Lesson: ${title}`,
+      `/admin/lessons/edit/${lesson.id}`
+    );
+  });
+
+  input.versions.forEach(version => {
+    const owner = activeVersionOwner(version, tests, input.mocks);
+    const versionName = displayName(version.data.name, `Version ${version.id}`);
+    const ownerLabel = owner.kind === 'test' ? `Test: ${owner.title}` : `Mock test: ${owner.title}`;
+    const prefix = owner.kind === 'orphan' ? `${owner.title}: ${versionName}` : `${ownerLabel} → ${versionName}`;
+    appendReferences(
+      usages,
+      version,
+      extractVocabularyPoolReferences(version.data),
+      'test-version',
+      'test-version-exercise',
+      prefix,
+      prefix,
+      owner.kind === 'orphan' ? undefined : owner.editorUrl
+    );
+  });
+
+  const testById = new Map(tests.map(test => [test.id, test]));
+  input.drafts.forEach(draft => {
+    const testId = nonBlankString(draft.data.testId);
+    const parent = testId ? testById.get(testId) : undefined;
+    const testLabel = parent ? displayName(parent.data.title, `Test ${parent.id}`) : 'Orphaned test';
+    const versionName = displayName(draft.data.name, `Draft ${draft.id}`);
+    const prefix = `Test draft: ${testLabel} → ${versionName}`;
+    appendReferences(
+      usages,
+      draft,
+      extractVocabularyPoolReferences(draft.data),
+      'test-version-draft',
+      'test-version-draft-exercise',
+      prefix,
+      prefix,
+      parent && testId ? `/admin/tests/edit/${testId}/versions/${draft.id}/edit` : undefined
+    );
+  });
+
+  return usages.sort((left, right) => left.label.localeCompare(right.label) || left.id.localeCompare(right.id));
+}
+
+function countFromSnapshot(snapshot: { data: () => { count?: unknown } }): number {
+  const count = snapshot.data().count;
+  if (!Number.isSafeInteger(count) || (count as number) < 0) throw new Error('Invalid authoring document count');
+  return count as number;
+}
+
+async function loadUsageDocuments(
+  db: Firestore
+): Promise<
+  { documents: AuthoringDocument[][]; documentCount: number } | { unavailable: string; documentCount?: number }
+> {
+  const queries = SCAN_COLLECTIONS.map(collection => db.collection(collection.name));
+  const countSnapshots = await Promise.all(queries.map(query => query.count().get()));
+  const documentCount = countSnapshots.reduce((total, snapshot) => total + countFromSnapshot(snapshot), 0);
+  if (documentCount > MAX_AUTHORING_DOCUMENTS) {
+    return {
+      unavailable: `Assignment checks are unavailable because there are more than ${MAX_AUTHORING_DOCUMENTS} authoring documents.`,
+      documentCount,
+    };
+  }
+  const snapshots = await Promise.all(
+    queries.map((query, index) => query.select(...SCAN_COLLECTIONS[index].fields).get())
+  );
+  const documents = snapshots.map(snapshot =>
+    snapshot.docs.map(document => ({ id: document.id, data: document.data() }))
+  );
+  const loadedDocumentCount = documents.reduce((total, collection) => total + collection.length, 0);
+  if (loadedDocumentCount > MAX_AUTHORING_DOCUMENTS) {
+    return {
+      unavailable: `Assignment checks are unavailable because more than ${MAX_AUTHORING_DOCUMENTS} authoring documents were loaded.`,
+      documentCount: loadedDocumentCount,
+    };
+  }
+  return {
+    documentCount: loadedDocumentCount,
+    documents,
+  };
+}
+
+function logScan(status: VocabularyPoolUsageScan['status'], durationMs: number, documentCount?: number) {
+  console.info('[vocabulary-pool-usage-scan]', { context: 'management', status, documentCount, durationMs });
+}
+
+/** Scans the four canonical authoring collections with an explicit size guard. */
+export async function scanVocabularyPoolUsages(db: Firestore): Promise<VocabularyPoolUsageScan> {
+  const startedAt = Date.now();
+  try {
+    const loaded = await loadUsageDocuments(db);
+    if ('unavailable' in loaded) {
+      const result: VocabularyPoolUsageScan = {
+        status: 'unavailable',
+        message: loaded.unavailable,
+        ...(loaded.documentCount === undefined ? {} : { documentCount: loaded.documentCount }),
+      };
+      logScan(result.status, Date.now() - startedAt, result.documentCount);
+      return result;
+    }
+    const [learningUnits, versions, drafts, mocks] = loaded.documents;
+    const result: VocabularyPoolUsageScan = {
+      status: 'available',
+      documentCount: loaded.documentCount,
+      usages: projectVocabularyPoolUsages({ learningUnits, versions, drafts, mocks }),
+    };
+    logScan(result.status, Date.now() - startedAt, result.documentCount);
+    return result;
+  } catch (error) {
+    console.error('[vocabulary-pool-usage-scan] failed', error);
+    const result: VocabularyPoolUsageScan = {
+      status: 'unavailable',
+      message: 'Assignment checks are temporarily unavailable. Try again shortly.',
+    };
+    logScan(result.status, Date.now() - startedAt);
+    return result;
+  }
+}

--- a/src/store/api/vocabularyPoolApi.ts
+++ b/src/store/api/vocabularyPoolApi.ts
@@ -4,6 +4,7 @@ import {
   VocabularyPoolSummary,
   VocabularyPoolWithWords,
   CreatePoolRequest,
+  VocabularyPoolUsageResponse,
 } from '@/src/types/vocabulary-pool';
 import { Word } from '@/src/types/admin-vocabulary';
 import { createAuthenticatedBaseQuery } from './baseQuery';
@@ -28,12 +29,18 @@ interface ParadigmSummaryData {
 export const vocabularyPoolApi = createApi({
   reducerPath: 'vocabularyPoolApi',
   baseQuery: createAuthenticatedBaseQuery(),
-  tagTypes: ['Pool', 'PoolList', 'AvailableWords'],
+  tagTypes: ['Pool', 'PoolList', 'PoolUsage', 'AvailableWords'],
   keepUnusedDataFor: 60 * 5,
   refetchOnMountOrArgChange: 300,
   refetchOnFocus: false,
   refetchOnReconnect: true,
   endpoints: builder => ({
+    getVocabularyPoolUsages: builder.query<VocabularyPoolUsageResponse, void>({
+      query: () => '/admin/vocabulary-pools/usages',
+      transformResponse: (response: { success: boolean; data: VocabularyPoolUsageResponse }) => response.data,
+      providesTags: [{ type: 'PoolUsage', id: 'MANAGEMENT' }],
+    }),
+
     getPools: builder.query<
       { pools: VocabularyPoolSummary[]; hasMore: boolean; lastPoolId: string | null },
       {
@@ -152,6 +159,7 @@ export const vocabularyPoolApi = createApi({
       invalidatesTags: (result, error, poolId) => [
         { type: 'Pool', id: poolId },
         { type: 'PoolList', id: 'LIST' },
+        { type: 'PoolUsage', id: 'MANAGEMENT' },
       ],
     }),
 
@@ -240,6 +248,7 @@ export const vocabularyPoolApi = createApi({
 });
 
 export const {
+  useGetVocabularyPoolUsagesQuery,
   useGetPoolsQuery,
   useGetPoolQuery,
   useGetPoolSummaryQuery,

--- a/src/types/vocabulary-pool.d.ts
+++ b/src/types/vocabulary-pool.d.ts
@@ -35,6 +35,29 @@ export interface VocabularyPoolsResponse {
   };
 }
 
+export type VocabularyPoolUsageKind =
+  | 'lesson'
+  | 'lesson-exercise'
+  | 'test-version'
+  | 'test-version-exercise'
+  | 'test-version-draft'
+  | 'test-version-draft-exercise';
+
+/** A saved lesson, test version, or draft that currently references a pool. */
+export interface VocabularyPoolUsage {
+  id: string;
+  poolId: string;
+  kind: VocabularyPoolUsageKind;
+  label: string;
+  editorUrl?: string;
+}
+
+export interface VocabularyPoolUsageResponse {
+  status: 'available' | 'unavailable';
+  usagesByPoolId: Record<string, VocabularyPoolUsage[]>;
+  message?: string;
+}
+
 export interface VocabularyPoolResponse {
   success: boolean;
   data: {

--- a/tests/vocabularyPoolDeleteConfirmation.test.ts
+++ b/tests/vocabularyPoolDeleteConfirmation.test.ts
@@ -1,0 +1,29 @@
+import { buildVocabularyPoolDeleteConfirmation } from '@/src/lib/vocabulary-pools/delete-confirmation';
+
+const usage = (label: string) => ({ id: label, poolId: 'pool-1', kind: 'lesson' as const, label });
+
+describe('vocabulary pool deletion confirmation', () => {
+  it('warns about saved assignments and shows a compact list of their names', () => {
+    expect(
+      buildVocabularyPoolDeleteConfirmation(
+        'Chapter 1 words',
+        [usage('Lesson: One'), usage('Lesson: Two'), usage('Lesson: Three'), usage('Lesson: Four')],
+        'available'
+      )
+    ).toBe(
+      'Are you sure you want to delete "Chapter 1 words"?\n\nThis pool is assigned to 4 saved assignments:\n• Lesson: One\n• Lesson: Two\n• Lesson: Three\n• +1 more\n\nDeleting it may break that saved content. This action cannot be undone.'
+    );
+  });
+
+  it('warns when assignments could not be checked', () => {
+    expect(buildVocabularyPoolDeleteConfirmation('Chapter 1 words', [], 'unavailable')).toContain(
+      'Assignments could not be checked. Deleting this pool may break lessons or exercises that use it.'
+    );
+  });
+
+  it('uses the normal irreversible-delete confirmation for an unused pool', () => {
+    expect(buildVocabularyPoolDeleteConfirmation('Chapter 1 words', [], 'available')).toBe(
+      'Are you sure you want to delete "Chapter 1 words"? This action cannot be undone.'
+    );
+  });
+});

--- a/tests/vocabularyPoolList.test.tsx
+++ b/tests/vocabularyPoolList.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PoolList } from '@/src/components/ui/admin/vocabulary-pools/PoolList';
+
+jest.mock('@/src/hooks/useInfiniteScroll', () => ({ useInfiniteScroll: () => ({ current: null }) }));
+
+const pool = {
+  id: 'pool-1',
+  name: 'Chapter 1 words',
+  description: 'Words for chapter 1.',
+  metadata: {
+    createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    createdBy: 'admin-1',
+    updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+    updatedBy: 'admin-1',
+    wordCount: 12,
+    isActive: true,
+    tags: [],
+    difficulty: 'beginner' as const,
+  },
+};
+
+describe('vocabulary pool list usage status', () => {
+  it('shows two usages, expands the remainder, and keeps deletion available while assigned', async () => {
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+    render(
+      <PoolList
+        pools={[pool]}
+        loading={false}
+        loadingMore={false}
+        hasMore={false}
+        onLoadMore={jest.fn()}
+        onEdit={jest.fn()}
+        onDelete={onDelete}
+        usagesByPoolId={{
+          'pool-1': [
+            { id: '1', poolId: 'pool-1', kind: 'lesson', label: 'Lesson: One', editorUrl: '/admin/lessons/edit/one' },
+            { id: '2', poolId: 'pool-1', kind: 'lesson', label: 'Lesson: Two', editorUrl: '/admin/lessons/edit/two' },
+            {
+              id: '3',
+              poolId: 'pool-1',
+              kind: 'lesson',
+              label: 'Lesson: Three',
+              editorUrl: '/admin/lessons/edit/three',
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByText('Assigned (3)')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Lesson: One' })).toHaveAttribute('href', '/admin/lessons/edit/one');
+    expect(screen.queryByText('Lesson: Three')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Delete pool')).toBeEnabled();
+
+    await user.click(screen.getByTitle('Delete pool'));
+    expect(onDelete).toHaveBeenCalledWith('pool-1', 'Chapter 1 words');
+
+    await user.click(screen.getByRole('button', { name: '+1 more' }));
+    expect(screen.getByText('Lesson: Three')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument();
+  });
+});

--- a/tests/vocabularyPoolUsage.test.ts
+++ b/tests/vocabularyPoolUsage.test.ts
@@ -1,0 +1,258 @@
+import {
+  extractVocabularyPoolReferences,
+  projectVocabularyPoolUsages,
+  scanVocabularyPoolUsages,
+} from '@/src/lib/vocabulary-pools/usage.server';
+
+type TestDocument = { id: string; data: Record<string, unknown> };
+
+function scanDb(documentsByCollection: Record<string, TestDocument[]>, counts: Partial<Record<string, number>> = {}) {
+  const select = jest.fn();
+  return {
+    select,
+    db: {
+      collection: (collection: string) => {
+        const documents = documentsByCollection[collection] ?? [];
+        return {
+          count: () => ({ get: async () => ({ data: () => ({ count: counts[collection] ?? documents.length }) }) }),
+          select: (...fields: string[]) => {
+            select(collection, fields);
+            return {
+              get: async () => ({ docs: documents.map(document => ({ id: document.id, data: () => document.data })) }),
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe('vocabulary pool usage extraction', () => {
+  it('keeps direct assignments and only counts generated exercises configured to use a pool', () => {
+    expect(
+      extractVocabularyPoolReferences({
+        vocabulary_pool: 'lesson-pool',
+        pages: [
+          {
+            id: 'page-1',
+            items: [
+              { id: 'from-pool', data: { generatorConfig: { wordSource: 'pool', poolId: 'exercise-pool' } } },
+              { id: 'stale-pool', data: { generatorConfig: { wordSource: 'filters', poolId: 'ignored-pool' } } },
+              { id: 'missing-pool', data: { generatorConfig: { wordSource: 'pool' } } },
+            ],
+          },
+        ],
+      })
+    ).toEqual([
+      { poolId: 'lesson-pool', kind: 'direct' },
+      { poolId: 'exercise-pool', kind: 'exercise', pageIndex: 0, pageId: 'page-1', itemIndex: 0, itemId: 'from-pool' },
+    ]);
+  });
+
+  it('preserves page and exercise titles, with ordinals when either title is absent', () => {
+    const references = extractVocabularyPoolReferences({
+      pages: [
+        {
+          id: 'page-titled',
+          title: 'Verb practice',
+          items: [
+            {
+              id: 'item-titled',
+              title: 'Identify the tense',
+              data: { generatorConfig: { wordSource: 'pool', poolId: 'titled-pool' } },
+            },
+          ],
+        },
+        {
+          id: 'page-untitled',
+          items: [
+            {
+              id: 'item-untitled',
+              data: { generatorConfig: { wordSource: 'pool', poolId: 'untitled-pool' } },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(references).toEqual([
+      expect.objectContaining({ pageTitle: 'Verb practice', itemTitle: 'Identify the tense' }),
+      expect.objectContaining({ pageIndex: 1, itemIndex: 0 }),
+    ]);
+
+    const usages = projectVocabularyPoolUsages({
+      learningUnits: [
+        {
+          id: 'lesson-1',
+          data: {
+            kind: 'lesson',
+            title: 'Lesson one',
+            pages: [
+              {
+                id: 'page-titled',
+                title: 'Verb practice',
+                items: [
+                  {
+                    id: 'item-titled',
+                    title: 'Identify the tense',
+                    data: { generatorConfig: { wordSource: 'pool', poolId: 'titled-pool' } },
+                  },
+                ],
+              },
+              {
+                id: 'page-untitled',
+                items: [
+                  { id: 'item-untitled', data: { generatorConfig: { wordSource: 'pool', poolId: 'untitled-pool' } } },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      versions: [],
+      drafts: [],
+      mocks: [],
+    });
+
+    expect(usages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          poolId: 'titled-pool',
+          label: 'Lesson: Lesson one → Verb practice → Identify the tense',
+        }),
+        expect.objectContaining({
+          poolId: 'untitled-pool',
+          label: 'Lesson: Lesson one → Page 2 → exercise 1',
+        }),
+      ])
+    );
+  });
+
+  it('uses the active mock before normal rotation ownership and preserves draft editor links', () => {
+    const usages = projectVocabularyPoolUsages({
+      learningUnits: [
+        { id: 'lesson-1', data: { kind: 'lesson', title: 'First lesson', vocabulary_pool: 'lesson-pool' } },
+        {
+          id: 'test-1',
+          data: { kind: 'test', title: 'Chapter test', rotationVersions: [{ versionId: 'version-1' }] },
+        },
+      ],
+      versions: [
+        {
+          id: 'version-1',
+          data: {
+            name: 'Version A',
+            vocabularyPoolId: 'version-pool',
+            pages: [
+              {
+                id: 'page-1',
+                items: [
+                  { id: 'exercise-1', data: { generatorConfig: { wordSource: 'pool', poolId: 'exercise-pool' } } },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      drafts: [{ id: 'draft-1', data: { testId: 'test-1', name: 'Draft A', vocabularyPoolId: 'draft-pool' } }],
+      mocks: [{ id: 'mock-1', data: { title: 'Mock A', versionId: 'version-1', status: 'active' } }],
+    });
+
+    expect(usages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          poolId: 'version-pool',
+          label: 'Mock test: Mock A → Version A',
+          editorUrl: '/admin/mock-tests/mock-1',
+        }),
+        expect.objectContaining({
+          poolId: 'exercise-pool',
+          label: 'Mock test: Mock A → Version A → Page 1 → exercise 1',
+        }),
+        expect.objectContaining({
+          poolId: 'draft-pool',
+          label: 'Test draft: Chapter test → Draft A',
+          editorUrl: '/admin/tests/edit/test-1/versions/draft-1/edit',
+        }),
+      ])
+    );
+  });
+
+  it('uses an archived standalone mock before falling back to text-only orphan ownership', () => {
+    const usages = projectVocabularyPoolUsages({
+      learningUnits: [],
+      versions: [
+        { id: 'archived-version', data: { name: 'Archived version', vocabularyPoolId: 'archived-pool' } },
+        { id: 'orphan-version', data: { name: 'Lost version', vocabularyPoolId: 'orphan-pool' } },
+      ],
+      drafts: [],
+      mocks: [
+        {
+          id: 'archived-mock',
+          data: {
+            title: 'Archived mock',
+            versionId: 'archived-version',
+            status: 'archived',
+            parent: { kind: 'standalone' },
+          },
+        },
+      ],
+    });
+
+    expect(usages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          poolId: 'archived-pool',
+          label: 'Mock test: Archived mock → Archived version',
+          editorUrl: '/admin/mock-tests/archived-mock',
+        }),
+        expect.objectContaining({
+          poolId: 'orphan-pool',
+          label: 'Orphaned version: Lost version',
+        }),
+      ])
+    );
+    expect(usages.find(usage => usage.poolId === 'orphan-pool')?.editorUrl).toBeUndefined();
+  });
+
+  it('fails closed before reading documents when aggregate counts exceed the cap', async () => {
+    const { db, select } = scanDb({}, { lessons: 501 });
+    const result = await scanVocabularyPoolUsages(db as never);
+
+    expect(result).toMatchObject({ status: 'unavailable', documentCount: 501 });
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it('projects a successful canonical scan and guards a post-count document race', async () => {
+    const successful = scanDb({
+      lessons: [
+        { id: 'lesson-1', data: { kind: 'lesson', title: 'Lesson one', vocabulary_pool: 'lesson-pool' } },
+        { id: 'test-1', data: { kind: 'test', title: 'Test one', rotationVersions: [{ versionId: 'version-1' }] } },
+      ],
+      testVersions: [{ id: 'version-1', data: { name: 'Version one', vocabularyPoolId: 'version-pool' } }],
+    });
+    const result = await scanVocabularyPoolUsages(successful.db as never);
+
+    expect(result).toMatchObject({ status: 'available', documentCount: 3 });
+    if (result.status === 'available') {
+      expect(result.usages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ poolId: 'lesson-pool', label: 'Lesson: Lesson one' }),
+          expect.objectContaining({
+            poolId: 'version-pool',
+            editorUrl: '/admin/tests/edit/test-1/versions/version-1/edit',
+          }),
+        ])
+      );
+    }
+
+    const race = scanDb(
+      { lessons: Array.from({ length: 501 }, (_, index) => ({ id: `lesson-${index}`, data: { kind: 'lesson' } })) },
+      { lessons: 500 }
+    );
+    await expect(scanVocabularyPoolUsages(race.db as never)).resolves.toMatchObject({
+      status: 'unavailable',
+      documentCount: 501,
+    });
+  });
+});

--- a/tests/vocabularyPoolUsageRoutes.test.ts
+++ b/tests/vocabularyPoolUsageRoutes.test.ts
@@ -1,0 +1,87 @@
+const mockVerifyAdminAccess = jest.fn();
+const mockScanVocabularyPoolUsages = jest.fn();
+const transactionDelete = jest.fn();
+
+jest.mock('next/server', () => jest.requireActual('./helpers/routeMocks'));
+jest.mock('firebase-admin/firestore', () => ({ FieldPath: { documentId: jest.fn() } }));
+jest.mock('@/src/lib/verifyAdminAccess', () => ({
+  verifyAdminAccess: (...args: unknown[]) => mockVerifyAdminAccess(...args),
+}));
+jest.mock('@/src/lib/vocabulary-pools/usage.server', () => ({
+  scanVocabularyPoolUsages: (...args: unknown[]) => mockScanVocabularyPoolUsages(...args),
+}));
+jest.mock('@/src/services/firebase-admin', () => ({
+  adminDb: {
+    collection: (collection: string) => ({ doc: (id: string) => ({ collection, id }) }),
+    runTransaction: (callback: (transaction: unknown) => unknown) =>
+      callback({ get: async (ref: { id: string }) => ({ id: ref.id, exists: true }), delete: transactionDelete }),
+  },
+}));
+
+import { GET as getUsages } from '@/src/app/api/admin/vocabulary-pools/usages/route';
+import { DELETE as deletePool } from '@/src/app/api/admin/vocabulary-pools/[poolId]/route';
+
+describe('vocabulary pool usage routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockVerifyAdminAccess.mockResolvedValue({ uid: 'admin-1' });
+  });
+
+  it('groups canonical usages for the management page', async () => {
+    mockScanVocabularyPoolUsages.mockResolvedValue({
+      status: 'available',
+      documentCount: 4,
+      usages: [
+        { id: 'lesson:1', poolId: 'pool-1', kind: 'lesson', label: 'Lesson: First lesson' },
+        { id: 'draft:1', poolId: 'pool-2', kind: 'test-version-draft', label: 'Test draft: Draft A' },
+      ],
+    });
+
+    const response = (await getUsages({} as never)) as unknown as { status: number; body: { data: unknown } };
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual({
+      status: 'available',
+      usagesByPoolId: {
+        'pool-1': [{ id: 'lesson:1', poolId: 'pool-1', kind: 'lesson', label: 'Lesson: First lesson' }],
+        'pool-2': [{ id: 'draft:1', poolId: 'pool-2', kind: 'test-version-draft', label: 'Test draft: Draft A' }],
+      },
+    });
+  });
+
+  it('deletes a pool without checking its saved assignments', async () => {
+    mockScanVocabularyPoolUsages.mockResolvedValue({
+      status: 'available',
+      documentCount: 4,
+      usages: [
+        {
+          id: 'exercise:1',
+          poolId: 'pool-1',
+          kind: 'lesson-exercise',
+          label: 'Lesson: First lesson → Page 1, exercise 1',
+        },
+      ],
+    });
+
+    const response = (await deletePool({} as never, { params: Promise.resolve({ poolId: 'pool-1' }) })) as unknown as {
+      status: number;
+    };
+
+    expect(response.status).toBe(200);
+    expect(transactionDelete).toHaveBeenCalledTimes(1);
+    expect(mockScanVocabularyPoolUsages).not.toHaveBeenCalled();
+  });
+
+  it('deletes a pool even when assignment checks would be unavailable', async () => {
+    mockScanVocabularyPoolUsages.mockResolvedValueOnce({
+      status: 'unavailable',
+      message: 'Assignment checks are temporarily unavailable.',
+    });
+    const deleted = (await deletePool({} as never, { params: Promise.resolve({ poolId: 'pool-1' }) })) as unknown as {
+      status: number;
+    };
+    expect(deleted.status).toBe(200);
+    expect(transactionDelete).toHaveBeenCalledTimes(1);
+    expect(mockScanVocabularyPoolUsages).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Recreates the clean work from incident-corrupted PR #174 using preserved commit `87a1692fe9cfcce5a24224acee4202b0ff946631`. Shows where vocabulary pools are assigned and warns administrators before deleting an assigned pool.

## Behavior

- Adds assignment counts and saved-content labels to vocabulary-pool cards.
- Links assignments to the relevant editor.
- Expands long assignment lists with `+N more`.
- Gives detailed deletion warnings, including a fail-safe warning when usage cannot be checked.
- Uses canonical scans; no database migration or secondary index is introduced.

## Validation

- Incident IOC scan passed.
- TypeScript passed.
- ESLint passed.
- Jest: 84/84 suites, 525/525 tests passed.
- Exact source commit and edge ancestry verified locally.