### PR TITLE
Clarify the student test flow

### DIFF
--- a/src/app/test/[testId]/page.tsx
+++ b/src/app/test/[testId]/page.tsx
@@ -493,20 +493,21 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
               <div className="font-semibold text-roman-red">
                 {test.passingPercentage === null
                   ? isMockTest
-                    ? 'Score only — this mock is practice and never gates your Learning Path'
-                    : 'Score only — this test cannot be failed'
+                    ? 'Practice only — your score will not affect your Learning Path'
+                    : 'Complete this test to continue — any score counts'
                   : isMockTest
-                    ? `Practice target: ${test.passingPercentage}% — informational only`
-                    : `Passing requirement: ${test.passingPercentage}%`}
+                    ? `Aim for ${test.passingPercentage}% — this is practice and will not affect your Learning Path`
+                    : `Score ${test.passingPercentage}% or higher to continue along your Learning Path`}
               </div>
               <div className="mt-1 shrink-0 text-sm text-roman-stone sm:mt-0">{points} · Untimed</div>
             </div>
             <ul className="space-y-3 rounded-xl border border-slate-200 bg-slate-50/70 p-4 text-sm leading-6 text-slate-700">
               <li className="flex gap-3 before:mt-2.5 before:h-1.5 before:w-1.5 before:shrink-0 before:rounded-full before:bg-roman-red">
-                Translation exercises show brief AI feedback; other feedback appears after submission.
+                For translations, you’ll get brief guidance as you go. Feedback on other questions appears after you
+                submit.
               </li>
               <li className="flex gap-3 before:mt-2.5 before:h-1.5 before:w-1.5 before:shrink-0 before:rounded-full before:bg-roman-red">
-                Your committed answers are saved and can be resumed after a refresh.
+                Your answers save automatically, so you can refresh or return later without losing your work.
               </li>
               <li className="flex gap-3 before:mt-2.5 before:h-1.5 before:w-1.5 before:shrink-0 before:rounded-full before:bg-roman-red">
                 Review your answers before submitting.

--- a/src/components/ui/admin/vocabulary-pools/PoolList.tsx
+++ b/src/components/ui/admin/vocabulary-pools/PoolList.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Button } from '@/src/components/ui/button';
 import { Badge } from '@/src/components/ui/badge';
 import { RomanCard, RomanCardContent } from '@/src/components/ui/core/roman-card';
+import { SimpleRichDisplay } from '@/src/components/ui/core/simple-rich-display';
 import { Edit, Trash2, Library, Calendar, Hash, Loader2 } from 'lucide-react';
 import { useInfiniteScroll } from '@/src/hooks/useInfiniteScroll';
 import type { VocabularyPoolSummary, VocabularyPoolUsage } from '@/src/types/vocabulary-pool';
@@ -114,10 +115,10 @@ export const PoolList: React.FC<PoolListProps> = ({
                           <li key={usage.id}>
                             {usage.editorUrl ? (
                               <a href={usage.editorUrl} className="text-roman-red hover:underline">
-                                {usage.label}
+                                <SimpleRichDisplay content={usage.label} />
                               </a>
                             ) : (
-                              usage.label
+                              <SimpleRichDisplay content={usage.label} />
                             )}
                           </li>
                         ))}

