### PR TITLE
Restore feedback in lesson previews

### DIFF
--- a/src/components/ui/lesson/lesson-player.tsx
+++ b/src/components/ui/lesson/lesson-player.tsx
@@ -43,7 +43,10 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
   resolvedExerciseState,
   testAttemptId,
 }) => {
-  const effectiveRuntimeMode = runtimeMode ?? (trackProgress ? 'practice' : 'preview');
+  // Lesson previews should preserve the normal student feedback experience.
+  // `trackProgress` controls persistence independently; assessment callers pass
+  // an explicit runtime mode when answer-revealing feedback must be withheld.
+  const effectiveRuntimeMode = runtimeMode ?? 'practice';
   const shouldTrackProgress = trackProgress && effectiveRuntimeMode === 'practice';
   const { user } = useAuth();
   const [markExerciseComplete] = useMarkExerciseCompleteMutation();
@@ -119,7 +122,7 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
 
   const handleDiagrammingAttempt = useCallback(
     async (itemIndex: number, exerciseId: string, attempt: DiagramAuditSubmission) => {
-      if (effectiveRuntimeMode === 'preview') return;
+      if (effectiveRuntimeMode === 'preview' || (effectiveRuntimeMode === 'practice' && !shouldTrackProgress)) return;
       const token = await auth.currentUser?.getIdToken();
       if (!token) return;
       const source =
@@ -146,7 +149,7 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
         console.warn('Unable to record diagramming attempt', error);
       }
     },
-    [currentPageIndex, effectiveRuntimeMode, lesson.id, testAttemptId]
+    [currentPageIndex, effectiveRuntimeMode, lesson.id, shouldTrackProgress, testAttemptId]
   );
 
   const isListeningLesson = lesson.type === 'listening';

--- a/tests/lessonPlayerPreview.test.tsx
+++ b/tests/lessonPlayerPreview.test.tsx
@@ -82,10 +82,10 @@ beforeEach(() => {
 });
 
 describe('LessonPlayer preview mode', () => {
-  it('does not persist page, exercise, or completion progress', async () => {
+  it('preserves practice feedback mode without persisting progress', async () => {
     render(<LessonPlayer lesson={lesson} trackProgress={false} />);
 
-    expect(screen.getByText('Runtime mode: preview')).toBeInTheDocument();
+    expect(screen.getByText('Runtime mode: practice')).toBeInTheDocument();
     await waitFor(() => expect(mockUpdatePageProgress).not.toHaveBeenCalled());
     fireEvent.click(screen.getByRole('button', { name: 'Complete exercise' }));
     fireEvent.click(screen.getByRole('button', { name: 'Finish lesson' }));


### PR DESCRIPTION
## What changed

- Keep ordinary lesson previews in practice feedback mode while leaving progress tracking disabled.
- Prevent lesson-preview sentence-diagram attempts from being persisted.
- Update the preview regression test to assert practice feedback behavior and no progress writes.

## Why

Lesson previews were implicitly assigned the shared `preview` runtime mode whenever progress tracking was disabled. Exercise components treat every non-practice mode as an assessment, so admin lesson previews replaced correctness, hints, and configured answer reveals with `Answer recorded.`

This separates the feedback policy from persistence: lesson previews now behave like student practice without saving progress. Actual tests and test-version previews continue using assessment behavior and withholding answers.

## Validation

- `npm test -- --runInBand tests/lessonPlayerPreview.test.tsx tests/runtimeModeScoring.test.tsx`
- `npx eslint src/components/ui/lesson/lesson-player.tsx tests/lessonPlayerPreview.test.tsx`
- `git diff --check`
