### PR TITLE
Render vocabulary pool assignments as rich text

### DIFF
--- a/src/components/ui/admin/vocabulary-pools/PoolList.tsx
+++ b/src/components/ui/admin/vocabulary-pools/PoolList.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Button } from '@/src/components/ui/button';
 import { Badge } from '@/src/components/ui/badge';
 import { RomanCard, RomanCardContent } from '@/src/components/ui/core/roman-card';
+import { SimpleRichDisplay } from '@/src/components/ui/core/simple-rich-display';
 import { Edit, Trash2, Library, Calendar, Hash, Loader2 } from 'lucide-react';
 import { useInfiniteScroll } from '@/src/hooks/useInfiniteScroll';
 import type { VocabularyPoolSummary, VocabularyPoolUsage } from '@/src/types/vocabulary-pool';
@@ -114,10 +115,10 @@ export const PoolList: React.FC<PoolListProps> = ({
                           <li key={usage.id}>
                             {usage.editorUrl ? (
                               <a href={usage.editorUrl} className="text-roman-red hover:underline">
-                                {usage.label}
+                                <SimpleRichDisplay content={usage.label} />
                               </a>
                             ) : (
-                              usage.label
+                              <SimpleRichDisplay content={usage.label} />
                             )}
                           </li>
                         ))}

--- a/tests/vocabularyPoolList.test.tsx
+++ b/tests/vocabularyPoolList.test.tsx
@@ -61,4 +61,33 @@ describe('vocabulary pool list usage status', () => {
     expect(screen.getByText('Lesson: Three')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument();
   });
+
+  it('renders rich text in assigned usage labels instead of showing HTML tags', () => {
+    render(
+      <PoolList
+        pools={[pool]}
+        loading={false}
+        loadingMore={false}
+        hasMore={false}
+        onLoadMore={jest.fn()}
+        onEdit={jest.fn()}
+        onDelete={jest.fn()}
+        usagesByPoolId={{
+          'pool-1': [
+            {
+              id: 'rich-usage',
+              poolId: 'pool-1',
+              kind: 'lesson-exercise',
+              label: 'Lesson: <p></p> (Copy) → <p><strong>Dictionary Entries</strong></p>',
+              editorUrl: '/admin/lessons/edit/one',
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByRole('link', { name: 'Lesson: (Copy) → Dictionary Entries' })).toBeInTheDocument();
+    expect(screen.getByText('Dictionary Entries').tagName).toBe('STRONG');
+    expect(screen.queryByText(/<p>/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## What changed

- Render assigned vocabulary-pool lesson and exercise labels with the existing rich-text display component.
- Add a regression test proving formatted labels render as markup instead of literal HTML tags.

## Why

Assignment labels include saved rich-text lesson/page/exercise titles. The pool list previously rendered the label as plain text, exposing tags such as `<p>` in the admin UI.

## Validation

- `npm test -- --runInBand tests/vocabularyPoolList.test.tsx tests/vocabularyPoolUsage.test.ts`
- `npx eslint src/components/ui/admin/vocabulary-pools/PoolList.tsx tests/vocabularyPoolList.test.tsx`
- `git diff --check`