--- a/src/components/ui/exercises/fill-exercise.tsx
+++ b/src/components/ui/exercises/fill-exercise.tsx
@@ -86,6 +86,7 @@ const FillExerciseComponent: React.FC<Props> = ({ exercise, onComplete, runtimeM
     if (testAnswerMode) {
       onAnswer?.({ type: 'fill', answers: nextAnswers });
       setTestSubmitted(true);
+      if (isLastItem) onComplete?.(0);
       return;
     }
 
@@ -190,7 +191,7 @@ const FillExerciseComponent: React.FC<Props> = ({ exercise, onComplete, runtimeM
         />
 
         {testAnswerMode ? (
-          testSubmitted && <RecordedAnswerControls isLastItem={isLastItem} onContinue={continueTest} />
+          testSubmitted && <RecordedAnswerControls isLastItem={isLastItem} onContinue={continueTest} hideFinishAction />
         ) : (
           <FeedbackDisplay
             isCorrect={isCorrect}

--- a/src/components/ui/exercises/recorded-answer-controls.tsx
+++ b/src/components/ui/exercises/recorded-answer-controls.tsx
@@ -5,16 +5,23 @@ import { Button } from '@/src/components/ui/button';
 interface RecordedAnswerControlsProps {
   isLastItem: boolean;
   onContinue: () => void;
+  hideFinishAction?: boolean;
 }
 
-export const RecordedAnswerControls: React.FC<RecordedAnswerControlsProps> = ({ isLastItem, onContinue }) => (
+export const RecordedAnswerControls: React.FC<RecordedAnswerControlsProps> = ({
+  isLastItem,
+  onContinue,
+  hideFinishAction = false,
+}) => (
   <div className="mt-4 space-y-3">
     <div className="flex items-center gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-900">
       <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-600" aria-hidden="true" />
       <span>Answer recorded.</span>
     </div>
-    <Button onClick={onContinue} className="w-full rounded-xl">
-      {isLastItem ? 'Finish exercise' : 'Continue'}
-    </Button>
+    {(!isLastItem || !hideFinishAction) && (
+      <Button onClick={onContinue} className="w-full rounded-xl">
+        {isLastItem ? 'Finish exercise' : 'Continue'}
+      </Button>
+    )}
   </div>
 );

--- a/tests/e2e/assessment-acceptance.spec.ts
+++ b/tests/e2e/assessment-acceptance.spec.ts
@@ -14,7 +14,7 @@ test.describe('Assessment acceptance', () => {
     await expect(card).toContainText('Score only · cannot fail');
     await card.getByRole('button', { name: 'Start Test' }).click();
 
-    await expect(page.getByText('Score only — this test cannot be failed')).toBeVisible();
+    await expect(page.getByText('Complete this test to continue — any score counts')).toBeVisible();
     await page.getByRole('button', { name: 'Start Test' }).click();
     await recordFillAnswer(page, 'love');
     await submitCurrentTest(page);
@@ -28,7 +28,7 @@ test.describe('Assessment acceptance', () => {
   test('required-pass failure gates and nudges, then pass and a failed retake never relock', async ({ page }) => {
     await signIn(page, E2E_USERS.requiredPass);
     await dashboardCard(page, 'Required-pass checkpoint').getByRole('button', { name: 'Start Test' }).click();
-    await expect(page.getByText('Passing requirement: 100%')).toBeVisible();
+    await expect(page.getByText('Score 100% or higher to continue along your Learning Path')).toBeVisible();
     await page.getByRole('button', { name: 'Start Test' }).click();
     await recordFillAnswer(page, 'wrong');
     await submitCurrentTest(page);
@@ -102,7 +102,7 @@ test.describe('Assessment acceptance', () => {
     });
 
     await page.reload();
-    await expect(page.getByText('Score only — this test cannot be failed')).toBeVisible();
+    await expect(page.getByText('Complete this test to continue — any score counts')).toBeVisible();
     await page.getByRole('button', { name: 'Continue Test' }).click();
     await expect(page.getByText('amo, amare', { exact: true })).toBeVisible();
     await expect(page.getByPlaceholder('Type your answer...')).toHaveValue('love');
@@ -188,7 +188,9 @@ test.describe('Assessment acceptance', () => {
     ]);
     const mockCard = dashboardCard(studentPage, 'Ordered fixed-version mock');
     await mockCard.getByRole('button', { name: 'Start Mock Test' }).click();
-    await expect(studentPage.getByText('Practice target: 80% — informational only')).toBeVisible();
+    await expect(
+      studentPage.getByText('Aim for 80% — this is practice and will not affect your Learning Path')
+    ).toBeVisible();
     await studentPage.getByRole('button', { name: 'Start Mock Test' }).click();
     await expect(studentPage.getByText('fixed-version-prompt')).toBeVisible();
     await recordFillAnswer(studentPage, 'fixed-answer');

--- a/tests/studentTestPage.test.tsx
+++ b/tests/studentTestPage.test.tsx
@@ -207,8 +207,8 @@ describe('student normal test flow', () => {
       </Suspense>
     );
 
-    expect(await screen.findByText('Passing requirement: 70%')).toBeInTheDocument();
-    expect(screen.getByText(/committed answers are saved and can be resumed/i)).toBeInTheDocument();
+    expect(await screen.findByText('Score 70% or higher to continue along your Learning Path')).toBeInTheDocument();
+    expect(screen.getByText(/answers save automatically/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Start Test' }));
     expect(await screen.findByRole('button', { name: 'Record two answers' })).toBeInTheDocument();

--- a/tests/testDeliveryRendering.test.tsx
+++ b/tests/testDeliveryRendering.test.tsx
@@ -58,13 +58,18 @@ describe('sanitized test delivery rendering', () => {
     };
     const { content } = sanitizeExercise(exercise);
     const onAnswer = jest.fn();
+    const onComplete = jest.fn();
 
-    render(<ContentRenderer content={content.items[0]} runtimeMode="test" onAnswer={onAnswer} />);
+    render(
+      <ContentRenderer content={content.items[0]} runtimeMode="test" onAnswer={onAnswer} onComplete={onComplete} />
+    );
     fireEvent.change(screen.getByPlaceholderText('Type your answer'), { target: { value: 'response' } });
     fireEvent.click(screen.getByRole('button', { name: 'Check' }));
 
     expect(screen.getByText('Answer recorded.')).toBeInTheDocument();
     expect(onAnswer).toHaveBeenCalledWith(expect.objectContaining({ answer: { type: 'fill', answers: ['response'] } }));
+    expect(onComplete).toHaveBeenCalledWith(0);
+    expect(screen.queryByRole('button', { name: 'Finish exercise' })).not.toBeInTheDocument();
   });
 
   it('restores the authenticated student committed answer when an attempt resumes', () => {

--- a/tests/vocabularyPoolList.test.tsx
+++ b/tests/vocabularyPoolList.test.tsx
@@ -61,4 +61,33 @@ describe('vocabulary pool list usage status', () => {
     expect(screen.getByText('Lesson: Three')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument();
   });
+
+  it('renders rich text in assigned usage labels instead of showing HTML tags', () => {
+    render(
+      <PoolList
+        pools={[pool]}
+        loading={false}
+        loadingMore={false}
+        hasMore={false}
+        onLoadMore={jest.fn()}
+        onEdit={jest.fn()}
+        onDelete={jest.fn()}
+        usagesByPoolId={{
+          'pool-1': [
+            {
+              id: 'rich-usage',
+              poolId: 'pool-1',
+              kind: 'lesson-exercise',
+              label: 'Lesson: <p></p> (Copy) → <p><strong>Dictionary Entries</strong></p>',
+              editorUrl: '/admin/lessons/edit/one',
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByRole('link', { name: 'Lesson: (Copy) → Dictionary Entries' })).toBeInTheDocument();
+    expect(screen.getByText('Dictionary Entries').tagName).toBe('STRONG');
+    expect(screen.queryByText(/<p>/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- remove the redundant final action from fill-in-the-blank test exercises
- complete the final fill item as soon as its answer is recorded
- rewrite test and mock-test introductions in student-friendly language
- keep practice outcomes and Learning Path consequences explicit

## Why

The final “Finish exercise” button did not provide meaningful navigation or persistence after the answer had already been saved. Some introduction text also described assessment behavior using implementation-oriented terms such as “gate” and “committed answers.”

## Student impact

Students now finish fill-in-the-blank questions with one clear action and see plain-language explanations of whether a score affects their Learning Path.

## Validation

- ESLint on the changed source and test files
- `tests/testDeliveryRendering.test.tsx`
- `tests/studentTestPage.test.tsx`
- `tests/testTakingView.test.tsx`
- 24 relevant Jest tests passing
