### PR TITLE
Fix assessment scoring and attempt integrity

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import prettierConfig from 'eslint-config-prettier';
 
 const eslintConfig = [
   {
-    ignores: ['.next/**', 'node_modules/**', 'functions/**', 'public/**'],
+    ignores: ['.next/**', 'node_modules/**', 'functions/**', 'public/**', 'playwright-report/**', 'test-results/**'],
   },
   ...nextConfig,
   ...tseslint.configs.recommended,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -24,6 +24,7 @@ import { SwiperNavigation } from '@/src/components/ui/core/swiper-nav';
 import { PracticeSection } from '@/src/components/ui/core/PracticeSection';
 import { SimpleRichDisplay } from '@/src/components/ui/core/simple-rich-display';
 import { FeedbackBanner } from '@/src/components/ui/core/feedback-banner';
+import { formatScorePercentage } from '@/src/lib/tests/formatting';
 export { MockTestCard } from '@/src/components/ui/core/mock-test-card';
 
 const statusConfig: Record<LessonStatus, { card: string }> = {
@@ -126,6 +127,7 @@ export const TestCard = memo(
 
     return (
       <RomanCard
+        data-testid="dashboard-test-card"
         className={`group cursor-pointer rounded-3xl border shadow-xl transition-all duration-300 hover:-translate-y-2 hover:scale-[1.02] hover:shadow-2xl ${
           locked
             ? 'border-gray-300 bg-gradient-to-br from-gray-100 to-gray-50'
@@ -178,14 +180,16 @@ export const TestCard = memo(
                   <Trophy className="h-3.5 w-3.5" aria-hidden="true" />
                   Best
                 </div>
-                <div className="text-2xl font-semibold text-indigo-800">{Math.round(summary.best.percentage)}%</div>
+                <div className="text-2xl font-semibold text-indigo-800">
+                  {formatScorePercentage(summary.best.percentage)}%
+                </div>
               </div>
               <div>
                 <div className="text-xs text-gray-500">Latest</div>
                 <div className="font-medium text-gray-900">
                   {formatPoints(summary.latest?.score ?? 0)} / {formatPoints(summary.latest?.maxScore ?? 0)}
                 </div>
-                <div className="text-xs text-gray-600">{Math.round(summary.latest?.percentage ?? 0)}%</div>
+                <div className="text-xs text-gray-600">{formatScorePercentage(summary.latest?.percentage ?? 0)}%</div>
                 {latestOutcome && (
                   <div
                     className={`mt-1 text-xs font-semibold ${
@@ -305,9 +309,12 @@ export default function DashboardPage() {
     [router, learningUnits, vocabLessons, diagrammingLessons, listeningLessons]
   );
 
-  const handleMockClick = useCallback((mockTestId: string) => {
-    router.push(`/test/${encodeURIComponent(mockTestId)}?origin=mock`);
-  }, [router]);
+  const handleMockClick = useCallback(
+    (mockTestId: string) => {
+      router.push(`/test/${encodeURIComponent(mockTestId)}?origin=mock`);
+    },
+    [router]
+  );
 
   useEffect(() => {
     if (!loading && !user) {

--- a/src/app/test/[testId]/page.tsx
+++ b/src/app/test/[testId]/page.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/src/hooks/useAuth';
 import { useBufferedAttemptAnswers } from '@/src/hooks/useBufferedAttemptAnswers';
 import { isExerciseType } from '@/src/lib/content/registry';
 import { isExerciseAnswerComplete } from '@/src/lib/tests/answer-completion';
+import { formatScorePercentage, formatScoreShortfall } from '@/src/lib/tests/formatting';
 import { getApiErrorCode, getApiErrorMessage } from '@/src/store/api/baseQuery';
 import { useGetStudentDashboardQuery } from '@/src/store/api/lessonApi';
 import { useGetStudentMockDetailQuery } from '@/src/store/api/mockTestApi';
@@ -62,6 +63,7 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
     activateAttempt,
     adoptPersistedAnswer,
     answers,
+    clearAnswer,
     flushPendingAnswers,
     hasUnsavedAnswers,
     recordAnswer,
@@ -75,6 +77,7 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
   const [result, setResult] = useState<StudentSubmittedTestAttempt | null>(null);
   const [pageIndex, setPageIndex] = useState(0);
   const [mockRetakeAvailability, setMockRetakeAvailability] = useState<MockRetakeAvailability>('unchecked');
+  const [editingExerciseId, setEditingExerciseId] = useState<string | null>(null);
   const allowNextHistoryPopRef = useRef(false);
   const historyNavigationPendingRef = useRef(false);
   const historyEffectActiveRef = useRef(false);
@@ -347,6 +350,38 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
     }
   };
 
+  const openExercise = async (exerciseId: string, exercisePageIndex: number, clearExisting: boolean) => {
+    if (!attempt) return;
+    if (!clearExisting) {
+      setPageIndex(exercisePageIndex);
+      setScreen('taking');
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
+    const previousAnswer = answers[exerciseId];
+    setEditingExerciseId(exerciseId);
+    clearAnswer(exerciseId);
+    try {
+      await flushPendingAnswers();
+      setAttempt(current => {
+        if (!current) return current;
+        const nextAnswers = { ...current.answers };
+        const nextTranslationGrades = { ...current.translationGrades };
+        delete nextAnswers[exerciseId];
+        delete nextTranslationGrades[exerciseId];
+        return { ...current, answers: nextAnswers, translationGrades: nextTranslationGrades };
+      });
+      setPageIndex(exercisePageIndex);
+      setScreen('taking');
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } catch {
+      if (previousAnswer) recordAnswer({ exerciseId, answer: previousAnswer });
+      toast.error('This answer could not be reopened. Try again.');
+    } finally {
+      setEditingExerciseId(null);
+    }
+  };
+
   if (authLoading || dashboardLoading || (isMockTest && mockDetailLoading) || (!user && !dashboardError)) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-roman-marble">
@@ -531,14 +566,14 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
                       : 'Test complete'
                     : 'Keep going'}
               </h1>
-              <div className="text-5xl font-semibold text-roman-red">{Math.round(result.percentage)}%</div>
+              <div className="text-5xl font-semibold text-roman-red">{formatScorePercentage(result.percentage)}%</div>
               <p className="text-lg">
                 {formatPoints(result.score)} / {formatPoints(result.maxScore)} points
               </p>
               {result.outcome === 'not-passed' && result.passingPercentage !== null && (
                 <div className="rounded-lg bg-amber-50 p-3 text-amber-950">
-                  You need {result.passingPercentage}% — you reached {Math.round(result.percentage)}%. You are{' '}
-                  {shortfall.toFixed(1).replace(/\.0$/, '')} percentage points away.
+                  You need {result.passingPercentage}% — you reached {formatScorePercentage(result.percentage)}%. You
+                  are {formatScoreShortfall(shortfall)} percentage points away.
                 </div>
               )}
               {!isMockTest && result.outcome === 'not-passed' && normalTest?.relatedLiveMocks?.[0] && (
@@ -640,6 +675,51 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
                   </ul>
                 </div>
               )}
+              <div className="space-y-2">
+                <h2 className="font-semibold text-slate-900">Review each exercise</h2>
+                <ul className="divide-y rounded-lg border border-slate-200 bg-white">
+                  {exerciseItems.map(item => {
+                    const complete = isExerciseAnswerComplete(item.exercise, answers[item.id], item.resolvedItemCount);
+                    const hasRecordedAnswer = Boolean(answers[item.id]);
+                    const translationIsFinal =
+                      item.exercise.type === 'translation-grading' &&
+                      Object.keys(attempt.translationGrades[item.id] ?? {}).length > 0;
+                    const clearExisting = complete && !translationIsFinal;
+                    const actionLabel = translationIsFinal
+                      ? complete
+                        ? 'Review answer'
+                        : 'Continue exercise'
+                      : complete
+                        ? 'Edit answer'
+                        : hasRecordedAnswer
+                          ? 'Continue exercise'
+                          : 'Answer exercise';
+                    return (
+                      <li
+                        key={item.id}
+                        className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <div className="font-medium text-slate-900">
+                            Page {item.pageIndex + 1}: {item.title}
+                          </div>
+                          <div className={complete ? 'text-sm text-emerald-700' : 'text-sm text-amber-700'}>
+                            {complete ? 'Answer recorded' : 'Needs an answer'}
+                          </div>
+                        </div>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={editingExerciseId !== null}
+                          aria-label={`${actionLabel.replace(' answer', '').replace(' exercise', '')} ${item.title}`}
+                          onClick={() => void openExercise(item.id, item.pageIndex, clearExisting)}>
+                          {editingExerciseId === item.id ? 'Opening…' : actionLabel}
+                        </Button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
               <p className="text-sm text-gray-600">
                 Submission is final for this attempt. Exact questions and answers cannot be reopened afterward, but your
                 score breakdown will be retained.
@@ -647,13 +727,13 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
             </CardContent>
           </Card>
           <div className="flex flex-col gap-3 sm:flex-row sm:justify-between">
-            <Button variant="outline" onClick={() => setScreen('taking')}>
+            <Button variant="outline" disabled={editingExerciseId !== null} onClick={() => setScreen('taking')}>
               <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
               Return to test
             </Button>
             <Button
               className="bg-roman-red hover:bg-roman-red/90"
-              disabled={submitting || translationGrading}
+              disabled={submitting || translationGrading || editingExerciseId !== null}
               onClick={submit}>
               {submitting ? 'Submitting…' : 'Submit Test'}
             </Button>

--- a/src/components/ui/core/mock-test-card.tsx
+++ b/src/components/ui/core/mock-test-card.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, ClipboardCheck, Trophy } from 'lucide-react';
 import type { StudentMockTestSummary } from '@/src/types/test';
 import { RomanCard, RomanCardContent } from '@/src/components/ui/core/roman-card';
 import { cn } from '@/src/lib/utils';
+import { formatScorePercentage } from '@/src/lib/tests/formatting';
 import { stripHtmlTags } from '@/src/utils/exercises/helpers';
 
 const formatPoints = (value: number) =>
@@ -43,7 +44,9 @@ export const MockTestCard = memo(
     const description = stripHtmlTags(mock.description ?? '');
 
     return (
-      <RomanCard className="group relative flex h-[16rem] min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-5 text-left shadow-[0_12px_35px_-24px_rgba(30,41,59,0.55)] transition duration-300 hover:-translate-y-1 hover:border-teal-300/70 hover:shadow-[0_20px_45px_-24px_rgba(30,41,59,0.45)]">
+      <RomanCard
+        data-testid="mock-test-card"
+        className="group relative flex h-[16rem] min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-5 text-left shadow-[0_12px_35px_-24px_rgba(30,41,59,0.55)] transition duration-300 hover:-translate-y-1 hover:border-teal-300/70 hover:shadow-[0_20px_45px_-24px_rgba(30,41,59,0.45)]">
         <div
           aria-hidden="true"
           className="absolute inset-x-0 top-0 h-24 bg-gradient-to-br from-teal-300/35 via-cyan-100/30 to-transparent opacity-80"
@@ -74,7 +77,7 @@ export const MockTestCard = memo(
                 <span className="flex min-w-0 shrink-0 items-center gap-1.5">
                   <Trophy className="h-3.5 w-3.5 text-teal-700" aria-hidden="true" />
                   <span>Best</span>
-                  <span className="font-semibold text-teal-800">{Math.round(summary.best.percentage)}%</span>
+                  <span className="font-semibold text-teal-800">{formatScorePercentage(summary.best.percentage)}%</span>
                 </span>
               ) : (
                 <span className="min-w-0 truncate">Not attempted · {formatPoints(mock.totalPoints)} points</span>
@@ -87,7 +90,8 @@ export const MockTestCard = memo(
                 {latest && (
                   <>
                     {' · Latest '}
-                    {formatPoints(latest.score)} / {formatPoints(latest.maxScore)} ({Math.round(latest.percentage)}%)
+                    {formatPoints(latest.score)} / {formatPoints(latest.maxScore)} (
+                    {formatScorePercentage(latest.percentage)}%)
                   </>
                 )}
               </p>
@@ -103,15 +107,15 @@ export const MockTestCard = memo(
             )}
             {mock.scoreTrend.length > 0 && (
               <p className="mt-0.5 truncate text-xs text-slate-500">
-                Recent {mock.scoreTrend.map(score => `${Math.round(score.percentage)}%`).join(' → ')}
+                Recent {mock.scoreTrend.map(score => `${formatScorePercentage(score.percentage)}%`).join(' → ')}
               </p>
             )}
 
             <p
               className="sr-only"
-              aria-label={`Recent scores: ${mock.scoreTrend.length ? mock.scoreTrend.map(score => `${Math.round(score.percentage)} percent`).join(', ') : 'no submitted attempts'}`}>
+              aria-label={`Recent scores: ${mock.scoreTrend.length ? mock.scoreTrend.map(score => `${formatScorePercentage(score.percentage)} percent`).join(', ') : 'no submitted attempts'}`}>
               {mock.scoreTrend.length
-                ? `Recent scores: ${mock.scoreTrend.map(score => `${Math.round(score.percentage)}%`).join(' → ')}`
+                ? `Recent scores: ${mock.scoreTrend.map(score => `${formatScorePercentage(score.percentage)}%`).join(' → ')}`
                 : 'Your practice attempts will appear here.'}
             </p>
             <span className="sr-only">

--- a/src/hooks/useBufferedAttemptAnswers.ts
+++ b/src/hooks/useBufferedAttemptAnswers.ts
@@ -149,6 +149,40 @@ export function useBufferedAttemptAnswers() {
     [clearSaveTimer, flushPendingAnswers]
   );
 
+  const clearAnswer = useCallback(
+    (exerciseId: string) => {
+      const activeAttempt = activeAttemptRef.current;
+      if (!activeAttempt) return;
+
+      setAnswers(current => {
+        const next = { ...current };
+        delete next[exerciseId];
+        return next;
+      });
+      const queued = pendingAnswersRef.current;
+      pendingAnswersRef.current =
+        queued?.scope === activeAttempt.scope
+          ? {
+              scope: activeAttempt.scope,
+              answers: { ...queued.answers, [exerciseId]: null },
+            }
+          : {
+              scope: activeAttempt.scope,
+              answers: { [exerciseId]: null },
+            };
+      setSaveError(null);
+      setSaveStatus('recorded');
+
+      clearSaveTimer();
+      saveTimerRef.current = setTimeout(() => {
+        void flushPendingAnswers().catch(() => {
+          toast.error('An answer is still waiting to be saved. Try again before leaving.');
+        });
+      }, ANSWER_SAVE_DEBOUNCE_MS);
+    },
+    [clearSaveTimer, flushPendingAnswers]
+  );
+
   const adoptPersistedAnswer = useCallback((event: ExerciseAnswerEvent) => {
     const activeAttempt = activeAttemptRef.current;
     if (!activeAttempt) return;
@@ -190,6 +224,7 @@ export function useBufferedAttemptAnswers() {
     activateAttempt,
     adoptPersistedAnswer,
     answers,
+    clearAnswer,
     flushPendingAnswers,
     hasUnsavedAnswers,
     recordAnswer,

--- a/src/lib/learning-units/learning-path-service.ts
+++ b/src/lib/learning-units/learning-path-service.ts
@@ -10,7 +10,8 @@ import { adminDb } from '@/src/services/firebase-admin';
 import type { AdminLearningPathView, LearningPathDocument, LearningUnit } from '@/src/types/learning-unit';
 import type { RotationVersionReference } from '@/src/types/test';
 import { estimateFirestoreDocumentBytes } from '@/src/lib/tests/firestore-size';
-import { mockTestDocumentSchema, testVersionDocumentSchema } from '@/src/lib/tests/schemas';
+import { mockTestDocumentSchema } from '@/src/lib/tests/schemas';
+import { isStoredVersionReadyForStudentVisibility } from '@/src/lib/tests/persistence';
 import { validateTestAssignmentGraph } from '@/src/lib/tests/domain';
 import { normalizeLearningUnit } from './domain';
 import { validateLessonProgression } from '@/src/utils/lessonProgress';
@@ -70,6 +71,7 @@ function assertDocumentSize(document: LearningPathDocument) {
     throw new LearningPathServiceError('LEARNING_PATH_TOO_LARGE', 'The Learning Path is too large to save safely', 422);
   }
 }
+
 export async function assertUnitDeletionAllowedInTransaction(
   transaction: Transaction,
   db: Firestore,
@@ -140,13 +142,7 @@ export async function assertPlacedTestRotationAllowedInTransaction(
   const snapshots = await transaction.getAll(
     ...rotationVersions.map(reference => db.collection(TEST_VERSIONS_COLLECTION).doc(reference.versionId))
   );
-  const invalid = snapshots.find(snapshot => {
-    const parsed = testVersionDocumentSchema.safeParse({
-      ...snapshot.data(),
-      id: snapshot.id,
-    });
-    return !snapshot.exists || !parsed.success;
-  });
+  const invalid = snapshots.find(snapshot => !isStoredVersionReadyForStudentVisibility(snapshot));
   if (invalid) {
     throw new LearningPathServiceError(
       'PLACED_UNIT_INVALID',
@@ -318,13 +314,7 @@ export class LearningPathService {
       : [];
     const validVersionIds = new Set<string>();
     for (const snapshot of versionSnapshots) {
-      if (
-        snapshot.exists &&
-        testVersionDocumentSchema.safeParse({
-          ...snapshot.data(),
-          id: snapshot.id,
-        }).success
-      ) {
+      if (isStoredVersionReadyForStudentVisibility(snapshot)) {
         validVersionIds.add(snapshot.id);
       }
     }

--- a/src/lib/tests/active-exercise-validation.ts
+++ b/src/lib/tests/active-exercise-validation.ts
@@ -1,0 +1,583 @@
+import { z } from 'zod';
+import { PARADIGM_AVAILABLE_STEPS } from '@/src/config/paradigmDefinitions';
+import { validateSentenceDiagramDocument } from '@/src/features/sentence-diagramming/validation';
+import type { SentenceDiagramDocument } from '@/src/features/sentence-diagramming/model';
+import type { GeneratorConfigBase } from '@/src/types/exercises/base';
+import {
+  FormIdentificationStepSchema,
+  type FormIdentificationStep,
+} from '@/src/types/exercises/schemas/form-identification';
+import { richTextToPlainText } from '@/src/utils/exercises/helpers';
+import { buildLegacyParadigmConfigs, buildLegacyPosConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
+
+export interface ActiveExerciseConfigurationIssue {
+  message: string;
+  path: (string | number)[];
+}
+
+const nonBlankIdSchema = z.string().trim().min(1, 'ID cannot be blank');
+const nonBlankPlainTextSchema = z.string().trim().min(1, 'Answer cannot be blank');
+const visibleRichTextSchema = z.string().refine(value => richTextToPlainText(value).length > 0, 'Text cannot be blank');
+const looseObjectSchema = z.object({}).passthrough();
+
+const matchingDataSchema = z
+  .object({
+    leftColumn: z
+      .array(z.object({ id: nonBlankIdSchema, value: visibleRichTextSchema }).passthrough())
+      .min(1, 'Add at least one left-column item'),
+    rightColumn: z
+      .array(z.object({ id: nonBlankIdSchema, value: visibleRichTextSchema }).passthrough())
+      .min(1, 'Add at least one right-column item'),
+    answers: z.record(z.string(), nonBlankIdSchema),
+    requiredRepetitions: z.number().int().min(1).max(10).optional(),
+  })
+  .passthrough();
+
+const multipleChoiceDataSchema = z
+  .object({
+    question: visibleRichTextSchema,
+    options: z
+      .array(z.object({ id: nonBlankIdSchema, text: visibleRichTextSchema, isCorrect: z.boolean() }).passthrough())
+      .min(2, 'Add at least two answer options'),
+    allowMultipleSelections: z.boolean(),
+  })
+  .passthrough();
+
+const oddOneOutDataSchema = z
+  .object({
+    question: visibleRichTextSchema,
+    items: z
+      .array(z.object({ id: nonBlankIdSchema, text: visibleRichTextSchema, isOddOneOut: z.boolean() }).passthrough())
+      .min(2, 'Add at least two items'),
+  })
+  .passthrough();
+
+const tableFillCellSchema = z
+  .object({
+    content: z.string(),
+    isBlank: z.boolean(),
+    answer: z.string().optional(),
+  })
+  .passthrough();
+const tableFillDataSchema = z
+  .object({
+    columns: z
+      .array(z.object({ id: nonBlankIdSchema, header: z.string() }).passthrough())
+      .min(1, 'Add at least one table column'),
+    rows: z
+      .array(
+        z
+          .object({
+            id: nonBlankIdSchema,
+            cells: z.record(z.string(), tableFillCellSchema),
+          })
+          .passthrough()
+      )
+      .min(1, 'Add at least one table row'),
+  })
+  .passthrough();
+
+const clickDataSchema = z
+  .object({
+    passage: visibleRichTextSchema,
+    correctWordIndices: z.array(z.number().int().nonnegative()).min(1, 'Select at least one target word'),
+    allowOverSelection: z.boolean().optional(),
+    minimumCorrect: z.number().int().positive().optional(),
+  })
+  .passthrough();
+
+const fillDataSchema = z
+  .object({
+    items: z
+      .array(
+        z
+          .object({
+            text: visibleRichTextSchema,
+            answer: nonBlankPlainTextSchema,
+          })
+          .passthrough()
+      )
+      .min(1, 'Add at least one fill-in item'),
+  })
+  .passthrough();
+
+const textSelectionDataSchema = z
+  .object({
+    passage: visibleRichTextSchema,
+    questions: z
+      .array(
+        z
+          .object({
+            id: nonBlankIdSchema,
+            text: visibleRichTextSchema,
+            correctWordIndex: z.number().int().nonnegative(),
+          })
+          .passthrough()
+      )
+      .min(1, 'Add at least one selection question'),
+  })
+  .passthrough();
+
+const fillEmboldedDataSchema = z
+  .object({
+    passage: visibleRichTextSchema,
+    words: z
+      .array(
+        z
+          .object({
+            wordIndex: z.number().int().nonnegative(),
+            correctAnswer: nonBlankPlainTextSchema,
+          })
+          .passthrough()
+      )
+      .min(1, 'Add at least one emboldened-word answer'),
+  })
+  .passthrough();
+
+const formSelectionSchema = z
+  .object({
+    tableType: z.string().trim().min(1),
+    selectedCellPaths: z.array(z.string().trim().min(1)),
+  })
+  .passthrough();
+
+const generatorConfigSchema = z
+  .object({
+    collection: z.string(),
+    wordSource: z.enum(['filters', 'pool']).default('filters'),
+    poolId: z.string().trim().min(1).nullable().optional(),
+    poolWordLimit: z.number().int().positive().nullable().optional(),
+    count: z.union([z.literal('all'), z.number().int().positive()]),
+    filters: looseObjectSchema.optional(),
+    formSelection: formSelectionSchema.optional(),
+  })
+  .passthrough();
+
+const generatedPosConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    filters: looseObjectSchema,
+    formSelection: formSelectionSchema.optional(),
+  })
+  .passthrough();
+
+const generatedTranslationDataSchema = z
+  .object({
+    generatorConfig: generatorConfigSchema,
+    posConfigs: z.record(z.string(), generatedPosConfigSchema).default({}),
+  })
+  .passthrough();
+
+const paradigmConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    steps: z.array(FormIdentificationStepSchema),
+    filters: looseObjectSchema,
+    formSelection: formSelectionSchema.optional(),
+  })
+  .passthrough();
+
+const generatedFormDataSchema = z
+  .object({
+    mode: z.enum(['step-by-step', 'single-field']),
+    generatorConfig: generatorConfigSchema,
+    paradigmConfigs: z.record(z.string(), paradigmConfigSchema).default({}),
+  })
+  .passthrough();
+
+const translationGradingDataSchema = z
+  .object({
+    items: z
+      .array(
+        z
+          .object({
+            latinText: visibleRichTextSchema,
+            instructions: z.string().optional(),
+          })
+          .passthrough()
+      )
+      .min(1, 'Add at least one translation prompt'),
+  })
+  .passthrough();
+
+const diagramSpanSchema = z
+  .object({
+    startTokenIndex: z.number(),
+    endTokenIndex: z.number(),
+    startCharOffset: z.number(),
+    endCharOffset: z.number(),
+  })
+  .passthrough();
+const diagramAnnotationSchema = z.object({ id: z.string(), kind: z.string(), span: diagramSpanSchema }).passthrough();
+const diagramTokenSchema = z.object({ id: z.string(), text: z.string(), index: z.number() }).passthrough();
+const diagramFeedbackSchema = z
+  .object({
+    text: z.string(),
+    tokens: z.array(diagramTokenSchema),
+    annotations: z.array(diagramAnnotationSchema),
+  })
+  .passthrough();
+const sentenceDiagramDataSchema = z
+  .object({
+    latin: visibleRichTextSchema,
+    translation: z.string(),
+    tokens: z.array(diagramTokenSchema),
+    solutionAnnotations: z.array(diagramAnnotationSchema),
+    availableStudentTools: z.array(z.string()).optional(),
+    hint: diagramFeedbackSchema.optional(),
+    explanation: diagramFeedbackSchema.optional(),
+    difficulty: z.enum(['beginner', 'intermediate', 'advanced']).optional(),
+  })
+  .passthrough();
+
+const uniqueValues = (values: readonly string[]) => new Set(values).size === values.length;
+const visibleWordCount = (value: string) => {
+  const plainText = richTextToPlainText(value);
+  return plainText ? plainText.split(/\s+/).length : 0;
+};
+const rawWhitespaceWordCount = (value: string) => (value.trim() ? value.trim().split(/\s+/).length : 0);
+
+const zodIssues = (error: z.ZodError): ActiveExerciseConfigurationIssue[] =>
+  error.issues.map(issue => ({
+    message: issue.message,
+    path: issue.path.map(segment => (typeof segment === 'symbol' ? String(segment) : segment)),
+  }));
+
+const issue = (message: string, path: (string | number)[]): ActiveExerciseConfigurationIssue => ({ message, path });
+
+const parseDiagramIssuePath = (value: string): (string | number)[] =>
+  value
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .filter(Boolean)
+    .map(segment => (/^\d+$/.test(segment) ? Number(segment) : segment));
+
+function validateMatching(data: unknown): ActiveExerciseConfigurationIssue[] {
+  const parsed = matchingDataSchema.safeParse(data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+
+  const issues: ActiveExerciseConfigurationIssue[] = [];
+  const leftIds = parsed.data.leftColumn.map(entry => entry.id);
+  const rightIds = parsed.data.rightColumn.map(entry => entry.id);
+  if (!uniqueValues(leftIds)) issues.push(issue('Left-column IDs must be unique', ['data', 'leftColumn']));
+  if (!uniqueValues(rightIds)) issues.push(issue('Right-column IDs must be unique', ['data', 'rightColumn']));
+
+  const leftIdSet = new Set(leftIds);
+  const rightIdSet = new Set(rightIds);
+  leftIds.forEach((leftId, index) => {
+    const rightId = parsed.data.answers[leftId];
+    if (!rightId) {
+      issues.push(issue('Every left-column item must have an answer', ['data', 'answers', leftId || index]));
+    } else if (!rightIdSet.has(rightId)) {
+      issues.push(issue('Matching answers must reference an existing right-column ID', ['data', 'answers', leftId]));
+    }
+  });
+  Object.keys(parsed.data.answers).forEach(leftId => {
+    if (!leftIdSet.has(leftId)) {
+      issues.push(issue('Matching answers cannot reference an unknown left-column ID', ['data', 'answers', leftId]));
+    }
+  });
+  return issues;
+}
+
+function validateMultipleChoice(data: unknown): ActiveExerciseConfigurationIssue[] {
+  const parsed = multipleChoiceDataSchema.safeParse(data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+  const issues: ActiveExerciseConfigurationIssue[] = [];
+  if (!uniqueValues(parsed.data.options.map(option => option.id))) {
+    issues.push(issue('Multiple-choice option IDs must be unique', ['data', 'options']));
+  }
+  const correctCount = parsed.data.options.filter(option => option.isCorrect).length;
+  if (parsed.data.allowMultipleSelections ? correctCount === 0 : correctCount !== 1) {
+    issues.push(
+      issue(
+        parsed.data.allowMultipleSelections
+          ? 'Multiple-selection questions require at least one correct option'
+          : 'Single-selection questions require exactly one correct option',
+        ['data', 'options']
+      )
+    );
+  }
+  return issues;
+}
+
+function validateOddOneOut(data: unknown): ActiveExerciseConfigurationIssue[] {
+  const parsed = oddOneOutDataSchema.safeParse(data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+  const issues: ActiveExerciseConfigurationIssue[] = [];
+  if (!uniqueValues(parsed.data.items.map(item => item.id))) {
+    issues.push(issue('Odd-one-out item IDs must be unique', ['data', 'items']));
+  }
+  if (parsed.data.items.filter(item => item.isOddOneOut).length !== 1) {
+    issues.push(issue('Odd-one-out exercises require exactly one odd item', ['data', 'items']));
+  }
+  return issues;
+}
+
+function validateTableFill(data: unknown): ActiveExerciseConfigurationIssue[] {
+  const parsed = tableFillDataSchema.safeParse(data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+  const issues: ActiveExerciseConfigurationIssue[] = [];
+  const columnIds = parsed.data.columns.map(column => column.id);
+  const columnIdSet = new Set(columnIds);
+  if (!uniqueValues(columnIds)) issues.push(issue('Table column IDs must be unique', ['data', 'columns']));
+  if (!uniqueValues(parsed.data.rows.map(row => row.id))) {
+    issues.push(issue('Table row IDs must be unique', ['data', 'rows']));
+  }
+
+  let blankCount = 0;
+  parsed.data.rows.forEach((row, rowIndex) => {
+    columnIds.forEach(columnId => {
+      const cell = row.cells[columnId];
+      if (!cell) {
+        issues.push(
+          issue('Every row must contain a cell for every column', ['data', 'rows', rowIndex, 'cells', columnId])
+        );
+        return;
+      }
+      if (cell.isBlank) {
+        blankCount += 1;
+        if (!cell.answer?.trim()) {
+          issues.push(
+            issue('Every blank table cell requires a nonblank answer', [
+              'data',
+              'rows',
+              rowIndex,
+              'cells',
+              columnId,
+              'answer',
+            ])
+          );
+        }
+      }
+    });
+    Object.keys(row.cells).forEach(columnId => {
+      if (!columnIdSet.has(columnId)) {
+        issues.push(
+          issue('Table rows cannot contain cells for unknown columns', ['data', 'rows', rowIndex, 'cells', columnId])
+        );
+      }
+    });
+  });
+  if (blankCount === 0) issues.push(issue('Table-fill exercises require at least one blank cell', ['data', 'rows']));
+  return issues;
+}
+
+function validateClick(data: unknown): ActiveExerciseConfigurationIssue[] {
+  const parsed = clickDataSchema.safeParse(data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+  const issues: ActiveExerciseConfigurationIssue[] = [];
+  const indices = parsed.data.correctWordIndices;
+  if (!uniqueValues(indices.map(String))) {
+    issues.push(issue('Target word indices must be unique', ['data', 'correctWordIndices']));
+  }
+  const wordCount = visibleWordCount(parsed.data.passage);
+  indices.forEach((wordIndex, index) => {
+    if (wordIndex >= wordCount) {
+      issues.push(issue('Target word index is outside the passage', ['data', 'correctWordIndices', index]));
+    }
+  });
+  if (parsed.data.minimumCorrect !== undefined && parsed.data.minimumCorrect > new Set(indices).size) {
+    issues.push(issue('minimumCorrect cannot exceed the number of target words', ['data', 'minimumCorrect']));
+  }
+  return issues;
+}
+
+function validateTextSelection(data: unknown): ActiveExerciseConfigurationIssue[] {
+  const parsed = textSelectionDataSchema.safeParse(data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+  const issues: ActiveExerciseConfigurationIssue[] = [];
+  if (!uniqueValues(parsed.data.questions.map(question => question.id))) {
+    issues.push(issue('Text-selection question IDs must be unique', ['data', 'questions']));
+  }
+  const wordCount = visibleWordCount(parsed.data.passage);
+  parsed.data.questions.forEach((question, index) => {
+    if (question.correctWordIndex >= wordCount) {
+      issues.push(issue('Correct word index is outside the passage', ['data', 'questions', index, 'correctWordIndex']));
+    }
+  });
+  return issues;
+}
+
+function validateFillEmbolded(data: unknown): ActiveExerciseConfigurationIssue[] {
+  const parsed = fillEmboldedDataSchema.safeParse(data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+  const issues: ActiveExerciseConfigurationIssue[] = [];
+  const wordIndices = parsed.data.words.map(word => word.wordIndex);
+  if (!uniqueValues(wordIndices.map(String))) {
+    issues.push(issue('Emboldened word indices must be unique', ['data', 'words']));
+  }
+  const wordCount = rawWhitespaceWordCount(parsed.data.passage);
+  parsed.data.words.forEach((word, index) => {
+    if (word.wordIndex >= wordCount) {
+      issues.push(issue('Emboldened word index is outside the passage', ['data', 'words', index, 'wordIndex']));
+    }
+  });
+  return issues;
+}
+
+function validateGeneratorConfig(config: z.infer<typeof generatorConfigSchema>): ActiveExerciseConfigurationIssue[] {
+  if (config.wordSource === 'pool' && !config.poolId) {
+    return [issue('Pool-backed generated exercises require a vocabulary pool', ['data', 'generatorConfig', 'poolId'])];
+  }
+  return [];
+}
+
+function validateGeneratedTranslation(item: Record<string, unknown>): ActiveExerciseConfigurationIssue[] {
+  const parsed = generatedTranslationDataSchema.safeParse(item.data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+  const issues = validateGeneratorConfig(parsed.data.generatorConfig);
+  if (
+    item.translationDirection !== undefined &&
+    !['latin-to-english', 'english-to-latin'].includes(String(item.translationDirection))
+  ) {
+    issues.push(issue('Unknown translation direction', ['translationDirection']));
+  }
+  const effectivePosConfigs = Object.keys(parsed.data.posConfigs).length
+    ? parsed.data.posConfigs
+    : buildLegacyPosConfigs(parsed.data.generatorConfig as GeneratorConfigBase);
+  const activePosConfigs = Object.entries(effectivePosConfigs).filter(([, config]) => config?.enabled);
+  const validPartOfSpeech = new Set([
+    'noun',
+    'verb',
+    'pronoun',
+    'adjective',
+    'adverb',
+    'preposition',
+    'conjunction',
+    'interjection',
+  ]);
+  activePosConfigs.forEach(([partOfSpeech]) => {
+    if (!validPartOfSpeech.has(partOfSpeech)) {
+      issues.push(issue('Unknown generated-translation part of speech', ['data', 'posConfigs', partOfSpeech]));
+    }
+  });
+  if (parsed.data.generatorConfig.wordSource === 'filters' && activePosConfigs.length === 0) {
+    issues.push(
+      issue('Filter-backed generated translations require at least one enabled part of speech', ['data', 'posConfigs'])
+    );
+  }
+  return issues;
+}
+
+function validateGeneratedForm(data: unknown): ActiveExerciseConfigurationIssue[] {
+  const parsed = generatedFormDataSchema.safeParse(data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+  const issues = validateGeneratorConfig(parsed.data.generatorConfig);
+  const paradigmConfigs = Object.keys(parsed.data.paradigmConfigs).length
+    ? parsed.data.paradigmConfigs
+    : buildLegacyParadigmConfigs(parsed.data.generatorConfig as GeneratorConfigBase);
+  const validParadigms = new Set(Object.keys(PARADIGM_AVAILABLE_STEPS));
+  const activeParadigms = Object.entries(paradigmConfigs).filter(([, config]) => config?.enabled);
+
+  Object.entries(paradigmConfigs).forEach(([paradigm, config]) => {
+    if (!config) return;
+    if (!validParadigms.has(paradigm)) {
+      issues.push(issue('Unknown morphology paradigm', ['data', 'paradigmConfigs', paradigm]));
+      return;
+    }
+    if (!config.enabled) return;
+    if (config.steps.length === 0) {
+      issues.push(
+        issue('Enabled morphology paradigms require at least one scoring step', [
+          'data',
+          'paradigmConfigs',
+          paradigm,
+          'steps',
+        ])
+      );
+    } else if (!uniqueValues(config.steps)) {
+      issues.push(issue('Morphology scoring steps must be unique', ['data', 'paradigmConfigs', paradigm, 'steps']));
+    }
+    const availableSteps = PARADIGM_AVAILABLE_STEPS[paradigm as keyof typeof PARADIGM_AVAILABLE_STEPS];
+    config.steps.forEach((step: FormIdentificationStep, index: number) => {
+      if (!availableSteps.includes(step)) {
+        issues.push(
+          issue('Scoring step is not supported by this morphology paradigm', [
+            'data',
+            'paradigmConfigs',
+            paradigm,
+            'steps',
+            index,
+          ])
+        );
+      }
+    });
+    if (!config.formSelection?.selectedCellPaths.length) {
+      issues.push(
+        issue('Enabled morphology paradigms require at least one selected form', [
+          'data',
+          'paradigmConfigs',
+          paradigm,
+          'formSelection',
+          'selectedCellPaths',
+        ])
+      );
+    }
+  });
+
+  if (activeParadigms.length === 0) {
+    issues.push(issue('Morphology exercises require at least one enabled paradigm', ['data', 'paradigmConfigs']));
+  }
+  return issues;
+}
+
+function validateSentenceDiagram(data: unknown): ActiveExerciseConfigurationIssue[] {
+  const parsed = sentenceDiagramDataSchema.safeParse(data);
+  if (!parsed.success) return zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+  return validateSentenceDiagramDocument(parsed.data as SentenceDiagramDocument).map(entry => ({
+    message: entry.message,
+    path: parseDiagramIssuePath(entry.path),
+  }));
+}
+
+/**
+ * Validates answer-key and denominator invariants before an exercise can be
+ * persisted in an active test version. Drafts deliberately do not call this
+ * validator so partially authored exercises remain saveable.
+ */
+export function validateActiveTestExerciseConfiguration(
+  item: Record<string, unknown>
+): ActiveExerciseConfigurationIssue[] {
+  switch (item.type) {
+    case 'matching':
+      return validateMatching(item.data);
+    case 'multiple-choice':
+      return validateMultipleChoice(item.data);
+    case 'odd-one-out':
+      return validateOddOneOut(item.data);
+    case 'table-fill':
+      return validateTableFill(item.data);
+    case 'click-on-multiple-words':
+      return validateClick(item.data);
+    case 'fill': {
+      const parsed = fillDataSchema.safeParse(item.data);
+      return parsed.success ? [] : zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+    }
+    case 'text-selection':
+      return validateTextSelection(item.data);
+    case 'fill-embolded-text':
+      return validateFillEmbolded(item.data);
+    case 'sentence-diagramming':
+      return validateSentenceDiagram(item.data);
+    case 'generated-translation':
+      return validateGeneratedTranslation(item);
+    case 'generated-form-identification':
+      return validateGeneratedForm(item.data);
+    case 'translation-grading': {
+      const parsed = translationGradingDataSchema.safeParse(item.data);
+      const issues = parsed.success
+        ? []
+        : zodIssues(parsed.error).map(entry => ({ ...entry, path: ['data', ...entry.path] }));
+      if (
+        item.translationDirection !== undefined &&
+        !['latin-to-english', 'english-to-latin'].includes(String(item.translationDirection))
+      ) {
+        issues.push(issue('Unknown translation direction', ['translationDirection']));
+      }
+      return issues;
+    }
+    default:
+      return [];
+  }
+}

--- a/src/lib/tests/attempt-service.ts
+++ b/src/lib/tests/attempt-service.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type { DocumentReference, DocumentSnapshot, Firestore, Transaction } from 'firebase-admin/firestore';
 import {
   DEFAULT_LEARNING_PATH_ID,
@@ -30,6 +30,8 @@ import type {
   TestAttemptResultSummary,
   TestAttemptSession,
   TestTranslationItemGrade,
+  TestTranslationGradeReservations,
+  TestTranslationGradeRequestWindows,
   TestVersion,
 } from '@/src/types/test';
 import { isAnswerForExercise, parseExerciseAnswer } from './answer-schemas';
@@ -52,11 +54,9 @@ import { TestServiceError } from './errors';
 import { estimateFirestoreDocumentBytes } from './firestore-size';
 import type { GeneratedWordLoader } from './generated-exercises';
 import { createFirestoreGeneratedWordLoader } from './generated-word-loader.server';
+import { createFirestoreVocabularyPoolLoader, type VocabularyPoolLoader } from './vocabulary-pool-loader.server';
 import {
-  createFirestoreVocabularyPoolLoader,
-  type VocabularyPoolLoader,
-} from './vocabulary-pool-loader.server';
-import {
+  assertVersionReadyForStudentVisibility,
   configurationError,
   parseMockSnapshot,
   parseTestSnapshot,
@@ -84,6 +84,11 @@ export const MAX_TEST_ATTEMPT_DOCUMENT_BYTES = 900 * 1024;
  * remaining orders of magnitude below the smallest meaningful score gap.
  */
 export const PASSING_THRESHOLD_TOLERANCE = 1e-9;
+
+/** Longer than the route timeout, while still making a crashed grading request recoverable. */
+export const TRANSLATION_GRADING_RESERVATION_MS = 5 * 60 * 1000;
+export const TRANSLATION_GRADING_REQUEST_WINDOW_MS = 10 * 60 * 1000;
+export const MAX_TRANSLATION_GRADING_REQUESTS_PER_WINDOW = 5;
 
 type TestTranslationGrader = (request: TranslationGradingRequest) => Promise<TestTranslationGradingOutput>;
 
@@ -146,12 +151,36 @@ function toStudentAttempt(attempt: TestAttempt): StudentTestAttempt {
     return studentAttempt;
   }
 
-  const { studentId: _studentId, deliveryState, ...studentAttempt } = attempt;
+  const {
+    studentId: _studentId,
+    deliveryState,
+    translationGradeReservations: _translationGradeReservations,
+    translationGradeRequestWindows: _translationGradeRequestWindows,
+    ...studentAttempt
+  } = attempt;
   return {
     ...studentAttempt,
     delivery: sanitizeTestDeliveryState(deliveryState as FrozenTestDeliveryState),
   };
 }
+
+const translationReservationIsActive = (expiresAt: string, now: string) => Date.parse(expiresAt) > Date.parse(now);
+
+function withoutTranslationGradeReservation(
+  reservations: TestTranslationGradeReservations,
+  exerciseId: string,
+  itemIndex: number
+): TestTranslationGradeReservations {
+  const exerciseReservations = { ...reservations[exerciseId] };
+  delete exerciseReservations[String(itemIndex)];
+  const updated = { ...reservations };
+  if (Object.keys(exerciseReservations).length === 0) delete updated[exerciseId];
+  else updated[exerciseId] = exerciseReservations;
+  return updated;
+}
+
+const translationRequestWindowIsActive = (windowStartedAt: string, now: string) =>
+  Date.parse(windowStartedAt) + TRANSLATION_GRADING_REQUEST_WINDOW_MS > Date.parse(now);
 
 function assertAttemptOwner(attempt: TestAttempt, studentId: string) {
   if (attempt.studentId !== studentId) {
@@ -241,6 +270,37 @@ export class TestAttemptService {
       await this.assertNormalTestUnlocked(transaction, studentId, attempt.origin.testId, true);
     }
     return attempt;
+  }
+
+  private async releaseTranslationGradeReservation(
+    attemptRef: DocumentReference,
+    studentId: string,
+    request: GradeTestTranslationInput,
+    reservationToken: string
+  ): Promise<void> {
+    try {
+      await this.db.runTransaction(async transaction => {
+        const snapshot = await transaction.get(attemptRef);
+        if (!snapshot.exists) return;
+        const attempt = parseAttemptSnapshot(snapshot);
+        if (attempt.status !== 'in-progress' || attempt.studentId !== studentId) return;
+        const reservation = attempt.translationGradeReservations[request.exerciseId]?.[String(request.itemIndex)];
+        if (!reservation || reservation.token !== reservationToken) return;
+
+        const updated = testAttemptDocumentSchema.parse({
+          ...attempt,
+          translationGradeReservations: withoutTranslationGradeReservation(
+            attempt.translationGradeReservations,
+            request.exerciseId,
+            request.itemIndex
+          ),
+        }) as InProgressTestAttempt;
+        transaction.set(attemptRef, updated);
+      });
+    } catch (error) {
+      // The lease expires automatically if cleanup itself is interrupted.
+      console.error(`Could not release translation grading reservation for attempt ${attemptRef.id}`, error);
+    }
   }
 
   private submittedAttemptsQuery(studentId: string, origin: TestAttemptOrigin) {
@@ -472,13 +532,10 @@ export class TestAttemptService {
       }
 
       const { version, passingPercentage } = await this.resolveAttemptVersion(transaction, studentId, origin);
+      assertVersionReadyForStudentVisibility(version);
       let deliveryState: FrozenTestDeliveryState;
       try {
-        deliveryState = await createFrozenTestDeliveryState(
-          version,
-          this.loadGeneratedWords,
-          this.loadVocabularyPool
-        );
+        deliveryState = await createFrozenTestDeliveryState(version, this.loadGeneratedWords, this.loadVocabularyPool);
       } catch (error) {
         throw configurationError(
           `Could not resolve frozen delivery for ${origin.kind}:${originId(origin)} version ${version.id}`,
@@ -498,6 +555,8 @@ export class TestAttemptService {
           status: 'in-progress',
           answers: {},
           translationGrades: {},
+          translationGradeReservations: {},
+          translationGradeRequestWindows: {},
           deliveryState,
           startedAt: timestamp,
           updatedAt: timestamp,
@@ -537,9 +596,16 @@ export class TestAttemptService {
       const translationGrades = Object.fromEntries(
         Object.entries(attempt.translationGrades).map(([exerciseId, grades]) => [exerciseId, { ...grades }])
       );
+      const translationGradeReservations = Object.fromEntries(
+        Object.entries(attempt.translationGradeReservations).map(([exerciseId, reservations]) => [
+          exerciseId,
+          { ...reservations },
+        ])
+      );
       const itemsById = new Map(
         attempt.deliveryState.pages.flatMap(page => page.items).map(item => [item.id, item] as const)
       );
+      const timestamp = this.now();
 
       for (const [exerciseId, rawAnswer] of Object.entries(changes.answers)) {
         const item = itemsById.get(exerciseId);
@@ -549,6 +615,27 @@ export class TestAttemptService {
             'An answer does not belong to an exercise in this attempt',
             400
           );
+        }
+        if (item.type === 'translation-grading') {
+          if (Object.keys(translationGrades[exerciseId] ?? {}).length > 0) {
+            throw new TestServiceError(
+              'ATTEMPT_TRANSLATION_ALREADY_GRADED',
+              'A graded translation answer is final for this attempt',
+              409
+            );
+          }
+          const activeReservation = Object.values(translationGradeReservations[exerciseId] ?? {}).some(reservation =>
+            translationReservationIsActive(reservation.expiresAt, timestamp)
+          );
+          if (activeReservation) {
+            throw new TestServiceError(
+              'ATTEMPT_TRANSLATION_GRADING_IN_PROGRESS',
+              'This translation is already being graded',
+              409
+            );
+          }
+          // An abandoned provider request must not permanently lock the answer.
+          delete translationGradeReservations[exerciseId];
         }
         if (rawAnswer === null) {
           delete answers[exerciseId];
@@ -573,7 +660,8 @@ export class TestAttemptService {
         ...attempt,
         answers,
         translationGrades,
-        updatedAt: this.now(),
+        translationGradeReservations,
+        updatedAt: timestamp,
       }) as InProgressTestAttempt;
       this.assertAttemptDocumentSize(updated);
       transaction.set(attemptRef, updated);
@@ -588,23 +676,97 @@ export class TestAttemptService {
   ): Promise<StudentInProgressTestAttempt> {
     const request = gradeTestTranslationInputSchema.parse(input);
     const attemptRef = this.attempts.doc(attemptId);
+    const reservationToken = randomUUID();
 
-    const gradingRequest = await this.db.runTransaction(async transaction => {
+    const preparation = await this.db.runTransaction(async transaction => {
       const attempt = await this.getOwnedInProgressAttempt(transaction, attemptRef, studentId);
       const { exercise, item } = getTranslationExerciseItem(attempt, request);
+      const existingGrade = attempt.translationGrades[request.exerciseId]?.[String(request.itemIndex)];
+      if (existingGrade) {
+        if (existingGrade.translation !== request.userTranslation) {
+          throw new TestServiceError(
+            'ATTEMPT_TRANSLATION_ALREADY_GRADED',
+            'This translation item has already been graded with a different answer',
+            409
+          );
+        }
+        return {
+          kind: 'existing' as const,
+          attempt: toStudentAttempt(attempt) as StudentInProgressTestAttempt,
+        };
+      }
+
+      const timestamp = this.now();
+      const existingReservation = attempt.translationGradeReservations[request.exerciseId]?.[String(request.itemIndex)];
+      if (existingReservation && translationReservationIsActive(existingReservation.expiresAt, timestamp)) {
+        throw new TestServiceError(
+          'ATTEMPT_TRANSLATION_GRADING_IN_PROGRESS',
+          'This translation is already being graded',
+          409
+        );
+      }
+
+      const existingRequestWindow =
+        attempt.translationGradeRequestWindows[request.exerciseId]?.[String(request.itemIndex)];
+      const requestWindowActive =
+        existingRequestWindow && translationRequestWindowIsActive(existingRequestWindow.windowStartedAt, timestamp);
+      if (requestWindowActive && existingRequestWindow.count >= MAX_TRANSLATION_GRADING_REQUESTS_PER_WINDOW) {
+        throw new TestServiceError(
+          'ATTEMPT_TRANSLATION_GRADING_RATE_LIMITED',
+          'Too many translation grading requests. Please try again after the grading window resets.',
+          429
+        );
+      }
+
+      const exerciseRequestWindows = {
+        ...attempt.translationGradeRequestWindows[request.exerciseId],
+        [String(request.itemIndex)]: requestWindowActive
+          ? { ...existingRequestWindow, count: existingRequestWindow.count + 1 }
+          : { windowStartedAt: timestamp, count: 1 },
+      };
+      const translationGradeRequestWindows: TestTranslationGradeRequestWindows = {
+        ...attempt.translationGradeRequestWindows,
+        [request.exerciseId]: exerciseRequestWindows,
+      };
+
+      const exerciseReservations = {
+        ...attempt.translationGradeReservations[request.exerciseId],
+        [String(request.itemIndex)]: {
+          token: reservationToken,
+          expiresAt: new Date(Date.parse(timestamp) + TRANSLATION_GRADING_RESERVATION_MS).toISOString(),
+        },
+      };
+      const reservedAttempt = testAttemptDocumentSchema.parse({
+        ...attempt,
+        translationGradeReservations: {
+          ...attempt.translationGradeReservations,
+          [request.exerciseId]: exerciseReservations,
+        },
+        translationGradeRequestWindows,
+      }) as InProgressTestAttempt;
+      this.assertAttemptDocumentSize(reservedAttempt);
+      transaction.set(attemptRef, reservedAttempt);
 
       return {
-        sourceText: richTextToPlainText(item.latinText),
-        userTranslation: request.userTranslation,
-        direction: exercise.translationDirection ?? 'latin-to-english',
-      } satisfies TranslationGradingRequest;
+        kind: 'reserved' as const,
+        gradingRequest: {
+          sourceText: richTextToPlainText(item.latinText),
+          userTranslation: request.userTranslation,
+          direction: exercise.translationDirection ?? 'latin-to-english',
+        } satisfies TranslationGradingRequest,
+      };
     });
+
+    if (preparation.kind === 'existing') return preparation.attempt;
 
     let gradingOutput: TestTranslationGradingOutput;
     try {
-      gradingOutput = testTranslationGradingOutputSchema.parse(await this.gradeTestTranslation(gradingRequest));
+      gradingOutput = testTranslationGradingOutputSchema.parse(
+        await this.gradeTestTranslation(preparation.gradingRequest)
+      );
     } catch (error) {
       console.error(`Could not grade translation item for attempt ${attemptId}`, error);
+      await this.releaseTranslationGradeReservation(attemptRef, studentId, request, reservationToken);
       throw new TestServiceError(
         'ATTEMPT_GRADING_UNAVAILABLE',
         'Translation grading is temporarily unavailable. Please try checking the translation again.',
@@ -612,45 +774,63 @@ export class TestAttemptService {
       );
     }
 
-    return this.db.runTransaction(async transaction => {
-      const attempt = await this.getOwnedInProgressAttempt(transaction, attemptRef, studentId);
-      const { exercise } = getTranslationExerciseItem(attempt, request);
+    try {
+      return await this.db.runTransaction(async transaction => {
+        const attempt = await this.getOwnedInProgressAttempt(transaction, attemptRef, studentId);
+        const { exercise } = getTranslationExerciseItem(attempt, request);
+        const reservation = attempt.translationGradeReservations[request.exerciseId]?.[String(request.itemIndex)];
+        if (!reservation || reservation.token !== reservationToken) {
+          throw new TestServiceError(
+            'ATTEMPT_TRANSLATION_GRADING_IN_PROGRESS',
+            'This translation grading request no longer owns the item reservation',
+            409
+          );
+        }
 
-      const existingAnswer = attempt.answers[request.exerciseId];
-      const parsedExistingAnswer = existingAnswer === undefined ? null : parseExerciseAnswer(existingAnswer);
-      if (parsedExistingAnswer && parsedExistingAnswer.type !== 'translation-grading') {
-        throw new TestServiceError('ATTEMPT_ANSWER_INVALID', 'The saved translation answer has an invalid type', 400);
-      }
-      const translations = Array.from(
-        { length: exercise.data.items.length },
-        (_, index) => parsedExistingAnswer?.translations[index] ?? ''
-      );
-      translations[request.itemIndex] = request.userTranslation;
-      const grade: TestTranslationItemGrade = {
-        translation: request.userTranslation,
-        score: gradingOutput.score,
-        feedback: gradingOutput.feedback,
-      };
-      const updated = testAttemptDocumentSchema.parse({
-        ...attempt,
-        answers: {
-          ...attempt.answers,
-          [request.exerciseId]: { type: 'translation-grading', translations },
-        },
-        translationGrades: {
-          ...attempt.translationGrades,
-          [request.exerciseId]: {
-            ...attempt.translationGrades[request.exerciseId],
-            [String(request.itemIndex)]: grade,
+        const existingAnswer = attempt.answers[request.exerciseId];
+        const parsedExistingAnswer = existingAnswer === undefined ? null : parseExerciseAnswer(existingAnswer);
+        if (parsedExistingAnswer && parsedExistingAnswer.type !== 'translation-grading') {
+          throw new TestServiceError('ATTEMPT_ANSWER_INVALID', 'The saved translation answer has an invalid type', 400);
+        }
+        const translations = Array.from(
+          { length: exercise.data.items.length },
+          (_, index) => parsedExistingAnswer?.translations[index] ?? ''
+        );
+        translations[request.itemIndex] = request.userTranslation;
+        const grade: TestTranslationItemGrade = {
+          translation: request.userTranslation,
+          score: gradingOutput.score,
+          feedback: gradingOutput.feedback,
+        };
+        const updated = testAttemptDocumentSchema.parse({
+          ...attempt,
+          answers: {
+            ...attempt.answers,
+            [request.exerciseId]: { type: 'translation-grading', translations },
           },
-        },
-        updatedAt: this.now(),
-      }) as InProgressTestAttempt;
-      this.assertAttemptDocumentSize(updated);
-      transaction.set(attemptRef, updated);
+          translationGrades: {
+            ...attempt.translationGrades,
+            [request.exerciseId]: {
+              ...attempt.translationGrades[request.exerciseId],
+              [String(request.itemIndex)]: grade,
+            },
+          },
+          translationGradeReservations: withoutTranslationGradeReservation(
+            attempt.translationGradeReservations,
+            request.exerciseId,
+            request.itemIndex
+          ),
+          updatedAt: this.now(),
+        }) as InProgressTestAttempt;
+        this.assertAttemptDocumentSize(updated);
+        transaction.set(attemptRef, updated);
 
-      return toStudentAttempt(updated) as StudentInProgressTestAttempt;
-    });
+        return toStudentAttempt(updated) as StudentInProgressTestAttempt;
+      });
+    } catch (error) {
+      await this.releaseTranslationGradeReservation(attemptRef, studentId, request, reservationToken);
+      throw error;
+    }
   }
 
   async submitAttempt(attemptId: string, studentId: string): Promise<SubmitTestAttemptResult> {
@@ -661,6 +841,19 @@ export class TestAttemptService {
       assertAttemptOwner(attempt, studentId);
       if (attempt.status === 'submitted') {
         return { attempt: toStudentAttempt(attempt) as StudentSubmittedTestAttempt, completionGranted: false };
+      }
+      const gradingTimestamp = this.now();
+      const translationGradingInProgress = Object.values(attempt.translationGradeReservations).some(reservations =>
+        Object.values(reservations).some(reservation =>
+          translationReservationIsActive(reservation.expiresAt, gradingTimestamp)
+        )
+      );
+      if (translationGradingInProgress) {
+        throw new TestServiceError(
+          'ATTEMPT_TRANSLATION_GRADING_IN_PROGRESS',
+          'Wait for translation grading to finish before submitting this test',
+          409
+        );
       }
       if (attempt.origin.kind === 'normal-test') {
         await this.assertNormalTestUnlocked(transaction, studentId, attempt.origin.testId, true);

--- a/src/lib/tests/authoring-service.ts
+++ b/src/lib/tests/authoring-service.ts
@@ -27,6 +27,7 @@ import {
   buildVersionDraft,
   buildVersion,
   getVersionSummaries,
+  isStoredVersionReadyForStudentVisibility,
   parseMockSnapshot,
   parseTestSnapshot,
   parseVersionDraftSnapshot,
@@ -512,6 +513,20 @@ export class TestAuthoringService {
           409
         );
       }
+      const remainingRotationVersions = test.rotationVersions.filter(reference => reference.versionId !== versionId);
+      if (placed) {
+        const remainingSnapshots = await Promise.all(
+          remainingRotationVersions.map(reference => transaction.get(this.versions.doc(reference.versionId)))
+        );
+        const invalid = remainingSnapshots.find(snapshot => !isStoredVersionReadyForStudentVisibility(snapshot));
+        if (invalid) {
+          throw new TestServiceError(
+            'PLACED_TEST_REQUIRES_ROTATION_VERSION',
+            `A test in the Learning Path cannot retain missing or invalid rotation version ${invalid.id}.`,
+            409
+          );
+        }
+      }
       const draft = this.buildVersionDraft(
         testId,
         testVersionDraftInputSchema.parse({
@@ -525,7 +540,7 @@ export class TestAuthoringService {
       );
       const updatedTest = testUnitSchema.parse({
         ...test,
-        rotationVersions: test.rotationVersions.filter(reference => reference.versionId !== versionId),
+        rotationVersions: remainingRotationVersions,
         updatedAt: this.now(),
         updatedBy: actorId,
       }) as TestUnit;

--- a/src/lib/tests/errors.ts
+++ b/src/lib/tests/errors.ts
@@ -13,6 +13,9 @@ export type TestServiceErrorCode =
   | 'ATTEMPT_NOT_FOUND'
   | 'ATTEMPT_NOT_IN_PROGRESS'
   | 'ATTEMPT_ANSWER_INVALID'
+  | 'ATTEMPT_TRANSLATION_ALREADY_GRADED'
+  | 'ATTEMPT_TRANSLATION_GRADING_IN_PROGRESS'
+  | 'ATTEMPT_TRANSLATION_GRADING_RATE_LIMITED'
   | 'ATTEMPT_GRADING_UNAVAILABLE'
   | 'ATTEMPT_TOO_LARGE'
   | 'STALE_TEST_ATTEMPT_DATA'
@@ -25,7 +28,7 @@ export class TestServiceError extends Error {
   constructor(
     public readonly code: TestServiceErrorCode,
     message: string,
-    public readonly status: 400 | 404 | 409 | 422 | 503
+    public readonly status: 400 | 404 | 409 | 422 | 429 | 503
   ) {
     super(message);
     this.name = 'TestServiceError';

--- a/src/lib/tests/formatting.ts
+++ b/src/lib/tests/formatting.ts
@@ -1,0 +1,23 @@
+const DISPLAY_PERCENTAGE_DECIMALS = 2;
+const DISPLAY_PERCENTAGE_SCALE = 10 ** DISPLAY_PERCENTAGE_DECIMALS;
+
+/**
+ * Formats an assessment percentage without rounding a failing value up to a
+ * passing threshold. Scores are non-negative, so flooring preserves an honest
+ * student-facing representation while still hiding floating-point noise.
+ */
+export function formatScorePercentage(value: number): string {
+  if (!Number.isFinite(value)) return '0';
+
+  const bounded = Math.max(0, Math.min(100, value));
+  const floored = Math.floor(bounded * DISPLAY_PERCENTAGE_SCALE + 1e-9) / DISPLAY_PERCENTAGE_SCALE;
+  return floored
+    .toFixed(DISPLAY_PERCENTAGE_DECIMALS)
+    .replace(/\.00$/, '')
+    .replace(/(\.\d)0$/, '$1');
+}
+
+export function formatScoreShortfall(value: number): string {
+  if (Number.isFinite(value) && value > 0 && value < 0.01) return '<0.01';
+  return formatScorePercentage(value);
+}

--- a/src/lib/tests/grading.ts
+++ b/src/lib/tests/grading.ts
@@ -64,7 +64,10 @@ export function gradeMatching(
   maxPoints = maxPointsFor(exercise)
 ): ExerciseScore {
   const expected = Object.entries(exercise.data.answers);
-  const requiredRounds = exercise.data.requiredRepetitions || 1;
+  const requiredRounds = exercise.data.requiredRepetitions ?? 1;
+  if (!Number.isInteger(requiredRounds) || requiredRounds < 1 || requiredRounds > 10) {
+    throw new Error(`Matching exercise ${exercise.id} has invalid requiredRepetitions`);
+  }
   let correct = 0;
 
   for (let roundIndex = 0; roundIndex < requiredRounds; roundIndex += 1) {

--- a/src/lib/tests/mock-service.ts
+++ b/src/lib/tests/mock-service.ts
@@ -27,9 +27,11 @@ import { runVocabularyContentMutation } from '@/src/lib/vocabulary-pools/sync-lo
 import { TestAttemptService } from './attempt-service';
 import { TestServiceError } from './errors';
 import {
+  assertVersionReadyForStudentVisibility,
   buildVersion,
   configurationError,
   getVersionSummaries,
+  isStoredVersionReadyForStudentVisibility,
   parseMockSnapshot,
   parseTestSnapshot,
   parseVersionSnapshot,
@@ -42,7 +44,6 @@ import {
   moveStandaloneMockToTestInputSchema,
   reactivateStandaloneMockInputSchema,
   reorderMockTestsInputSchema,
-  testVersionDocumentSchema,
   updateMockTestInputSchema,
   updateTestVersionInputSchema,
   type AssignVersionToMockInput,
@@ -161,11 +162,10 @@ export class MockTestService {
       );
     }
     if (parsed.data.unitIds.includes(test.id)) {
-      const snapshots = await transaction.getAll(...rotationVersionIds.map(versionId => this.versions.doc(versionId)));
-      const invalid = snapshots.find(
-        snapshot =>
-          !snapshot.exists || !testVersionDocumentSchema.safeParse({ ...snapshot.data(), id: snapshot.id }).success
+      const snapshots = await Promise.all(
+        rotationVersionIds.map(versionId => transaction.get(this.versions.doc(versionId)))
       );
+      const invalid = snapshots.find(snapshot => !isStoredVersionReadyForStudentVisibility(snapshot));
       if (invalid) {
         throw new TestServiceError(
           'PLACED_TEST_REQUIRES_ROTATION_VERSION',
@@ -238,7 +238,7 @@ export class MockTestService {
       transaction.get(this.db.collection('lessons').where('kind', '==', 'test')),
       transaction.get(this.mocks.where('status', '==', 'active')),
     ]);
-    parseVersionSnapshot(versionSnapshot);
+    const version = parseVersionSnapshot(versionSnapshot);
     for (const snapshot of testSnapshots.docs) {
       const test = parseTestSnapshot(snapshot);
       if (test.rotationVersions.some(reference => reference.versionId === versionId) && test.id !== targetTestId) {
@@ -260,6 +260,7 @@ export class MockTestService {
         );
       }
     }
+    return version;
   }
 
   private buildMock(
@@ -432,7 +433,7 @@ export class MockTestService {
         transaction.get(mockRef),
       ]);
       const test = parseTestSnapshot(testSnapshot);
-      parseVersionSnapshot(versionSnapshot);
+      const version = parseVersionSnapshot(versionSnapshot);
       const existing = priorMock.exists ? parseMockSnapshot(priorMock) : undefined;
       if (
         existing &&
@@ -446,6 +447,7 @@ export class MockTestService {
       if (!inRotation && !existing)
         throw new TestServiceError('TEST_VERSION_NOT_IN_TEST', 'Test version is not assigned to this test', 409);
       await this.assertVersionClaim(transaction, parsed.versionId, parsed.testId, mockRef.id);
+      assertVersionReadyForStudentVisibility(version);
       const remainingRotationIds = test.rotationVersions
         .filter(reference => reference.versionId !== parsed.versionId)
         .map(reference => reference.versionId);
@@ -498,7 +500,8 @@ export class MockTestService {
       let parent: TestUnit | undefined;
       if (mock.parent.kind === 'test')
         parent = parseTestSnapshot(await transaction.get(this.units.doc(mock.parent.testId)));
-      await this.assertVersionClaim(transaction, mock.versionId, parent?.id, mock.id);
+      const version = await this.assertVersionClaim(transaction, mock.versionId, parent?.id, mock.id);
+      if (parent) assertVersionReadyForStudentVisibility(version);
       const archived = this.buildMock({ ...mock, status: 'archived', isLive: false, mockOrder: null }, actorId, mock);
       const liveScope = await this.readLiveMockOrderScope(transaction);
       transaction.set(mockRef, archived);
@@ -535,7 +538,8 @@ export class MockTestService {
         );
       }
       if (mock.status === 'active') return mock;
-      await this.assertVersionClaim(transaction, mock.versionId, undefined, mock.id);
+      const version = await this.assertVersionClaim(transaction, mock.versionId, undefined, mock.id);
+      assertVersionReadyForStudentVisibility(version);
       const reactivated = this.buildMock(
         {
           ...mock,
@@ -567,7 +571,8 @@ export class MockTestService {
           'Only an active standalone mock can be moved to normal rotation',
           409
         );
-      await this.assertVersionClaim(transaction, mock.versionId, test.id, mock.id);
+      const version = await this.assertVersionClaim(transaction, mock.versionId, test.id, mock.id);
+      assertVersionReadyForStudentVisibility(version);
       if (test.rotationVersions.some(reference => reference.versionId === mock.versionId))
         throw new TestServiceError('VERSION_ALREADY_ASSIGNED', 'Version is already in this test rotation', 409);
       const archived = this.buildMock({ ...mock, status: 'archived', isLive: false, mockOrder: null }, actorId, mock);
@@ -672,7 +677,8 @@ export class MockTestService {
           409
         );
       const isLive = changes.isLive ?? current.isLive;
-      await this.assertVersionClaim(transaction, current.versionId, undefined, current.id);
+      const version = await this.assertVersionClaim(transaction, current.versionId, undefined, current.id);
+      if (!current.isLive && isLive) assertVersionReadyForStudentVisibility(version);
       const updated = this.buildMock(
         {
           ...current,

--- a/src/lib/tests/persistence.ts
+++ b/src/lib/tests/persistence.ts
@@ -16,6 +16,7 @@ import {
   testVersionDraftDocumentSchema,
   testVersionDraftSummaryDocumentSchema,
   testVersionDocumentSchema,
+  testVersionInputSchema,
   testVersionSummaryDocumentSchema,
   type TestVersionDraftInput,
   type TestVersionInput,
@@ -122,6 +123,39 @@ export function configurationError(message: string, error?: unknown): TestServic
   );
 }
 
+/**
+ * Legacy active documents remain readable, but any transition that newly
+ * exposes one to students must satisfy the current authoring invariants.
+ */
+export function safeParseVersionForStudentVisibility(version: TestVersion) {
+  return testVersionInputSchema.safeParse({
+    id: version.id,
+    name: version.name,
+    pages: version.pages,
+    vocabularyPoolId: version.vocabularyPoolId,
+  });
+}
+
+export function isStoredVersionReadyForStudentVisibility(snapshot: DocumentSnapshot): boolean {
+  if (!snapshot.exists) return false;
+  const parsed = testVersionDocumentSchema.safeParse({
+    ...snapshot.data(),
+    id: snapshot.id,
+  });
+  return parsed.success && safeParseVersionForStudentVisibility(parsed.data as TestVersion).success;
+}
+
+export function assertVersionReadyForStudentVisibility(version: TestVersion): TestVersion {
+  const parsed = safeParseVersionForStudentVisibility(version);
+  if (!parsed.success) {
+    throw configurationError(
+      `Test version ${version.id} cannot become student-visible because its exercise configuration is invalid`,
+      parsed.error.flatten()
+    );
+  }
+  return version;
+}
+
 export async function getVersionSummaries(db: Firestore, versionIds: readonly string[]): Promise<TestVersionSummary[]> {
   if (versionIds.length === 0) return [];
 
@@ -151,9 +185,10 @@ export function buildVersion(
   created?: Pick<TestVersion, 'createdAt' | 'createdBy'>
 ): TestVersion {
   const timestamp = now();
+  const parsedInput = testVersionInputSchema.parse(input);
   return testVersionDocumentSchema.parse({
-    ...input,
-    ...getTestVersionSummaryFields(input.pages),
+    ...parsedInput,
+    ...getTestVersionSummaryFields(parsedInput.pages),
     createdAt: created?.createdAt ?? timestamp,
     createdBy: created?.createdBy ?? actorId,
     updatedAt: timestamp,

--- a/src/lib/tests/schemas.ts
+++ b/src/lib/tests/schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { isExerciseType, isKnownContentType, isTestEligibleExerciseType } from '@/src/lib/content/registry';
 import { firestoreDocumentIdSchema, pageSchema, passingPercentageSchema } from '@/src/lib/learning-units/schemas';
 import { validatePageDocumentIds } from '@/src/utils/lessonProgress';
+import { validateActiveTestExerciseConfiguration } from './active-exercise-validation';
 import { getTestVersionSummaryFields } from './domain';
 
 const optionalAuditFieldSchema = z.string().min(1).optional();
@@ -38,7 +39,8 @@ export const updateTestVersionDraftInputSchema = testVersionDraftInputSchema.omi
 
 function refineTestVersionContent(
   value: Pick<z.infer<typeof testVersionInputShapeSchema>, 'pages'>,
-  context: z.RefinementCtx
+  context: z.RefinementCtx,
+  options: { validateExerciseConfigurations?: boolean } = {}
 ) {
   for (const message of validatePageDocumentIds(value.pages, 'Test version')) {
     context.addIssue({ code: 'custom', message, path: ['pages'] });
@@ -83,6 +85,18 @@ function refineTestVersionContent(
           message: 'Test exercises require a positive whole-number maxPoints',
           path: [...path, 'maxPoints'],
         });
+      }
+
+      if (options.validateExerciseConfigurations !== false) {
+        for (const exerciseIssue of validateActiveTestExerciseConfiguration(
+          item as unknown as Record<string, unknown>
+        )) {
+          context.addIssue({
+            code: 'custom',
+            message: exerciseIssue.message,
+            path: [...path, ...exerciseIssue.path],
+          });
+        }
       }
     });
   });
@@ -132,7 +146,10 @@ const testVersionDocumentShapeSchema = z
 export const testVersionSummaryDocumentSchema = testVersionDocumentShapeSchema.omit({ pages: true });
 
 export const testVersionDocumentSchema = testVersionDocumentShapeSchema.superRefine((value, context) => {
-  refineTestVersionContent(value, context);
+  // Existing active versions remain readable for backward compatibility. All
+  // create, update, activation, and duplication paths pass through the strict
+  // input validator before a new active document is written.
+  refineTestVersionContent(value, context, { validateExerciseConfigurations: false });
   const derived = getTestVersionSummaryFields(value.pages);
 
   (Object.keys(derived) as (keyof typeof derived)[]).forEach(field => {
@@ -320,12 +337,32 @@ const testTranslationItemGradeSchema = z
   })
   .strict();
 
+const testTranslationGradeReservationSchema = z
+  .object({
+    token: z.string().uuid(),
+    expiresAt: isoTimestampSchema,
+  })
+  .strict();
+
+const testTranslationGradeRequestWindowSchema = z
+  .object({
+    windowStartedAt: isoTimestampSchema,
+    count: z.number().int().positive().max(1_000),
+  })
+  .strict();
+
 const inProgressTestAttemptDocumentSchema = z
   .object({
     ...testAttemptBaseShape,
     status: z.literal('in-progress'),
     answers: z.record(z.string(), z.unknown()),
     translationGrades: z.record(z.string(), z.record(z.string(), testTranslationItemGradeSchema)).default({}),
+    translationGradeReservations: z
+      .record(z.string(), z.record(z.string(), testTranslationGradeReservationSchema))
+      .default({}),
+    translationGradeRequestWindows: z
+      .record(z.string(), z.record(z.string(), testTranslationGradeRequestWindowSchema))
+      .default({}),
     deliveryState: testAttemptDeliveryStateSchema,
   })
   .strict()

--- a/src/types/test.ts
+++ b/src/types/test.ts
@@ -85,10 +85,7 @@ export interface StudentMockTestSummary {
  * visibility change.
  */
 export interface StudentMockTestDetail {
-  mock: Pick<
-    MockTest,
-    'id' | 'title' | 'description' | 'passingPercentage' | 'status' | 'isLive'
-  >;
+  mock: Pick<MockTest, 'id' | 'title' | 'description' | 'passingPercentage' | 'status' | 'isLive'>;
   attempt: Omit<StudentInProgressTestAttempt, 'answers' | 'translationGrades'> | null;
 }
 
@@ -117,10 +114,28 @@ export interface TestTranslationItemGrade extends TestTranslationGradingOutput {
 
 export type TestTranslationGrades = Record<string, Record<string, TestTranslationItemGrade>>;
 
+export interface TestTranslationGradeReservation {
+  token: string;
+  expiresAt: string;
+}
+
+export type TestTranslationGradeReservations = Record<string, Record<string, TestTranslationGradeReservation>>;
+
+export interface TestTranslationGradeRequestWindow {
+  windowStartedAt: string;
+  count: number;
+}
+
+export type TestTranslationGradeRequestWindows = Record<string, Record<string, TestTranslationGradeRequestWindow>>;
+
 export interface InProgressTestAttempt extends TestAttemptBase {
   status: 'in-progress';
   answers: Record<string, ExerciseAnswer>;
   translationGrades: TestTranslationGrades;
+  /** Server-only leases preventing concurrent AI grading of the same item. */
+  translationGradeReservations: TestTranslationGradeReservations;
+  /** Server-only fixed-window provider invocation budgets. */
+  translationGradeRequestWindows: TestTranslationGradeRequestWindows;
   deliveryState: TestAttemptDeliveryState;
 }
 
@@ -158,7 +173,10 @@ export interface StudentTestDelivery {
   vocabularyPool?: VocabularyPoolStudyData;
 }
 
-export type StudentInProgressTestAttempt = Omit<InProgressTestAttempt, 'studentId' | 'deliveryState'> & {
+export type StudentInProgressTestAttempt = Omit<
+  InProgressTestAttempt,
+  'studentId' | 'deliveryState' | 'translationGradeReservations' | 'translationGradeRequestWindows'
+> & {
   delivery: StudentTestDelivery;
 };
 

--- a/src/utils/exercises/clickOnMultipleWords.ts
+++ b/src/utils/exercises/clickOnMultipleWords.ts
@@ -42,7 +42,11 @@ export const validateClickOnMultipleWords = (
   let score = 0;
   if (totalRequired > 0) {
     const baseScore = (correctSelections / totalRequired) * 100;
-    if (allowOverSelection && overSelections > 0) {
+    if (!allowOverSelection && overSelections > 0) {
+      // Strict mode treats any extra selection as a failed exercise, even when
+      // every required word was also selected.
+      score = 0;
+    } else if (allowOverSelection && overSelections > 0) {
       // Apply penalty for over-selections in lenient mode
       const penalty = Math.min(baseScore, overSelections * 10); // 10% penalty per extra selection
       score = Math.max(0, baseScore - penalty);

--- a/src/utils/exercises/generatedFormIdentificationExercise.ts
+++ b/src/utils/exercises/generatedFormIdentificationExercise.ts
@@ -127,8 +127,9 @@ export interface SingleFieldPartialCredit {
 
 /**
  * Scores each requested grammatical field independently. Submitted paths are
- * paired with distinct expected paths to produce the highest legitimate score;
- * missing and extra values receive no credit and never subtract points.
+ * paired with distinct expected paths to produce the highest legitimate score.
+ * The submitted answer must retain the authored path and field shape so extra
+ * guesses cannot be hidden among otherwise valid partial answers.
  */
 export const scoreSingleFieldFormIdentificationAnswer = (
   userAnswer: string,
@@ -138,10 +139,11 @@ export const scoreSingleFieldFormIdentificationAnswer = (
   const expectedPaths = validatedItem.primaryFormPaths;
   const steps = validatedItem.steps;
   const availableUnits = expectedPaths.length * steps.length;
-  const userPaths = userAnswer
-    .split(';')
-    .map(path => path.split(',').map(normalize))
-    .filter(path => path.some(Boolean));
+  const userPaths = userAnswer.split(';').map(path => path.split(',').map(normalize));
+
+  if (userPaths.length !== expectedPaths.length || userPaths.some(path => path.length > steps.length)) {
+    return { earnedUnits: 0, availableUnits };
+  }
 
   const pathScores = userPaths.map(userPath =>
     expectedPaths.map(expectedPath =>

--- a/src/utils/exercises/matchingExercise.ts
+++ b/src/utils/exercises/matchingExercise.ts
@@ -15,13 +15,13 @@ export const validateMatchingExercise = (
 ): MatchingValidationResult => {
   const { rightColumn, answers: finalAnswer } = exercise.data;
 
-  // Get the expected right item value for this left item
+  // Get the expected right item for this left item
   const expectedRightId = finalAnswer[leftItem.id];
   const expectedRightItem = rightColumn.find(item => item.id === expectedRightId);
-  const expectedValue = expectedRightItem?.value;
 
-  // Check if the selected right item's value matches the expected value
-  const isCorrect = Boolean(expectedValue && rightItem.value === expectedValue);
+  // IDs are the authored answer identity. Display values are not necessarily
+  // unique, so comparing labels could credit a different right-side item.
+  const isCorrect = Boolean(expectedRightItem && rightItem.id === expectedRightId);
 
   return {
     isCorrect,

--- a/src/utils/exercises/oddOneOutExercise.ts
+++ b/src/utils/exercises/oddOneOutExercise.ts
@@ -1,4 +1,5 @@
 import { OddOneOutExercise } from '@/src/types/exercise';
+import { richTextToPlainText } from './helpers';
 
 export interface OddOneOutValidationResult {
   isCorrect: boolean;
@@ -13,9 +14,12 @@ export const validateOddOneOutExercise = (
 ): OddOneOutValidationResult => {
   const correctItem = exercise.data.items.find(item => item.isOddOneOut);
   const selectedItem = exercise.data.items.find(item => item.id === selectedItemId);
+  const hasRequiredExplanation =
+    !exercise.data.requireExplanation ||
+    richTextToPlainText(userExplanation).replace(/[\u200B-\u200D\uFEFF]/g, '').length > 0;
 
   return {
-    isCorrect: selectedItemId === correctItem?.id,
+    isCorrect: selectedItemId === correctItem?.id && hasRequiredExplanation,
     correctItemId: correctItem?.id,
     selectedItemText: selectedItem?.text,
   };

--- a/tests/adminTestRoutes.test.ts
+++ b/tests/adminTestRoutes.test.ts
@@ -60,7 +60,26 @@ describe('admin test routes', () => {
       version: {
         id: 'version-1',
         name: 'Version A',
-        pages: [{ id: 'page-1', items: [{ id: 'question-1', type: 'multiple-choice', maxPoints: 2 }] }],
+        pages: [
+          {
+            id: 'page-1',
+            items: [
+              {
+                id: 'question-1',
+                type: 'multiple-choice',
+                maxPoints: 2,
+                data: {
+                  question: 'Which answer is correct?',
+                  options: [
+                    { id: 'answer-a', text: 'A', isCorrect: true },
+                    { id: 'answer-b', text: 'B', isCorrect: false },
+                  ],
+                  allowMultipleSelections: false,
+                },
+              },
+            ],
+          },
+        ],
       },
     };
     mockCreateTestWithVersion.mockResolvedValue({ test: { id: 'test-1' }, version: { id: 'version-1' } });

--- a/tests/e2e/assessment-acceptance.spec.ts
+++ b/tests/e2e/assessment-acceptance.spec.ts
@@ -181,8 +181,8 @@ test.describe('Assessment acceptance', () => {
     const studentContext = await browser.newContext();
     const studentPage = await studentContext.newPage();
     await signIn(studentPage, E2E_USERS.mock);
-    const mockSection = studentPage.getByRole('region', { name: 'Mock Tests' });
-    await expect(mockSection.getByRole('heading', { level: 3 })).toHaveText([
+    const mockGrid = studentPage.getByTestId('mock-test-grid');
+    await expect(mockGrid.getByRole('heading', { level: 3 })).toHaveText([
       'Required-pass practice',
       'Ordered fixed-version mock',
     ]);

--- a/tests/e2e/fixtures/journeys.ts
+++ b/tests/e2e/fixtures/journeys.ts
@@ -13,8 +13,8 @@ export async function signIn(page: Page, user: SeededUser, destination: '/dashbo
 
 export function dashboardCard(page: Page, title: string) {
   return page
-    .getByRole('heading', { name: title, exact: true })
-    .locator('xpath=ancestor::div[contains(@class,"rounded-3xl")][1]');
+    .locator('[data-testid="dashboard-test-card"], [data-testid="mock-test-card"]')
+    .filter({ has: page.getByRole('heading', { name: title, exact: true }) });
 }
 
 export async function recordFillAnswer(page: Page, answer: string) {

--- a/tests/generatedFormPartialCredit.test.ts
+++ b/tests/generatedFormPartialCredit.test.ts
@@ -23,9 +23,16 @@ describe('single-field generated form partial credit', () => {
     });
   });
 
-  it('accepts aliases and ignores extra values without a penalty', () => {
+  it('rejects extra fields even when every authored field is correct', () => {
     expect(scoreSingleFieldFormIdentificationAnswer('1st,pl,pres,extra', item)).toEqual({
-      earnedUnits: 3,
+      earnedUnits: 0,
+      availableUnits: 3,
+    });
+  });
+
+  it('rejects extra paths instead of selecting the best submitted guess', () => {
+    expect(scoreSingleFieldFormIdentificationAnswer('wrong,wrong,wrong;1st,pl,pres', item)).toEqual({
+      earnedUnits: 0,
       availableUnits: 3,
     });
   });
@@ -46,9 +53,16 @@ describe('single-field generated form partial credit', () => {
     });
   });
 
-  it('gives missing fields zero credit', () => {
+  it('keeps legitimate partial credit when trailing fields are missing', () => {
     expect(scoreSingleFieldFormIdentificationAnswer('first', item)).toEqual({
       earnedUnits: 1,
+      availableUnits: 3,
+    });
+  });
+
+  it('preserves partial credit when the submitted answer has the correct shape', () => {
+    expect(scoreSingleFieldFormIdentificationAnswer('first,,present', item)).toEqual({
+      earnedUnits: 2,
       availableUnits: 3,
     });
   });

--- a/tests/learningPathService.test.ts
+++ b/tests/learningPathService.test.ts
@@ -6,6 +6,7 @@ import {
   assertUnitDeletionAllowedInTransaction,
 } from '@/src/lib/learning-units/learning-path-service';
 import { learningPathDocumentSchema, saveLearningPathInputSchema } from '@/src/lib/learning-units/schemas';
+import { testVersionDocumentSchema } from '@/src/lib/tests/schemas';
 
 jest.mock('@/src/services/firebase-admin', () => jest.requireActual('./helpers/routeMocks'));
 
@@ -142,6 +143,15 @@ const path = (overrides: Data = {}): Data => ({
   updatedBy: 'admin',
   ...overrides,
 });
+
+const readableLegacyInvalidVersion = {
+  name: 'Legacy version',
+  pages: [{ id: 'page-1', items: [{ id: 'question-1', type: 'multiple-choice', maxPoints: 1 }] }],
+  totalPages: 1,
+  totalItems: 1,
+  totalExercises: 1,
+  totalPoints: 1,
+};
 
 describe('Learning Path schemas', () => {
   it('requires unique bounded IDs and rejects unknown path fields', () => {
@@ -416,6 +426,43 @@ describe('LearningPathService', () => {
     await expect(
       assertPlacedTestRotationAllowedInTransaction(db.transaction as never, db as never, 'unplaced-test', [])
     ).resolves.toBeUndefined();
+
+    db.records.testVersions.version = readableLegacyInvalidVersion;
+    expect(testVersionDocumentSchema.safeParse({ id: 'version', ...readableLegacyInvalidVersion }).success).toBe(true);
+    await expect(
+      assertPlacedTestRotationAllowedInTransaction(db.transaction as never, db as never, 'test', [
+        { versionId: 'version' },
+      ])
+    ).rejects.toMatchObject({ code: 'PLACED_UNIT_INVALID' });
+    expect(db.writes).toHaveLength(0);
+  });
+
+  it('does not newly place a test backed by a readable legacy-invalid version', async () => {
+    const originalPath = path({ unitIds: [] });
+    const db = new FakeFirestore({
+      lessons: {
+        test: {
+          kind: 'test',
+          title: 'Test',
+          description: '',
+          rotationVersions: [{ versionId: 'version-1' }],
+          passingPercentage: null,
+        },
+      },
+      learningPaths: { default: originalPath },
+      testVersions: { 'version-1': readableLegacyInvalidVersion },
+      mockTests: {},
+    });
+    const service = new LearningPathService(db as never);
+
+    expect(testVersionDocumentSchema.safeParse({ id: 'version-1', ...readableLegacyInvalidVersion }).success).toBe(
+      true
+    );
+    await expect(service.save({ expectedRevision: 2, unitIds: ['test'] }, 'admin')).rejects.toMatchObject({
+      code: 'INELIGIBLE_LEARNING_UNIT',
+    });
+    expect(db.writes).toHaveLength(0);
+    expect(db.records.learningPaths.default).toEqual(originalPath);
   });
 
   it('validates every referenced version for mixed test placement', async () => {

--- a/tests/learningUnitDomain.test.ts
+++ b/tests/learningUnitDomain.test.ts
@@ -11,7 +11,19 @@ const versionPages = [
     id: 'page-1',
     items: [
       { id: 'instructions', type: 'text', content: 'Read carefully.' },
-      { id: 'question-1', type: 'multiple-choice', maxPoints: 3 },
+      {
+        id: 'question-1',
+        type: 'multiple-choice',
+        maxPoints: 3,
+        data: {
+          question: 'Which answer is correct?',
+          options: [
+            { id: 'answer-a', text: 'A', isCorrect: true },
+            { id: 'answer-b', text: 'B', isCorrect: false },
+          ],
+          allowMultipleSelections: false,
+        },
+      },
     ],
   },
 ];
@@ -153,10 +165,7 @@ describe('test-version boundaries', () => {
 
     const messages = result.error?.issues.map(issue => issue.message) ?? [];
     expect(messages).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('duplicate ID'),
-        'Non-exercise content cannot define maxPoints',
-      ])
+      expect.arrayContaining([expect.stringContaining('duplicate ID'), 'Non-exercise content cannot define maxPoints'])
     );
   });
 

--- a/tests/mockTestLifecycle.test.ts
+++ b/tests/mockTestLifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   tokenizeDiagramSentence,
 } from '@/src/features/sentence-diagramming/model';
 import { validateSentenceDiagramDocument } from '@/src/features/sentence-diagramming/validation';
+import { testVersionDocumentSchema, testVersionInputSchema } from '@/src/lib/tests/schemas';
 
 jest.mock('@/src/services/firebase-admin', () => jest.requireActual('./helpers/routeMocks'));
 jest.mock('firebase-admin/firestore', () => ({ FieldPath: { documentId: jest.fn() } }));
@@ -184,7 +185,26 @@ function mockDb(seed: Record<string, Record<string, Record<string, unknown>>>, e
 const version = {
   id: 'v1',
   name: 'A',
-  pages: [{ id: 'p1', items: [{ id: 'q1', type: 'multiple-choice', maxPoints: 1 }] }],
+  pages: [
+    {
+      id: 'p1',
+      items: [
+        {
+          id: 'q1',
+          type: 'multiple-choice',
+          maxPoints: 1,
+          data: {
+            question: 'Which answer is correct?',
+            options: [
+              { id: 'answer-a', text: 'A', isCorrect: true },
+              { id: 'answer-b', text: 'B', isCorrect: false },
+            ],
+            allowMultipleSelections: false,
+          },
+        },
+      ],
+    },
+  ],
   totalPages: 1,
   totalItems: 1,
   totalExercises: 1,
@@ -193,6 +213,10 @@ const version = {
   createdBy: 'a',
   updatedAt: at,
   updatedBy: 'a',
+};
+const invalidLegacyVersion = {
+  ...version,
+  pages: [{ id: 'legacy-page', items: [{ id: 'legacy-question', type: 'multiple-choice', maxPoints: 1 }] }],
 };
 const test = {
   id: 't1',
@@ -561,6 +585,59 @@ describe('mock transactional lifecycle', () => {
     ]);
   });
 
+  it('cannot remove a valid placed-test version while a strict-invalid legacy survivor remains', async () => {
+    const placedPath = {
+      revision: 1,
+      unitIds: ['t1'],
+      updatedAt: at,
+      updatedBy: 'admin',
+    };
+    const invalidSurvivor = { ...invalidLegacyVersion, id: 'v2', name: 'Invalid survivor' };
+    const authoringMemory = mockDb({
+      lessons: { t1: { ...test, rotationVersions: [{ versionId: 'v1' }, { versionId: 'v2' }] } },
+      testVersions: { v1: version, v2: invalidSurvivor },
+      testVersionDrafts: {},
+      mockTests: {},
+      mockTestOrdering: {},
+      learningPaths: { default: placedPath },
+    });
+
+    await expect(
+      new TestAuthoringService(authoringMemory.db as never, () => at).deactivateTestVersion('t1', 'v1', 'admin')
+    ).rejects.toMatchObject({ code: 'PLACED_TEST_REQUIRES_ROTATION_VERSION' });
+    expect(authoringMemory.get('testVersions', 'v1')).toEqual(version);
+    expect(authoringMemory.get('testVersionDrafts', 'v1')).toBeUndefined();
+    expect(authoringMemory.get('lessons', 't1')).toMatchObject({
+      rotationVersions: [{ versionId: 'v1' }, { versionId: 'v2' }],
+    });
+
+    const assignmentMemory = mockDb({
+      lessons: { t1: { ...test, rotationVersions: [{ versionId: 'v1' }, { versionId: 'v2' }] } },
+      testVersions: { v1: version, v2: invalidSurvivor },
+      testVersionDrafts: {},
+      mockTests: {},
+      mockTestOrdering: {},
+      learningPaths: { default: placedPath },
+    });
+    await expect(
+      new MockTestService(assignmentMemory.db as never, () => at).assignVersionToMock(
+        {
+          testId: 't1',
+          versionId: 'v1',
+          title: 'Valid target',
+          description: '',
+          passingPercentage: null,
+          isLive: true,
+        },
+        'admin'
+      )
+    ).rejects.toMatchObject({ code: 'PLACED_TEST_REQUIRES_ROTATION_VERSION' });
+    expect(assignmentMemory.get('mockTests', mock.id)).toBeUndefined();
+    expect(assignmentMemory.get('lessons', 't1')).toMatchObject({
+      rotationVersions: [{ versionId: 'v1' }, { versionId: 'v2' }],
+    });
+  });
+
   it('uses the same nested identity rewrite for normal and standalone mock duplicates without mutating their source', async () => {
     const richVersion = {
       ...version,
@@ -874,6 +951,143 @@ describe('mock transactional lifecycle', () => {
     const published = await service.updateMock('hidden', { isLive: true }, 'admin');
     expect(published).toMatchObject({ status: 'active', isLive: true, mockOrder: 0 });
     expect(memory.get('mockTests', 'archived')).toMatchObject({ isLive: false, mockOrder: null });
+  });
+
+  it('keeps invalid legacy versions readable but blocks every mock publication and rotation transition', async () => {
+    expect(testVersionDocumentSchema.safeParse(invalidLegacyVersion).success).toBe(true);
+    expect(
+      testVersionInputSchema.safeParse({
+        id: invalidLegacyVersion.id,
+        name: invalidLegacyVersion.name,
+        pages: invalidLegacyVersion.pages,
+      }).success
+    ).toBe(false);
+
+    const errors = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const assignMemory = mockDb({
+      lessons: { t1: { ...test, rotationVersions: [{ versionId: 'v1' }] } },
+      testVersions: { v1: invalidLegacyVersion },
+      mockTests: {},
+      mockTestOrdering: {},
+      learningPaths: {},
+    });
+    await expect(
+      new MockTestService(assignMemory.db as never, () => at).assignVersionToMock(
+        {
+          testId: 't1',
+          versionId: 'v1',
+          title: 'Invalid legacy assignment',
+          description: '',
+          passingPercentage: null,
+          isLive: true,
+        },
+        'admin'
+      )
+    ).rejects.toMatchObject({ code: 'TEST_CONFIGURATION_ERROR' });
+    expect(assignMemory.get('mockTests', mock.id)).toBeUndefined();
+    expect(assignMemory.get('lessons', 't1')).toMatchObject({ rotationVersions: [{ versionId: 'v1' }] });
+
+    const archivedParent = { ...mock, status: 'archived' as const, isLive: false, mockOrder: null };
+    const reassignMemory = mockDb({
+      lessons: { t1: { ...test, rotationVersions: [{ versionId: 'v1' }] } },
+      testVersions: { v1: invalidLegacyVersion },
+      mockTests: { [mock.id]: archivedParent },
+      mockTestOrdering: {},
+      learningPaths: {},
+    });
+    await expect(
+      new MockTestService(reassignMemory.db as never, () => at).assignVersionToMock(
+        {
+          testId: 't1',
+          versionId: 'v1',
+          title: 'Invalid legacy reassignment',
+          description: '',
+          passingPercentage: null,
+          isLive: false,
+        },
+        'admin'
+      )
+    ).rejects.toMatchObject({ code: 'TEST_CONFIGURATION_ERROR' });
+    expect(reassignMemory.get('mockTests', mock.id)).toMatchObject({ status: 'archived', isLive: false });
+
+    const archivedStandalone = {
+      ...mock,
+      id: 'standalone-archived',
+      parent: { kind: 'standalone' as const },
+      status: 'archived' as const,
+      isLive: false,
+      mockOrder: null,
+    };
+    const reactivateMemory = mockDb({
+      lessons: {},
+      testVersions: { v1: invalidLegacyVersion },
+      mockTests: { 'standalone-archived': archivedStandalone },
+      mockTestOrdering: {},
+      learningPaths: {},
+    });
+    await expect(
+      new MockTestService(reactivateMemory.db as never, () => at).reactivateStandaloneMock(
+        'standalone-archived',
+        { isLive: false },
+        'admin'
+      )
+    ).rejects.toMatchObject({ code: 'TEST_CONFIGURATION_ERROR' });
+    expect(reactivateMemory.get('mockTests', 'standalone-archived')).toMatchObject({ status: 'archived' });
+
+    const hiddenStandalone = {
+      ...mock,
+      id: 'standalone-hidden',
+      parent: { kind: 'standalone' as const },
+      isLive: false,
+      mockOrder: null,
+    };
+    const publishMemory = mockDb({
+      lessons: {},
+      testVersions: { v1: invalidLegacyVersion },
+      mockTests: { 'standalone-hidden': hiddenStandalone },
+      mockTestOrdering: {},
+      learningPaths: {},
+    });
+    await expect(
+      new MockTestService(publishMemory.db as never, () => at).updateMock(
+        'standalone-hidden',
+        { isLive: true },
+        'admin'
+      )
+    ).rejects.toMatchObject({ code: 'TEST_CONFIGURATION_ERROR' });
+    expect(publishMemory.get('mockTests', 'standalone-hidden')).toMatchObject({ isLive: false, mockOrder: null });
+
+    const hiddenParent = { ...mock, isLive: false, mockOrder: null };
+    const archiveMemory = mockDb({
+      lessons: { t1: { ...test, rotationVersions: [] } },
+      testVersions: { v1: invalidLegacyVersion },
+      mockTests: { [mock.id]: hiddenParent },
+      mockTestOrdering: {},
+      learningPaths: {},
+    });
+    await expect(
+      new MockTestService(archiveMemory.db as never, () => at).archiveMock(mock.id, 'admin')
+    ).rejects.toMatchObject({ code: 'TEST_CONFIGURATION_ERROR' });
+    expect(archiveMemory.get('mockTests', mock.id)).toMatchObject({ status: 'active', isLive: false });
+    expect(archiveMemory.get('lessons', 't1')).toMatchObject({ rotationVersions: [] });
+
+    const moveMemory = mockDb({
+      lessons: { t1: { ...test, rotationVersions: [] } },
+      testVersions: { v1: invalidLegacyVersion },
+      mockTests: { 'standalone-hidden': hiddenStandalone },
+      mockTestOrdering: {},
+      learningPaths: {},
+    });
+    await expect(
+      new MockTestService(moveMemory.db as never, () => at).moveStandaloneMockToTest(
+        'standalone-hidden',
+        { testId: 't1' },
+        'admin'
+      )
+    ).rejects.toMatchObject({ code: 'TEST_CONFIGURATION_ERROR' });
+    expect(moveMemory.get('mockTests', 'standalone-hidden')).toMatchObject({ status: 'active', isLive: false });
+    expect(moveMemory.get('lessons', 't1')).toMatchObject({ rotationVersions: [] });
+    errors.mockRestore();
   });
 
   it('projects isolated live cards with twelve chronological trend points and related-nudge filtering', async () => {

--- a/tests/mockTestRoutes.test.ts
+++ b/tests/mockTestRoutes.test.ts
@@ -44,7 +44,26 @@ const validMock = {
   version: {
     id: 'version-1',
     name: 'A',
-    pages: [{ id: 'page-1', items: [{ id: 'question-1', type: 'multiple-choice', maxPoints: 1 }] }],
+    pages: [
+      {
+        id: 'page-1',
+        items: [
+          {
+            id: 'question-1',
+            type: 'multiple-choice',
+            maxPoints: 1,
+            data: {
+              question: 'Which answer is correct?',
+              options: [
+                { id: 'answer-a', text: 'A', isCorrect: true },
+                { id: 'answer-b', text: 'B', isCorrect: false },
+              ],
+              allowMultipleSelections: false,
+            },
+          },
+        ],
+      },
+    ],
   },
 };
 

--- a/tests/studentTestPage.test.tsx
+++ b/tests/studentTestPage.test.tsx
@@ -238,6 +238,90 @@ describe('student normal test flow', () => {
     expect(screen.getByText('Results breakdown')).toBeInTheDocument();
   });
 
+  it('reopens a recorded answer from review and clears its server-side value before editing', async () => {
+    const params = Promise.resolve({ testId: 'test-1' }) as Promise<{ testId: string }> & {
+      status: 'fulfilled';
+      value: { testId: string };
+    };
+    params.status = 'fulfilled';
+    params.value = { testId: 'test-1' };
+    render(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start Test' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Record two answers' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review answers' }));
+    expect(await screen.findByText('Every exercise has a recorded answer.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit First' }));
+
+    await waitFor(() =>
+      expect(mockSaveAnswers).toHaveBeenLastCalledWith({
+        uid: 'student-1',
+        attemptId: 'attempt-1',
+        answers: { 'fill-one': null },
+      })
+    );
+    expect(await screen.findByRole('button', { name: 'Record two answers' })).toBeInTheDocument();
+    expect(screen.getByText('1 of 2 answered')).toBeInTheDocument();
+  });
+
+  it('shows precise percentages and a visible deficit for a near-threshold failure', async () => {
+    mockUseGetStudentDashboardQuery.mockReturnValue({
+      data: {
+        ...dashboard,
+        learningPath: dashboard.learningPath.map(unit =>
+          unit.kind === 'test' ? { ...unit, passingPercentage: 80 } : unit
+        ),
+      },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetchDashboard,
+    });
+    mockSubmitAttempt.mockReturnValue({
+      unwrap: jest.fn().mockResolvedValue({
+        completionGranted: false,
+        attempt: {
+          id: 'attempt-1',
+          versionId: 'version-a',
+          passingPercentage: 80,
+          origin: { kind: 'normal-test', testId: 'test-1' },
+          status: 'submitted',
+          exerciseResults: {},
+          score: 79.999,
+          maxScore: 100,
+          percentage: 79.999,
+          outcome: 'not-passed',
+          startedAt: 'now',
+          updatedAt: 'later',
+          submittedAt: 'later',
+        },
+      }),
+    });
+    const params = Promise.resolve({ testId: 'test-1' }) as Promise<{ testId: string }> & {
+      status: 'fulfilled';
+      value: { testId: string };
+    };
+    params.status = 'fulfilled';
+    params.value = { testId: 'test-1' };
+    render(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start Test' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Review answers' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit Test' }));
+
+    expect(await screen.findByText('79.99%')).toBeInTheDocument();
+    expect(screen.getByText(/You need 80% — you reached 79\.99%/)).toBeInTheDocument();
+    expect(screen.getByText(/<0\.01 percentage points away/)).toBeInTheDocument();
+  });
+
   it('keeps partial multi-item answers out of the answered count and protects them before unload', async () => {
     mockStartAttempt.mockReturnValue({
       unwrap: jest.fn().mockResolvedValue({
@@ -438,28 +522,61 @@ describe('student normal test flow', () => {
     mockUseGetStudentDashboardQuery.mockReturnValue({
       data: {
         ...dashboard,
-        mockTests: [{ id: 'test-1', title: 'Mock with same id', description: '', passingPercentage: null, totalPoints: 2, attemptSummary: { origin: { kind: 'mock-test', mockTestId: 'test-1' }, inProgressAttemptId: null, attemptCount: 0, best: null, latest: null }, scoreTrend: [] }],
+        mockTests: [
+          {
+            id: 'test-1',
+            title: 'Mock with same id',
+            description: '',
+            passingPercentage: null,
+            totalPoints: 2,
+            attemptSummary: {
+              origin: { kind: 'mock-test', mockTestId: 'test-1' },
+              inProgressAttemptId: null,
+              attemptCount: 0,
+              best: null,
+              latest: null,
+            },
+            scoreTrend: [],
+          },
+        ],
       },
       isLoading: false,
       isError: false,
     });
     mockUseGetStudentMockDetailQuery.mockReturnValue({
       data: {
-        mock: { id: 'test-1', title: 'Practice test', description: '', passingPercentage: 70, status: 'archived', isLive: false },
+        mock: {
+          id: 'test-1',
+          title: 'Practice test',
+          description: '',
+          passingPercentage: 70,
+          status: 'archived',
+          isLive: false,
+        },
         attempt: { ...startedAttempt, origin: { kind: 'mock-test', mockTestId: 'test-1' } },
       },
       isLoading: false,
       isError: false,
     });
-    const params = Promise.resolve({ testId: 'test-1' }) as Promise<{ testId: string }> & { status: 'fulfilled'; value: { testId: string } };
+    const params = Promise.resolve({ testId: 'test-1' }) as Promise<{ testId: string }> & {
+      status: 'fulfilled';
+      value: { testId: string };
+    };
     params.status = 'fulfilled';
     params.value = { testId: 'test-1' };
 
-    const rendered = render(<Suspense fallback={<div>Loading route</div>}><StudentTestPage params={params} /></Suspense>);
+    const rendered = render(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
 
     expect(await screen.findByText('Test in progress')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Record two answers' })).toBeInTheDocument();
-    expect(mockStartAttempt).toHaveBeenCalledWith({ uid: 'student-1', origin: { kind: 'mock-test', mockTestId: 'test-1' } });
+    expect(mockStartAttempt).toHaveBeenCalledWith({
+      uid: 'student-1',
+      origin: { kind: 'mock-test', mockTestId: 'test-1' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Record two answers' }));
     fireEvent.click(screen.getByRole('button', { name: 'Review answers' }));
     expect(await screen.findByText('Every exercise has a recorded answer.')).toBeInTheDocument();
@@ -467,8 +584,17 @@ describe('student normal test flow', () => {
     expect(await screen.findByText('Keep going')).toBeInTheDocument();
     expect(mockSaveAnswers).toHaveBeenCalledWith(expect.objectContaining({ attemptId: 'attempt-1' }));
     expect(mockSubmitAttempt).toHaveBeenCalledWith({ uid: 'student-1', attemptId: 'attempt-1' });
-    mockUseGetStudentMockDetailQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true, refetch: mockRefetchMockDetail });
-    rendered.rerender(<Suspense fallback={<div>Loading route</div>}><StudentTestPage params={params} /></Suspense>);
+    mockUseGetStudentMockDetailQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetchMockDetail,
+    });
+    rendered.rerender(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
     expect(screen.getByText('Keep going')).toBeInTheDocument();
     expect(screen.getByText('This mock test is no longer available for another attempt.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Retake Mock Test' })).not.toBeInTheDocument();
@@ -477,20 +603,95 @@ describe('student normal test flow', () => {
   it('never offers a retake from the stale mock detail after submit when the refreshed live card is gone', async () => {
     mockSearchParams.mockReturnValue(new URLSearchParams('origin=mock'));
     const liveMock = {
-      id: 'mock-1', title: 'Practice mock', description: '', passingPercentage: 70, totalPoints: 2,
-      attemptSummary: { origin: { kind: 'mock-test' as const, mockTestId: 'mock-1' }, inProgressAttemptId: null, attemptCount: 0, best: null, latest: null }, scoreTrend: [],
+      id: 'mock-1',
+      title: 'Practice mock',
+      description: '',
+      passingPercentage: 70,
+      totalPoints: 2,
+      attemptSummary: {
+        origin: { kind: 'mock-test' as const, mockTestId: 'mock-1' },
+        inProgressAttemptId: null,
+        attemptCount: 0,
+        best: null,
+        latest: null,
+      },
+      scoreTrend: [],
     };
-    mockUseGetStudentDashboardQuery.mockReturnValue({ data: { ...dashboard, mockTests: [liveMock] }, isLoading: false, isError: false, refetch: mockRefetchDashboard });
-    mockUseGetStudentMockDetailQuery.mockReturnValue({ data: { mock: { id: 'mock-1', title: 'Practice mock', description: '', passingPercentage: 70, status: 'active', isLive: true }, attempt: null }, isLoading: false, isError: false, refetch: mockRefetchMockDetail });
-    mockStartAttempt.mockReturnValue({ unwrap: jest.fn().mockResolvedValue({ attempt: { ...startedAttempt, origin: { kind: 'mock-test', mockTestId: 'mock-1' } }, resumed: false }) });
+    mockUseGetStudentDashboardQuery.mockReturnValue({
+      data: { ...dashboard, mockTests: [liveMock] },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetchDashboard,
+    });
+    mockUseGetStudentMockDetailQuery.mockReturnValue({
+      data: {
+        mock: {
+          id: 'mock-1',
+          title: 'Practice mock',
+          description: '',
+          passingPercentage: 70,
+          status: 'active',
+          isLive: true,
+        },
+        attempt: null,
+      },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetchMockDetail,
+    });
+    mockStartAttempt.mockReturnValue({
+      unwrap: jest.fn().mockResolvedValue({
+        attempt: { ...startedAttempt, origin: { kind: 'mock-test', mockTestId: 'mock-1' } },
+        resumed: false,
+      }),
+    });
     // Keep the result fixture explicit: a mock result is valid even after its card disappears.
-    mockSubmitAttempt.mockReturnValue({ unwrap: jest.fn().mockResolvedValue({ completionGranted: false, attempt: { id: 'attempt-1', versionId: 'version-a', passingPercentage: 70, origin: { kind: 'mock-test', mockTestId: 'mock-1' }, status: 'submitted', exerciseResults: {}, score: 1, maxScore: 2, percentage: 50, outcome: 'not-passed', startedAt: 'now', updatedAt: 'later', submittedAt: 'later' } }) });
+    mockSubmitAttempt.mockReturnValue({
+      unwrap: jest.fn().mockResolvedValue({
+        completionGranted: false,
+        attempt: {
+          id: 'attempt-1',
+          versionId: 'version-a',
+          passingPercentage: 70,
+          origin: { kind: 'mock-test', mockTestId: 'mock-1' },
+          status: 'submitted',
+          exerciseResults: {},
+          score: 1,
+          maxScore: 2,
+          percentage: 50,
+          outcome: 'not-passed',
+          startedAt: 'now',
+          updatedAt: 'later',
+          submittedAt: 'later',
+        },
+      }),
+    });
     mockRefetchDashboard.mockResolvedValue({ data: { ...dashboard, mockTests: [] } });
-    mockRefetchMockDetail.mockResolvedValue({ data: { mock: { id: 'mock-1', title: 'Practice mock', description: '', passingPercentage: 70, status: 'archived', isLive: false }, attempt: null } });
-    const params = Promise.resolve({ testId: 'mock-1' }) as Promise<{ testId: string }> & { status: 'fulfilled'; value: { testId: string } };
-    params.status = 'fulfilled'; params.value = { testId: 'mock-1' };
+    mockRefetchMockDetail.mockResolvedValue({
+      data: {
+        mock: {
+          id: 'mock-1',
+          title: 'Practice mock',
+          description: '',
+          passingPercentage: 70,
+          status: 'archived',
+          isLive: false,
+        },
+        attempt: null,
+      },
+    });
+    const params = Promise.resolve({ testId: 'mock-1' }) as Promise<{ testId: string }> & {
+      status: 'fulfilled';
+      value: { testId: string };
+    };
+    params.status = 'fulfilled';
+    params.value = { testId: 'mock-1' };
 
-    render(<Suspense fallback={<div>Loading route</div>}><StudentTestPage params={params} /></Suspense>);
+    render(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
     fireEvent.click(await screen.findByRole('button', { name: 'Start Mock Test' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Record two answers' }));
     fireEvent.click(screen.getByRole('button', { name: 'Review answers' }));
@@ -504,12 +705,24 @@ describe('student normal test flow', () => {
 
   it('retries the failing mock-detail source', async () => {
     mockSearchParams.mockReturnValue(new URLSearchParams('origin=mock'));
-    mockUseGetStudentMockDetailQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true, refetch: mockRefetchMockDetail });
-    const params = Promise.resolve({ testId: 'mock-1' }) as Promise<{ testId: string }> & { status: 'fulfilled'; value: { testId: string } };
+    mockUseGetStudentMockDetailQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetchMockDetail,
+    });
+    const params = Promise.resolve({ testId: 'mock-1' }) as Promise<{ testId: string }> & {
+      status: 'fulfilled';
+      value: { testId: string };
+    };
     params.status = 'fulfilled';
     params.value = { testId: 'mock-1' };
 
-    render(<Suspense fallback={<div>Loading route</div>}><StudentTestPage params={params} /></Suspense>);
+    render(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
     fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
 
     expect(mockRefetchMockDetail).toHaveBeenCalled();
@@ -517,11 +730,18 @@ describe('student normal test flow', () => {
   });
 
   it('resets local state and installs a distinct sentinel when the same id switches from normal to mock origin', async () => {
-    const params = Promise.resolve({ testId: 'test-1' }) as Promise<{ testId: string }> & { status: 'fulfilled'; value: { testId: string } };
+    const params = Promise.resolve({ testId: 'test-1' }) as Promise<{ testId: string }> & {
+      status: 'fulfilled';
+      value: { testId: string };
+    };
     params.status = 'fulfilled';
     params.value = { testId: 'test-1' };
     const pushState = jest.spyOn(window.history, 'pushState');
-    const rendered = render(<Suspense fallback={<div>Loading route</div>}><StudentTestPage params={params} /></Suspense>);
+    const rendered = render(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
 
     fireEvent.click(await screen.findByRole('button', { name: 'Start Test' }));
     expect(await screen.findByText('Test in progress')).toBeInTheDocument();
@@ -530,20 +750,54 @@ describe('student normal test flow', () => {
     mockUseGetStudentDashboardQuery.mockReturnValue({
       data: {
         ...dashboard,
-        mockTests: [{ id: 'test-1', title: 'Mock with same id', description: '', passingPercentage: null, totalPoints: 2, attemptSummary: { origin: { kind: 'mock-test', mockTestId: 'test-1' }, inProgressAttemptId: null, attemptCount: 0, best: null, latest: null }, scoreTrend: [] }],
+        mockTests: [
+          {
+            id: 'test-1',
+            title: 'Mock with same id',
+            description: '',
+            passingPercentage: null,
+            totalPoints: 2,
+            attemptSummary: {
+              origin: { kind: 'mock-test', mockTestId: 'test-1' },
+              inProgressAttemptId: null,
+              attemptCount: 0,
+              best: null,
+              latest: null,
+            },
+            scoreTrend: [],
+          },
+        ],
       },
       isLoading: false,
       isError: false,
     });
     mockUseGetStudentMockDetailQuery.mockReturnValue({
-      data: { mock: { id: 'test-1', title: 'Mock with same id', description: '', passingPercentage: null, status: 'active', isLive: true }, attempt: null },
+      data: {
+        mock: {
+          id: 'test-1',
+          title: 'Mock with same id',
+          description: '',
+          passingPercentage: null,
+          status: 'active',
+          isLive: true,
+        },
+        attempt: null,
+      },
       isLoading: false,
       isError: false,
     });
-    rendered.rerender(<Suspense fallback={<div>Loading route</div>}><StudentTestPage params={params} /></Suspense>);
+    rendered.rerender(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
 
     expect(await screen.findByRole('button', { name: 'Start Mock Test' })).toBeInTheDocument();
     expect(screen.queryByText('Test in progress')).not.toBeInTheDocument();
-    expect(pushState).toHaveBeenLastCalledWith(expect.objectContaining({ __latinTestHistoryGuard: 'test:mock-test:test-1' }), '', window.location.href);
+    expect(pushState).toHaveBeenLastCalledWith(
+      expect.objectContaining({ __latinTestHistoryGuard: 'test:mock-test:test-1' }),
+      '',
+      window.location.href
+    );
   });
 });

--- a/tests/testAttemptRoutes.test.ts
+++ b/tests/testAttemptRoutes.test.ts
@@ -137,6 +137,48 @@ describe('student test-attempt routes', () => {
     expect(mockGradeTranslationItem).toHaveBeenCalledWith('attempt-1', input, 'student-1');
   });
 
+  it('returns a clear conflict when a translation item is already graded', async () => {
+    mockGradeTranslationItem.mockRejectedValue(
+      new TestServiceError(
+        'ATTEMPT_TRANSLATION_ALREADY_GRADED',
+        'This translation item has already been graded with a different answer',
+        409
+      )
+    );
+
+    const response = (await gradeTranslation(
+      request({ exerciseId: 'translation.one', itemIndex: 0, userTranslation: 'A different answer.' }),
+      params('attempt-1')
+    )) as unknown as { status: number; body: { code: string; error: string } };
+
+    expect(response.status).toBe(409);
+    expect(response.body).toEqual({
+      code: 'ATTEMPT_TRANSLATION_ALREADY_GRADED',
+      error: 'This translation item has already been graded with a different answer',
+    });
+  });
+
+  it('returns a clear rate limit when the translation grading budget is exhausted', async () => {
+    mockGradeTranslationItem.mockRejectedValue(
+      new TestServiceError(
+        'ATTEMPT_TRANSLATION_GRADING_RATE_LIMITED',
+        'Too many translation grading requests. Please try again after the grading window resets.',
+        429
+      )
+    );
+
+    const response = (await gradeTranslation(
+      request({ exerciseId: 'translation.one', itemIndex: 0, userTranslation: 'The girl sings.' }),
+      params('attempt-1')
+    )) as unknown as { status: number; body: { code: string; error: string } };
+
+    expect(response.status).toBe(429);
+    expect(response.body).toEqual({
+      code: 'ATTEMPT_TRANSLATION_GRADING_RATE_LIMITED',
+      error: 'Too many translation grading requests. Please try again after the grading window resets.',
+    });
+  });
+
   it('maps submission domain errors and rejects unauthenticated submits', async () => {
     mockVerifyRequestAuth.mockResolvedValueOnce(null);
     const unauthenticated = (await submitAttempt(request(), params('attempt-1'))) as unknown as { status: number };

--- a/tests/testAttemptService.test.ts
+++ b/tests/testAttemptService.test.ts
@@ -1,4 +1,9 @@
-import { getTestAttemptSessionId, TestAttemptService } from '@/src/lib/tests/attempt-service';
+import {
+  getTestAttemptSessionId,
+  MAX_TRANSLATION_GRADING_REQUESTS_PER_WINDOW,
+  TestAttemptService,
+  TRANSLATION_GRADING_REQUEST_WINDOW_MS,
+} from '@/src/lib/tests/attempt-service';
 import { MockTestService } from '@/src/lib/tests/mock-service';
 import type { TestAttemptOrigin } from '@/src/types/test';
 
@@ -244,6 +249,9 @@ const versionDocument = (id: string, exercise: StoredDocument = fillExercise) =>
   totalPoints: 3,
 });
 
+const readableLegacyInvalidVersionDocument = (id: string) =>
+  versionDocument(id, { id: 'legacy-question', type: 'multiple-choice', maxPoints: 3 });
+
 const testDocument = (rotationVersions = ['version-a', 'version-b']) => ({
   id: 'test-1',
   kind: 'test',
@@ -293,6 +301,8 @@ describe('test attempt persistence service', () => {
     expect(db.readAll('testAttemptSessions')).toHaveLength(1);
     expect(first.attempt).not.toHaveProperty('studentId');
     expect(first.attempt).not.toHaveProperty('deliveryState');
+    expect(first.attempt).not.toHaveProperty('translationGradeReservations');
+    expect(first.attempt).not.toHaveProperty('translationGradeRequestWindows');
     expect(first.attempt.passingPercentage).toBe(70);
     expect(
       (first.attempt.delivery.pages[0] as { items: Array<{ data: { items: StoredDocument[] } }> }).items[0].data
@@ -332,6 +342,21 @@ describe('test attempt persistence service', () => {
     const db = new FakeFirestore();
     db.seed('lessons', 'test-1', testDocument(['version-a', 'missing-version']));
     db.seed('testVersions', 'version-a', versionDocument('version-a'));
+    const service = new TestAttemptService(db as never, () => timestamp, { random: () => 0 });
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(
+      service.startAttempt({ origin: { kind: 'normal-test', testId: 'test-1' } }, 'student-1')
+    ).rejects.toMatchObject({ code: 'TEST_CONFIGURATION_ERROR', status: 409 });
+    expect(db.readAll('testAttempts')).toHaveLength(0);
+    expect(db.readAll('testAttemptSessions')).toHaveLength(0);
+    consoleError.mockRestore();
+  });
+
+  it('rejects a fresh attempt for a readable legacy-invalid version without writing session state', async () => {
+    const db = new FakeFirestore();
+    db.seed('lessons', 'test-1', testDocument(['version-a']));
+    db.seed('testVersions', 'version-a', readableLegacyInvalidVersionDocument('version-a'));
     const service = new TestAttemptService(db as never, () => timestamp, { random: () => 0 });
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
@@ -672,7 +697,7 @@ describe('test attempt persistence service', () => {
       feedbackConfig: { escalationLevels: [] },
       data: {
         generatorConfig: { collection: 'words', wordSource: 'filters', count: 1 },
-        posConfigs: {},
+        posConfigs: { verb: { enabled: true, filters: {} } },
       },
     };
     db.seed('lessons', 'test-1', testDocument(['generated-version']));
@@ -870,6 +895,23 @@ describe('test attempt submission and sticky completion', () => {
   const normalOrigin: TestAttemptOrigin = { kind: 'normal-test', testId: 'test-1' };
   const startInput = { origin: normalOrigin };
 
+  it('resumes legacy in-progress attempts that predate translation grading leases and budgets', async () => {
+    const db = new FakeFirestore();
+    seedNormalTest(db, ['version-a']);
+    db.seed('testVersions', 'version-a', readableLegacyInvalidVersionDocument('version-a'));
+    const attemptId = 'legacy-in-progress';
+    const sessionId = getTestAttemptSessionId('student-1', normalOrigin);
+    db.seed('testAttempts', attemptId, inProgressAttemptDocument(attemptId));
+    db.seed('testAttemptSessions', sessionId, sessionDocument(sessionId, 'student-1', normalOrigin, attemptId));
+    const service = new TestAttemptService(db as never, () => timestamp);
+
+    const resumed = await service.startAttempt(startInput, 'student-1');
+
+    expect(resumed).toMatchObject({ resumed: true, attempt: { id: attemptId } });
+    expect(resumed.attempt).not.toHaveProperty('translationGradeReservations');
+    expect(resumed.attempt).not.toHaveProperty('translationGradeRequestWindows');
+  });
+
   const startAnswerSubmit = async (
     service: TestAttemptService,
     db: FakeFirestore,
@@ -984,15 +1026,111 @@ describe('test attempt submission and sticky completion', () => {
     });
   });
 
-  it('keeps a translation attempt resumable when AI grading is unavailable', async () => {
+  it('returns an existing translation grade idempotently and rejects grade fishing or reset attempts', async () => {
     const db = new FakeFirestore();
-    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     db.seed('lessons', 'test-1', testDocument(['version-a']));
     db.seed('testVersions', 'version-a', versionDocumentWith('version-a', translationGradingExercise, 8));
-    const service = new TestAttemptService(db as never, () => timestamp, {
-      gradeTestTranslation: async () => Promise.reject(new Error('provider unavailable')),
-    });
+    const gradeTestTranslation = jest.fn(async () => ({ score: 9, feedback: 'Accurate and idiomatic.' }));
+    const service = new TestAttemptService(db as never, () => timestamp, { gradeTestTranslation });
     const started = await service.startAttempt(startInput, 'student-1');
+    const input = {
+      exerciseId: 'translation-assessment',
+      itemIndex: 0,
+      userTranslation: 'The girl sings.',
+    };
+
+    const first = await service.gradeTranslationItem(started.attempt.id, input, 'student-1');
+    const retry = await service.gradeTranslationItem(started.attempt.id, input, 'student-1');
+
+    expect(retry.translationGrades).toEqual(first.translationGrades);
+    expect(gradeTestTranslation).toHaveBeenCalledTimes(1);
+    await expect(
+      service.gradeTranslationItem(started.attempt.id, { ...input, userTranslation: 'A girl is singing.' }, 'student-1')
+    ).rejects.toMatchObject({ code: 'ATTEMPT_TRANSLATION_ALREADY_GRADED', status: 409 });
+    await expect(
+      service.saveAttemptAnswers(started.attempt.id, { answers: { 'translation-assessment': null } }, 'student-1')
+    ).rejects.toMatchObject({ code: 'ATTEMPT_TRANSLATION_ALREADY_GRADED', status: 409 });
+    expect(gradeTestTranslation).toHaveBeenCalledTimes(1);
+    expect(db.read('testAttempts', started.attempt.id)?.translationGradeRequestWindows).toMatchObject({
+      'translation-assessment': { '0': { count: 1 } },
+    });
+    for (const studentAttempt of [started.attempt, first, retry]) {
+      expect(studentAttempt).not.toHaveProperty('translationGradeReservations');
+      expect(studentAttempt).not.toHaveProperty('translationGradeRequestWindows');
+    }
+  });
+
+  it('reserves translation items so concurrent requests cannot invoke the provider twice', async () => {
+    const db = new FakeFirestore();
+    db.seed('lessons', 'test-1', testDocument(['version-a']));
+    db.seed('testVersions', 'version-a', versionDocumentWith('version-a', translationGradingExercise, 8));
+    let providerStarted!: () => void;
+    let finishProvider!: (output: { score: number; feedback: string }) => void;
+    const startedProvider = new Promise<void>(resolve => {
+      providerStarted = resolve;
+    });
+    const providerOutput = new Promise<{ score: number; feedback: string }>(resolve => {
+      finishProvider = resolve;
+    });
+    const gradeTestTranslation = jest.fn(() => {
+      providerStarted();
+      return providerOutput;
+    });
+    const service = new TestAttemptService(db as never, () => timestamp, { gradeTestTranslation });
+    const started = await service.startAttempt(startInput, 'student-1');
+    const input = {
+      exerciseId: 'translation-assessment',
+      itemIndex: 0,
+      userTranslation: 'The girl sings.',
+    };
+
+    const firstRequest = service.gradeTranslationItem(started.attempt.id, input, 'student-1');
+    await startedProvider;
+
+    await expect(service.gradeTranslationItem(started.attempt.id, input, 'student-1')).rejects.toMatchObject({
+      code: 'ATTEMPT_TRANSLATION_GRADING_IN_PROGRESS',
+      status: 409,
+    });
+    await expect(service.submitAttempt(started.attempt.id, 'student-1')).rejects.toMatchObject({
+      code: 'ATTEMPT_TRANSLATION_GRADING_IN_PROGRESS',
+      status: 409,
+    });
+    expect(gradeTestTranslation).toHaveBeenCalledTimes(1);
+    expect(db.read('testAttempts', started.attempt.id)?.translationGradeRequestWindows).toMatchObject({
+      'translation-assessment': { '0': { count: 1 } },
+    });
+
+    finishProvider({ score: 9, feedback: 'Accurate and idiomatic.' });
+    await expect(firstRequest).resolves.toMatchObject({
+      translationGrades: {
+        'translation-assessment': {
+          '0': { translation: input.userTranslation, score: 9 },
+        },
+      },
+    });
+    expect(db.read('testAttempts', started.attempt.id)?.translationGradeReservations).toEqual({});
+  });
+
+  it('reclaims an expired translation reservation left by an interrupted request', async () => {
+    const db = new FakeFirestore();
+    db.seed('lessons', 'test-1', testDocument(['version-a']));
+    db.seed('testVersions', 'version-a', versionDocumentWith('version-a', translationGradingExercise, 8));
+    const gradeTestTranslation = jest.fn(async () => ({ score: 9, feedback: 'Accurate and idiomatic.' }));
+    const service = new TestAttemptService(db as never, () => timestamp, { gradeTestTranslation });
+    const started = await service.startAttempt(startInput, 'student-1');
+    const storedAttempt = db.read('testAttempts', started.attempt.id)!;
+    db.seed('testAttempts', started.attempt.id, {
+      ...storedAttempt,
+      translationGradeReservations: {
+        'translation-assessment': {
+          '0': {
+            token: '00000000-0000-4000-8000-000000000001',
+            expiresAt: '2026-07-20T11:59:59.000Z',
+          },
+        },
+      },
+    });
+
     await expect(
       service.gradeTranslationItem(
         started.attempt.id,
@@ -1003,7 +1141,35 @@ describe('test attempt submission and sticky completion', () => {
         },
         'student-1'
       )
-    ).rejects.toMatchObject({
+    ).resolves.toMatchObject({
+      translationGrades: {
+        'translation-assessment': {
+          '0': { translation: 'The girl sings.', score: 9 },
+        },
+      },
+    });
+    expect(gradeTestTranslation).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the reservation and keeps a translation item retryable when AI grading is unavailable', async () => {
+    const db = new FakeFirestore();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    db.seed('lessons', 'test-1', testDocument(['version-a']));
+    db.seed('testVersions', 'version-a', versionDocumentWith('version-a', translationGradingExercise, 8));
+    const gradeTestTranslation = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('provider unavailable'))
+      .mockResolvedValueOnce({ score: 9, feedback: 'Accurate and idiomatic.' });
+    const service = new TestAttemptService(db as never, () => timestamp, {
+      gradeTestTranslation,
+    });
+    const started = await service.startAttempt(startInput, 'student-1');
+    const input = {
+      exerciseId: 'translation-assessment',
+      itemIndex: 0,
+      userTranslation: 'The girl sings.',
+    };
+    await expect(service.gradeTranslationItem(started.attempt.id, input, 'student-1')).rejects.toMatchObject({
       code: 'ATTEMPT_GRADING_UNAVAILABLE',
       status: 503,
     });
@@ -1011,8 +1177,99 @@ describe('test attempt submission and sticky completion', () => {
       status: 'in-progress',
       answers: {},
       translationGrades: {},
+      translationGradeReservations: {},
     });
+    await expect(service.gradeTranslationItem(started.attempt.id, input, 'student-1')).resolves.toMatchObject({
+      translationGrades: {
+        'translation-assessment': {
+          '0': { translation: input.userTranslation, score: 9 },
+        },
+      },
+    });
+    expect(gradeTestTranslation).toHaveBeenCalledTimes(2);
     consoleError.mockRestore();
+  });
+
+  it('enforces a durable provider request budget across failures and generic answer saves', async () => {
+    const db = new FakeFirestore();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    db.seed('lessons', 'test-1', testDocument(['version-a']));
+    db.seed('testVersions', 'version-a', versionDocumentWith('version-a', translationGradingExercise, 8));
+    const gradeTestTranslation = jest.fn(async () => ({ score: Number.NaN, feedback: 'Malformed score.' }));
+    const service = new TestAttemptService(db as never, () => timestamp, { gradeTestTranslation });
+    const started = await service.startAttempt(startInput, 'student-1');
+    const input = {
+      exerciseId: 'translation-assessment',
+      itemIndex: 0,
+      userTranslation: 'The girl sings.',
+    };
+
+    for (let index = 0; index < MAX_TRANSLATION_GRADING_REQUESTS_PER_WINDOW - 1; index += 1) {
+      await expect(service.gradeTranslationItem(started.attempt.id, input, 'student-1')).rejects.toMatchObject({
+        code: 'ATTEMPT_GRADING_UNAVAILABLE',
+        status: 503,
+      });
+    }
+
+    // The generic answer endpoint must preserve the server-owned request window.
+    await service.saveAttemptAnswers(started.attempt.id, { answers: { 'translation-assessment': null } }, 'student-1');
+    await expect(service.gradeTranslationItem(started.attempt.id, input, 'student-1')).rejects.toMatchObject({
+      code: 'ATTEMPT_GRADING_UNAVAILABLE',
+      status: 503,
+    });
+    await expect(service.gradeTranslationItem(started.attempt.id, input, 'student-1')).rejects.toMatchObject({
+      code: 'ATTEMPT_TRANSLATION_GRADING_RATE_LIMITED',
+      status: 429,
+    });
+
+    expect(gradeTestTranslation).toHaveBeenCalledTimes(MAX_TRANSLATION_GRADING_REQUESTS_PER_WINDOW);
+    expect(db.read('testAttempts', started.attempt.id)?.translationGradeRequestWindows).toEqual({
+      'translation-assessment': {
+        '0': { windowStartedAt: timestamp, count: MAX_TRANSLATION_GRADING_REQUESTS_PER_WINDOW },
+      },
+    });
+    expect(await service.getActiveAttempt(startInput.origin, 'student-1')).not.toHaveProperty(
+      'translationGradeRequestWindows'
+    );
+    consoleError.mockRestore();
+  });
+
+  it('resets the provider request budget after the fixed window elapses', async () => {
+    const db = new FakeFirestore();
+    let now = timestamp;
+    db.seed('lessons', 'test-1', testDocument(['version-a']));
+    db.seed('testVersions', 'version-a', versionDocumentWith('version-a', translationGradingExercise, 8));
+    const gradeTestTranslation = jest.fn(async () => ({ score: 9, feedback: 'Accurate and idiomatic.' }));
+    const service = new TestAttemptService(db as never, () => now, { gradeTestTranslation });
+    const started = await service.startAttempt(startInput, 'student-1');
+    const storedAttempt = db.read('testAttempts', started.attempt.id)!;
+    db.seed('testAttempts', started.attempt.id, {
+      ...storedAttempt,
+      translationGradeRequestWindows: {
+        'translation-assessment': {
+          '0': { windowStartedAt: timestamp, count: MAX_TRANSLATION_GRADING_REQUESTS_PER_WINDOW },
+        },
+      },
+    });
+    now = new Date(Date.parse(timestamp) + TRANSLATION_GRADING_REQUEST_WINDOW_MS).toISOString();
+
+    await expect(
+      service.gradeTranslationItem(
+        started.attempt.id,
+        {
+          exerciseId: 'translation-assessment',
+          itemIndex: 0,
+          userTranslation: 'The girl sings.',
+        },
+        'student-1'
+      )
+    ).resolves.toMatchObject({
+      translationGrades: { 'translation-assessment': { '0': { score: 9 } } },
+    });
+    expect(gradeTestTranslation).toHaveBeenCalledTimes(1);
+    expect(db.read('testAttempts', started.attempt.id)?.translationGradeRequestWindows).toEqual({
+      'translation-assessment': { '0': { windowStartedAt: now, count: 1 } },
+    });
   });
 
   it('completes a score-only test on submission regardless of score', async () => {
@@ -1222,6 +1479,21 @@ describe('test attempt submission and sticky completion', () => {
 
 describe('test attempt summaries', () => {
   const normalOrigin: TestAttemptOrigin = { kind: 'normal-test', testId: 'test-1' };
+
+  it('defaults missing server-only translation state on legacy attempts without exposing it', async () => {
+    const db = new FakeFirestore();
+    const attemptId = 'legacy-active-attempt';
+    const sessionId = getTestAttemptSessionId('student-1', normalOrigin);
+    db.seed('testAttempts', attemptId, inProgressAttemptDocument(attemptId));
+    db.seed('testAttemptSessions', sessionId, sessionDocument(sessionId, 'student-1', normalOrigin, attemptId));
+    const service = new TestAttemptService(db as never, () => timestamp);
+
+    const projected = await service.getActiveAttempt(normalOrigin, 'student-1');
+
+    expect(projected).toMatchObject({ id: attemptId, status: 'in-progress' });
+    expect(projected).not.toHaveProperty('translationGradeReservations');
+    expect(projected).not.toHaveProperty('translationGradeRequestWindows');
+  });
 
   it('derives best, latest, count, and in-progress state per student and origin', async () => {
     const db = new FakeFirestore();

--- a/tests/testAuthoringService.test.ts
+++ b/tests/testAuthoringService.test.ts
@@ -10,7 +10,19 @@ const pages = [
     id: 'page-1',
     items: [
       { id: 'instructions', type: 'text', content: 'Read carefully.' },
-      { id: 'question-1', type: 'multiple-choice', maxPoints: 3 },
+      {
+        id: 'question-1',
+        type: 'multiple-choice',
+        maxPoints: 3,
+        data: {
+          question: 'Which answer is correct?',
+          options: [
+            { id: 'answer-a', text: 'A', isCorrect: true },
+            { id: 'answer-b', text: 'B', isCorrect: false },
+          ],
+          allowMultipleSelections: false,
+        },
+      },
     ],
   },
 ];

--- a/tests/testGradingFoundation.test.ts
+++ b/tests/testGradingFoundation.test.ts
@@ -6,7 +6,12 @@ import {
   sanitizeTestDeliveryState,
 } from '@/src/lib/tests/delivery';
 import { resolveGeneratedExerciseItems } from '@/src/lib/tests/generated-exercises';
-import { gradeGeneratedFormIdentification, gradeMatching } from '@/src/lib/tests/grading';
+import {
+  gradeClickOnMultipleWords,
+  gradeGeneratedFormIdentification,
+  gradeMatching,
+  gradeOddOneOut,
+} from '@/src/lib/tests/grading';
 import { estimateFirestoreDocumentBytes } from '@/src/lib/tests/firestore-size';
 import { applyValueFilter } from '@/src/lib/tests/generated-word-loader.server';
 import { filterOverlappingPronounParadigms } from '@/src/utils/generated/pronounParadigmFiltering';
@@ -15,6 +20,8 @@ import type {
   Exercise,
   GeneratedFormIdentificationExercise,
   MatchingExercise,
+  OddOneOutExercise,
+  ClickOnMultipleWordsExercise,
   TranslationGradingExercise,
 } from '@/src/types/exercises';
 import type {
@@ -89,10 +96,7 @@ describe('test grading foundation', () => {
       feedbackConfig,
       translationDirection: 'english-to-latin',
       data: {
-        items: [
-          { latinText: '<p>The girl&nbsp;sings.<br>Today.</p><p>Again.</p>' },
-          { latinText: 'The boys run.' },
-        ],
+        items: [{ latinText: '<p>The girl&nbsp;sings.<br>Today.</p><p>Again.</p>' }, { latinText: 'The boys run.' }],
       },
     };
     const state = await createFrozenTestDeliveryState(makeVersion(exercise), async () => []);
@@ -307,6 +311,119 @@ describe('test grading foundation', () => {
     ).toEqual({ awardedPoints: 4.5, maxPoints: 6 });
   });
 
+  it('does not credit a matching item with a duplicate display value but the wrong ID', () => {
+    const exercise: MatchingExercise = {
+      id: 'matching-duplicates',
+      type: 'matching',
+      title: 'Matching',
+      instructions: '',
+      maxPoints: 2,
+      feedbackConfig,
+      data: {
+        leftColumn: [{ id: 'left-a', value: 'A' }],
+        rightColumn: [
+          { id: 'right-a', value: 'Same label' },
+          { id: 'right-b', value: 'Same label' },
+        ],
+        answers: { 'left-a': 'right-a' },
+      },
+    };
+
+    expect(
+      gradeMatching(exercise, {
+        type: 'matching',
+        rounds: [{ 'left-a': 'right-b' }],
+      })
+    ).toEqual({ awardedPoints: 0, maxPoints: 2 });
+  });
+
+  it('rejects fractional matching repetitions before they can award more than maxPoints', () => {
+    const exercise: MatchingExercise = {
+      id: 'matching-fractional-rounds',
+      type: 'matching',
+      title: 'Matching',
+      instructions: '',
+      maxPoints: 2,
+      feedbackConfig,
+      data: {
+        leftColumn: [{ id: 'left-a', value: 'A' }],
+        rightColumn: [{ id: 'right-a', value: 'One' }],
+        answers: { 'left-a': 'right-a' },
+        requiredRepetitions: 1.5,
+      },
+    };
+
+    expect(() =>
+      gradeMatching(exercise, {
+        type: 'matching',
+        rounds: [{ 'left-a': 'right-a' }, { 'left-a': 'right-a' }],
+      })
+    ).toThrow('invalid requiredRepetitions');
+  });
+
+  it('fails strict click-selection scoring when any extra word is selected', () => {
+    const exercise: ClickOnMultipleWordsExercise = {
+      id: 'strict-click',
+      type: 'click-on-multiple-words',
+      title: 'Click',
+      instructions: '',
+      maxPoints: 3,
+      feedbackConfig,
+      data: {
+        passage: 'amo amas amat',
+        correctWordIndices: [0, 1],
+        allowOverSelection: false,
+      },
+    };
+
+    expect(
+      gradeClickOnMultipleWords(exercise, {
+        type: 'click-on-multiple-words',
+        selectedWordIndices: [0, 1, 2],
+      })
+    ).toEqual({ awardedPoints: 0, maxPoints: 3 });
+
+    expect(
+      gradeClickOnMultipleWords(exercise, {
+        type: 'click-on-multiple-words',
+        selectedWordIndices: [0],
+      })
+    ).toEqual({ awardedPoints: 1.5, maxPoints: 3 });
+  });
+
+  it('requires a nonblank explanation only when odd-one-out config requires one', () => {
+    const exercise: OddOneOutExercise = {
+      id: 'odd-one',
+      type: 'odd-one-out',
+      title: 'Odd one out',
+      instructions: '',
+      maxPoints: 2,
+      feedbackConfig,
+      data: {
+        question: 'Which one differs?',
+        items: [
+          { id: 'regular', text: 'Regular', isOddOneOut: false },
+          { id: 'odd', text: 'Odd', isOddOneOut: true },
+        ],
+        requireExplanation: true,
+      },
+    };
+    const blankAnswer = {
+      type: 'odd-one-out' as const,
+      selectedItemId: 'odd',
+      explanation: '<p><br>&nbsp;\u200B</p>',
+    };
+
+    expect(gradeOddOneOut(exercise, blankAnswer)).toEqual({ awardedPoints: 0, maxPoints: 2 });
+    expect(gradeOddOneOut(exercise, { ...blankAnswer, explanation: '<p>It has a different ending.</p>' })).toEqual({
+      awardedPoints: 2,
+      maxPoints: 2,
+    });
+    expect(gradeOddOneOut({ ...exercise, data: { ...exercise.data, requireExplanation: false } }, blankAnswer)).toEqual(
+      { awardedPoints: 2, maxPoints: 2 }
+    );
+  });
+
   it('does not throw when a multi-answer morphology response skips an intermediate step', () => {
     const exercise = {
       id: 'multi-morphology',
@@ -424,11 +541,7 @@ describe('test grading foundation', () => {
       ],
     }));
 
-    const state = await createFrozenTestDeliveryState(
-      version,
-      async () => [],
-      loadVocabularyPool as never
-    );
+    const state = await createFrozenTestDeliveryState(version, async () => [], loadVocabularyPool as never);
     const delivery = sanitizeTestDeliveryState(state);
 
     expect(loadVocabularyPool).toHaveBeenCalledWith('pool-one');

--- a/tests/testScoreFormatting.test.ts
+++ b/tests/testScoreFormatting.test.ts
@@ -1,0 +1,19 @@
+import { formatScorePercentage, formatScoreShortfall } from '@/src/lib/tests/formatting';
+
+describe('assessment percentage formatting', () => {
+  it('does not round a failing percentage up to the next whole number', () => {
+    expect(formatScorePercentage(79.999)).toBe('79.99');
+    expect(formatScorePercentage(79.6)).toBe('79.6');
+  });
+
+  it('keeps whole percentages compact and removes floating-point noise', () => {
+    expect(formatScorePercentage(80)).toBe('80');
+    expect(formatScorePercentage(66.6666666667)).toBe('66.66');
+    expect(formatScorePercentage(100.0000000001)).toBe('100');
+  });
+
+  it('keeps a positive near-threshold deficit visible', () => {
+    expect(formatScoreShortfall(0.001)).toBe('<0.01');
+    expect(formatScoreShortfall(0.4)).toBe('0.4');
+  });
+});

--- a/tests/testVersionEditorMockAssignment.test.tsx
+++ b/tests/testVersionEditorMockAssignment.test.tsx
@@ -75,7 +75,25 @@ const version = {
   id: 'version-1',
   name: 'Version A',
   pages: [
-    { id: 'page-1', title: 'Page A', items: [{ id: 'question-1', type: 'multiple-choice' as const, maxPoints: 1 }] },
+    {
+      id: 'page-1',
+      title: 'Page A',
+      items: [
+        {
+          id: 'question-1',
+          type: 'multiple-choice' as const,
+          maxPoints: 1,
+          data: {
+            question: 'Which answer is correct?',
+            options: [
+              { id: 'answer-a', text: 'A', isCorrect: true },
+              { id: 'answer-b', text: 'B', isCorrect: false },
+            ],
+            allowMultipleSelections: false,
+          },
+        },
+      ],
+    },
   ],
   totalPages: 1,
   totalItems: 1,

--- a/tests/testVersionExerciseValidation.test.ts
+++ b/tests/testVersionExerciseValidation.test.ts
@@ -1,0 +1,296 @@
+import {
+  createAnnotationId,
+  createSentenceDiagramFeedbackContent,
+  tokenizeDiagramSentence,
+} from '@/src/features/sentence-diagramming/model';
+import { testVersionDraftInputSchema, testVersionInputSchema } from '@/src/lib/tests/schemas';
+
+const diagramTokens = tokenizeDiagramSentence('amat');
+const diagramSpan = { startTokenIndex: 0, endTokenIndex: 0, startCharOffset: 0, endCharOffset: 4 };
+const diagramAnnotation = {
+  id: createAnnotationId('verb', diagramSpan),
+  kind: 'verb',
+  span: diagramSpan,
+};
+
+const validItems = {
+  matching: {
+    id: 'matching',
+    type: 'matching',
+    maxPoints: 1,
+    data: {
+      leftColumn: [{ id: 'left', value: 'amo' }],
+      rightColumn: [{ id: 'right', value: 'love' }],
+      answers: { left: 'right' },
+    },
+  },
+  'multiple-choice': {
+    id: 'multiple-choice',
+    type: 'multiple-choice',
+    maxPoints: 1,
+    data: {
+      question: 'Which answer is correct?',
+      options: [
+        { id: 'a', text: 'A', isCorrect: true },
+        { id: 'b', text: 'B', isCorrect: false },
+      ],
+      allowMultipleSelections: false,
+    },
+  },
+  'odd-one-out': {
+    id: 'odd-one-out',
+    type: 'odd-one-out',
+    maxPoints: 1,
+    data: {
+      question: 'Which item is different?',
+      items: [
+        { id: 'a', text: 'A', isOddOneOut: true },
+        { id: 'b', text: 'B', isOddOneOut: false },
+      ],
+    },
+  },
+  'table-fill': {
+    id: 'table-fill',
+    type: 'table-fill',
+    maxPoints: 1,
+    data: {
+      columns: [{ id: 'form', header: 'Form' }],
+      rows: [{ id: 'row', cells: { form: { content: '', isBlank: true, answer: 'amat' } } }],
+    },
+  },
+  'click-on-multiple-words': {
+    id: 'click-on-multiple-words',
+    type: 'click-on-multiple-words',
+    maxPoints: 1,
+    data: { passage: '<p>amo te</p>', correctWordIndices: [0], allowOverSelection: false },
+  },
+  fill: {
+    id: 'fill',
+    type: 'fill',
+    maxPoints: 1,
+    data: { items: [{ text: 'Marcus ___', answer: 'amat' }] },
+  },
+  'text-selection': {
+    id: 'text-selection',
+    type: 'text-selection',
+    maxPoints: 1,
+    data: {
+      passage: 'Marcus amat',
+      questions: [{ id: 'verb', text: 'Select the verb', correctWordIndex: 1 }],
+    },
+  },
+  'fill-embolded-text': {
+    id: 'fill-embolded-text',
+    type: 'fill-embolded-text',
+    maxPoints: 1,
+    data: { passage: 'Marcus amat', words: [{ wordIndex: 1, correctAnswer: 'loves' }] },
+  },
+  'sentence-diagramming': {
+    id: 'sentence-diagramming',
+    type: 'sentence-diagramming',
+    maxPoints: 1,
+    data: {
+      latin: 'amat',
+      translation: 'he loves',
+      tokens: diagramTokens,
+      solutionAnnotations: [diagramAnnotation],
+      availableStudentTools: ['verb'],
+      hint: createSentenceDiagramFeedbackContent(''),
+      explanation: createSentenceDiagramFeedbackContent(''),
+      difficulty: 'beginner',
+    },
+  },
+  'generated-translation': {
+    id: 'generated-translation',
+    type: 'generated-translation',
+    maxPoints: 1,
+    translationDirection: 'latin-to-english',
+    data: {
+      generatorConfig: {
+        collection: 'vocabulary_words',
+        wordSource: 'filters',
+        count: 5,
+      },
+      posConfigs: { noun: { enabled: true, filters: {} } },
+    },
+  },
+  'generated-form-identification': {
+    id: 'generated-form-identification',
+    type: 'generated-form-identification',
+    maxPoints: 1,
+    data: {
+      mode: 'step-by-step',
+      generatorConfig: {
+        collection: 'vocabulary_words',
+        wordSource: 'filters',
+        count: 5,
+      },
+      paradigmConfigs: {
+        'noun-declension': {
+          enabled: true,
+          steps: ['case', 'number'],
+          filters: {},
+          formSelection: { tableType: 'declension', selectedCellPaths: ['singular.nominative'] },
+        },
+      },
+    },
+  },
+  'translation-grading': {
+    id: 'translation-grading',
+    type: 'translation-grading',
+    maxPoints: 1,
+    translationDirection: 'latin-to-english',
+    data: { items: [{ latinText: 'Puella rosam videt.' }] },
+  },
+} satisfies Record<string, Record<string, unknown>>;
+
+const activeVersionResult = (item: Record<string, unknown>) =>
+  testVersionInputSchema.safeParse({
+    id: 'version',
+    name: 'Version',
+    pages: [{ id: 'page', items: [item] }],
+  });
+
+const messagesFor = (item: Record<string, unknown>) => {
+  const result = activeVersionResult(item);
+  return result.success ? [] : result.error.issues.map(entry => entry.message);
+};
+
+type MutableItem = Record<string, unknown> & { data: Record<string, unknown> };
+const copyItem = (item: Record<string, unknown>): MutableItem => JSON.parse(JSON.stringify(item)) as MutableItem;
+
+describe('active test exercise validation', () => {
+  it('accepts complete scoring configurations for every eligible exercise type', () => {
+    const result = testVersionInputSchema.safeParse({
+      id: 'version',
+      name: 'Version',
+      pages: [{ id: 'page', items: Object.values(validItems) }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('keeps partially authored exercises saveable as drafts but rejects activation', () => {
+    const incomplete = { id: 'question', type: 'multiple-choice', maxPoints: 1 };
+    const input = { id: 'version', name: 'Draft', pages: [{ id: 'page', items: [incomplete] }] };
+
+    expect(testVersionDraftInputSchema.safeParse(input).success).toBe(true);
+    expect(testVersionInputSchema.safeParse(input).success).toBe(false);
+  });
+
+  it('requires valid and complete matching IDs and mappings', () => {
+    const item = copyItem(validItems.matching);
+    item.data.answers = { left: 'missing-right', unknownLeft: 'right' };
+
+    expect(messagesFor(item)).toEqual(
+      expect.arrayContaining([
+        'Matching answers must reference an existing right-column ID',
+        'Matching answers cannot reference an unknown left-column ID',
+      ])
+    );
+  });
+
+  it('bounds matching repetitions to a small positive whole number', () => {
+    const fractional = copyItem(validItems.matching);
+    fractional.data.requiredRepetitions = 1.5;
+    const excessive = copyItem(validItems.matching);
+    excessive.data.requiredRepetitions = 11;
+
+    expect(activeVersionResult(fractional).success).toBe(false);
+    expect(activeVersionResult(excessive).success).toBe(false);
+  });
+
+  it('enforces answer-key cardinality for choice exercises', () => {
+    const multipleChoice = copyItem(validItems['multiple-choice']);
+    (multipleChoice.data.options as Array<{ isCorrect: boolean }>)[1].isCorrect = true;
+    const oddOneOut = copyItem(validItems['odd-one-out']);
+    (oddOneOut.data.items as Array<{ isOddOneOut: boolean }>)[0].isOddOneOut = false;
+
+    expect(messagesFor(multipleChoice)).toContain('Single-selection questions require exactly one correct option');
+    expect(messagesFor(oddOneOut)).toContain('Odd-one-out exercises require exactly one odd item');
+  });
+
+  it('requires a complete table grid, at least one blank, and an answer for every blank', () => {
+    const unansweredBlank = copyItem(validItems['table-fill']);
+    (unansweredBlank.data.rows as Array<{ cells: Record<string, { answer?: string }> }>)[0].cells.form.answer = '   ';
+    const missingCell = copyItem(validItems['table-fill']);
+    (missingCell.data.rows as Array<{ cells: Record<string, unknown> }>)[0].cells = {};
+
+    expect(messagesFor(unansweredBlank)).toContain('Every blank table cell requires a nonblank answer');
+    expect(messagesFor(missingCell)).toEqual(
+      expect.arrayContaining([
+        'Every row must contain a cell for every column',
+        'Table-fill exercises require at least one blank cell',
+      ])
+    );
+  });
+
+  it('rejects empty, duplicate, and out-of-passage click targets', () => {
+    const empty = copyItem(validItems['click-on-multiple-words']);
+    empty.data.correctWordIndices = [];
+    const invalid = copyItem(validItems['click-on-multiple-words']);
+    invalid.data.correctWordIndices = [0, 0, 8];
+
+    expect(messagesFor(empty)).toContain('Select at least one target word');
+    expect(messagesFor(invalid)).toEqual(
+      expect.arrayContaining(['Target word indices must be unique', 'Target word index is outside the passage'])
+    );
+  });
+
+  it('uses the sentence-diagram validator to reject empty or malformed solutions', () => {
+    const empty = copyItem(validItems['sentence-diagramming']);
+    empty.data.solutionAnnotations = [];
+    const malformed = copyItem(validItems['sentence-diagramming']);
+    (malformed.data.solutionAnnotations as Array<{ span: { endCharOffset: number } }>)[0].span.endCharOffset = 99;
+
+    expect(messagesFor(empty)).toContain('Add at least one solution annotation.');
+    expect(messagesFor(malformed)).toContain('Finite Verb has an invalid token or character span.');
+  });
+
+  it('rejects generated exercises that cannot resolve any scorable items', () => {
+    const translation = copyItem(validItems['generated-translation']);
+    translation.data.posConfigs = {};
+    const morphology = copyItem(validItems['generated-form-identification']);
+    const paradigms = morphology.data.paradigmConfigs as Record<
+      string,
+      { formSelection: { selectedCellPaths: string[] } }
+    >;
+    paradigms['noun-declension'].formSelection.selectedCellPaths = [];
+
+    expect(messagesFor(translation)).toContain(
+      'Filter-backed generated translations require at least one enabled part of speech'
+    );
+    expect(messagesFor(morphology)).toContain('Enabled morphology paradigms require at least one selected form');
+  });
+
+  it('accepts legacy generated configurations when they still resolve scorable items', () => {
+    const translation = copyItem(validItems['generated-translation']);
+    delete translation.data.posConfigs;
+    const translationGenerator = translation.data.generatorConfig as Record<string, unknown>;
+    delete translationGenerator.wordSource;
+    translationGenerator.filters = { partOfSpeech: 'noun' };
+
+    const morphology = copyItem(validItems['generated-form-identification']);
+    delete morphology.data.paradigmConfigs;
+    const morphologyGenerator = morphology.data.generatorConfig as Record<string, unknown>;
+    delete morphologyGenerator.wordSource;
+    morphologyGenerator.filters = { partOfSpeech: 'noun' };
+    morphologyGenerator.formSelection = {
+      tableType: 'declension',
+      selectedCellPaths: ['singular.nominative'],
+    };
+
+    expect(activeVersionResult(translation).success).toBe(true);
+    expect(activeVersionResult(morphology).success).toBe(true);
+  });
+
+  it('rejects empty static and AI-graded item collections', () => {
+    const fill = copyItem(validItems.fill);
+    fill.data.items = [];
+    const translation = copyItem(validItems['translation-grading']);
+    translation.data.items = [];
+
+    expect(messagesFor(fill)).toContain('Add at least one fill-in item');
+    expect(messagesFor(translation)).toContain('Add at least one translation prompt');
+  });
+});


### PR DESCRIPTION
## What changed

- Correct deterministic scoring edge cases:
  - strict click-selection answers with extras now score zero
  - matching uses authored right-side IDs instead of duplicate display labels
  - required odd-one-out explanations reject visually blank rich text
  - morphology partial credit rejects extra paths/fields without removing legitimate shorter partial answers
  - matching repetitions are bounded to whole values and defensively checked by the grader
- Validate every active exercise configuration before it can become student-visible. Drafts and persisted legacy documents remain readable, while Learning Path placement, mock transitions, placed-test rotation changes, and fresh attempt creation fail atomically for invalid configurations.
- Make AI translation grading one-shot and concurrency-safe with durable per-item leases, exact-request idempotency, server-only state, and a five-provider-call / ten-minute budget that persists across failures and generic saves.
- Add an answer-review/edit path that clears deterministic answers server-side before reopening them while preserving graded translations as final.
- Display score percentages without rounding a failing result up to a passing threshold, including visible sub-0.01 shortfalls.
- Stabilize assessment E2E card selectors and exclude generated Playwright artifacts from lint.

## Why

The audit found several independent integrity gaps: some graders trusted labels or extra-shaped answers, active versions only received generic page validation, legacy versions could be re-exposed through ownership and Learning Path transitions, and translation grading had no durable idempotency/concurrency/cost boundary. The review UI and percentage rounding could also mislead students around edits and passing thresholds.

These changes fail invalid authoring and visibility transitions before student delivery, prevent score inflation and AI grade fishing, preserve legacy reads/resumes where safe, and keep student-facing results precise.

## Verification

- `npm test -- --runInBand` — 111 suites, 725 tests passed
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm run test:e2e:assessment` — 4 Chromium journeys passed
- `git diff --check`

Independent blocker-only review of the final diff found no remaining scoring, correctness, or security blockers.
