### PR TITLE
Make Morphology configuration frictionless

### DIFF
--- a/src/app/admin/(shell)/lessons/live/page.tsx
+++ b/src/app/admin/(shell)/lessons/live/page.tsx
@@ -46,6 +46,7 @@ import { useGetTestsQuery } from '@/src/store/api/testApi';
 import type { LessonSummary } from '@/src/types/lesson';
 import type { PracticeLessonType } from '@/src/types/practice-category';
 import type { TestUnitSummary } from '@/src/types/test';
+import type { LearningPathLessonIssue } from '@/src/types/learning-unit';
 
 type LessonType = 'normal' | PracticeLessonType;
 type FilterStatus = 'all' | 'live' | 'draft';
@@ -182,6 +183,15 @@ function LiveLessonsPage() {
   const pathUnits = pathUnitIds.map(id => pathUnitById.get(id)).filter(Boolean) as Array<
     LessonSummary | TestUnitSummary
   >;
+  const lessonIssuesById: Record<string, LearningPathLessonIssue[]> = pathView?.lessonIssuesById ?? {};
+  const affectedPathLessons = pathUnitIds
+    .map(id => {
+      const unit = pathUnitById.get(id);
+      if (!unit || unit.kind === 'test') return null;
+      const issues = lessonIssuesById[id] ?? [];
+      return issues.length > 0 ? { unit, issues } : null;
+    })
+    .filter((entry): entry is { unit: LessonSummary; issues: LearningPathLessonIssue[] } => entry !== null);
   const unplacedNormalLessons = normalLessons
     .filter(lesson => !pathUnitIds.includes(lesson.id))
     .sort((left, right) => left.title.localeCompare(right.title));
@@ -328,6 +338,7 @@ function LiveLessonsPage() {
         unitIds: [...result.path.unitIds],
       });
       setPathConflict(null);
+      await refetchPath();
       toast.success('Learning Path saved');
     } catch (error) {
       if (hasApiErrorStatus(error, 409) && getApiErrorCode(error) === 'STALE_LEARNING_PATH_REVISION') {
@@ -587,6 +598,40 @@ function LiveLessonsPage() {
                     {pathView.editBlockedReason}
                   </p>
                 )}
+                {affectedPathLessons.length > 0 && (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="mt-3 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950">
+                    <p className="font-medium">
+                      {affectedPathLessons.length} lesson{affectedPathLessons.length === 1 ? '' : 's'} need
+                      {affectedPathLessons.length === 1 ? 's' : ''} attention
+                    </p>
+                    <p className="mt-1">
+                      These warnings do not block Learning Path changes, but the affected lessons should be repaired
+                      before students use them.
+                    </p>
+                    <ul className="mt-2 space-y-2">
+                      {affectedPathLessons.map(({ unit, issues }) => (
+                        <li key={unit.id} className="flex flex-wrap items-center justify-between gap-2">
+                          <span>
+                            <strong>{unit.title}</strong> ({issues.length} {issues.length === 1 ? 'issue' : 'issues'})
+                          </span>
+                          <Button size="sm" variant="outline" asChild>
+                            <Link
+                              href={`/admin/lessons/edit/${unit.id}`}
+                              onClick={event => {
+                                event.preventDefault();
+                                navigateFromPathDraft(`/admin/lessons/edit/${unit.id}`);
+                              }}>
+                              Fix lesson
+                            </Link>
+                          </Button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
                 {pathConflict && (
                   <div className="mt-3 rounded-md border border-orange-200 bg-orange-50 px-3 py-3 text-sm text-orange-950">
                     <p className="font-medium">A newer canonical Learning Path is available.</p>
@@ -716,6 +761,7 @@ function LiveLessonsPage() {
                               <SortableLearningPathLesson
                                 unit={unit}
                                 index={index}
+                                issues={unit.kind === 'test' ? [] : (lessonIssuesById[unit.id] ?? [])}
                                 disabled={!pathView?.canEdit || pathSaving}
                                 onNavigate={navigateFromPathDraft}
                                 onRemove={() =>

--- a/src/app/api/admin/words/route.ts
+++ b/src/app/api/admin/words/route.ts
@@ -4,7 +4,9 @@ import { Query, FieldPath } from 'firebase-admin/firestore';
 import { VocabularyWordSchema } from '@/shared/types/vocabulary/schemas';
 import { parseFormPathFromString } from '@/src/utils/exerciseFormPaths';
 import { TABLE_TYPE_CONFIG, type TableType } from '@/src/utils/schema-helpers';
+import type { FormIdentificationStep } from '@/src/types/exercises/schemas/form-identification';
 import { scanTableForMatchingForms, categorizeMatchingPaths } from '@/src/utils/tableScanner';
+import { getApplicableStepsForFormPath } from '@/src/utils/exercises/formIdentificationCompatibility';
 import { AdminAccessError, verifyAdminAccess, verifyAuthenticatedAccess } from '@/src/lib/verifyAdminAccess';
 import {
   requireVocabularyWordsCollection,
@@ -74,6 +76,11 @@ const parseCellPaths = (cellPaths: string | null): string[] => {
     .split(',')
     .map(p => p.trim())
     .filter(p => p.length > 0);
+};
+
+const parseSteps = (steps: string | null): FormIdentificationStep[] => {
+  if (!steps) return [];
+  return steps.split(',').map(step => step.trim()).filter(Boolean) as FormIdentificationStep[];
 };
 
 const parseSelectFields = (selectFields: string | null): string[] => {
@@ -172,6 +179,8 @@ export async function handleVocabularyWordsGET(
     const pronounType = searchParams.get('pronounType');
     const pronounPerson = searchParams.get('pronounPerson');
     const cellPaths = searchParams.get('cellPaths');
+    const steps = searchParams.get('steps');
+    const stepValues = parseSteps(steps);
     const tableType = searchParams.get('tableType');
     const selectFields = searchParams.get('select');
     const fetchAll = searchParams.get('fetchAll') === 'true';
@@ -198,6 +207,8 @@ export async function handleVocabularyWordsGET(
         return generatedRequestError(`Generated word limit must be between 1 and ${GENERATED_MAX_RESULTS}`);
       if (pathValues.length > GENERATED_MAX_CELL_PATHS || (cellPaths?.length ?? 0) > 10_000)
         return generatedRequestError('Generated word cellPaths are too large');
+      if (stepValues.length > 20 || (steps?.length ?? 0) > 2_000)
+        return generatedRequestError('Generated word steps are too large');
       if (
         selectValues.length > GENERATED_MAX_LIST_VALUES ||
         selectValues.some(field => field.length > 100 || !/^[A-Za-z0-9_.]+$/.test(field))
@@ -426,7 +437,7 @@ export async function handleVocabularyWordsGET(
           const paths = parseCellPaths(cellPaths);
 
           if (paths.length > 0 && tableType) {
-            const formResult = pickRandomFormServer(serialized, tableType as TableType, paths);
+            const formResult = pickRandomFormServer(serialized, tableType as TableType, paths, stepValues);
 
             if (!formResult) {
               return null;
@@ -771,7 +782,8 @@ interface FormSelectionResult {
 function pickRandomFormServer(
   word: Record<string, unknown>,
   tableType: TableType,
-  selectedPaths: string[]
+  selectedPaths: string[],
+  selectedSteps: readonly FormIdentificationStep[] = []
 ): FormSelectionResult | null {
   const rootField = TABLE_TYPE_CONFIG[tableType];
   if (!rootField) {
@@ -785,7 +797,13 @@ function pickRandomFormServer(
 
   const formsWithPaths: Array<{ form: string; path: string }> = [];
 
-  for (const path of selectedPaths) {
+  const compatiblePaths = selectedSteps.length
+    ? selectedPaths.filter(
+        path => (getApplicableStepsForFormPath(path, tableType, selectedSteps)?.applicableSteps.length ?? 0) > 0
+      )
+    : selectedPaths;
+
+  for (const path of compatiblePaths) {
     const fullPath = `${rootField}.${path}`;
     const forms = getCellValueAtPathServer(word, fullPath);
 
@@ -802,7 +820,7 @@ function pickRandomFormServer(
 
   const allMatchingPaths = scanTableForMatchingForms(table, selected.form, tableType);
 
-  const { primaryPaths, optionalPaths } = categorizeMatchingPaths(allMatchingPaths, selectedPaths);
+  const { primaryPaths, optionalPaths } = categorizeMatchingPaths(allMatchingPaths, compatiblePaths);
 
   if (!primaryPaths.includes(selected.path)) {
     primaryPaths.unshift(selected.path);

--- a/src/components/admin/SortableLearningPathLesson.tsx
+++ b/src/components/admin/SortableLearningPathLesson.tsx
@@ -6,6 +6,7 @@ import { BookOpen, FileCheck2, GripVertical, ShieldAlert, X } from 'lucide-react
 import Link from 'next/link';
 import type { LessonSummary } from '@/src/types/lesson';
 import type { TestUnitSummary } from '@/src/types/test';
+import type { LearningPathLessonIssue } from '@/src/types/learning-unit';
 import { Badge } from '@/src/components/ui/badge';
 import { Button } from '@/src/components/ui/button';
 import { SimpleRichDisplay } from '@/src/components/ui/core/simple-rich-display';
@@ -16,18 +17,22 @@ export function SortableLearningPathLesson({
   disabled,
   onRemove,
   onNavigate,
+  issues = [],
 }: {
   unit: LessonSummary | TestUnitSummary;
   index: number;
   disabled: boolean;
   onRemove: () => void;
   onNavigate?: (href: string) => void;
+  issues?: LearningPathLessonIssue[];
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: unit.id,
     disabled,
   });
   const isTest = unit.kind === 'test';
+  const hasIssues = !isTest && issues.length > 0;
+  const editHref = isTest ? `/admin/tests/edit/${unit.id}` : `/admin/lessons/edit/${unit.id}`;
 
   return (
     <div
@@ -81,6 +86,14 @@ export function SortableLearningPathLesson({
               'Lesson'
             )}
           </Badge>
+          {hasIssues && (
+            <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-900">
+              <span className="inline-flex items-center gap-1">
+                <ShieldAlert className="h-3 w-3" aria-hidden="true" />
+                Needs attention
+              </span>
+            </Badge>
+          )}
         </div>
         {unit.description && (
           <div className="mb-2 line-clamp-1 text-sm text-gray-600">
@@ -104,17 +117,29 @@ export function SortableLearningPathLesson({
             </>
           )}
         </div>
+        {hasIssues && (
+          <div
+            role="alert"
+            className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950">
+            <p className="font-medium">This lesson needs attention before students use it.</p>
+            <ul className="mt-1 list-disc space-y-1 pl-5">
+              {issues.map((issue, issueIndex) => (
+                <li key={`${issue.code}-${issue.message}-${issueIndex}`}>{issue.message}</li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
 
       <Button size="sm" variant="outline" asChild>
         <Link
-          href={isTest ? `/admin/tests/edit/${unit.id}` : `/admin/lessons/edit/${unit.id}`}
+          href={editHref}
           onClick={event => {
             if (!onNavigate) return;
             event.preventDefault();
-            onNavigate(isTest ? `/admin/tests/edit/${unit.id}` : `/admin/lessons/edit/${unit.id}`);
+            onNavigate(editHref);
           }}>
-          Edit
+          {hasIssues ? 'Fix lesson' : 'Edit'}
         </Link>
       </Button>
       <Button

--- a/src/components/ui/admin/content-editor/GeneratedFormIdentificationEditor.tsx
+++ b/src/components/ui/admin/content-editor/GeneratedFormIdentificationEditor.tsx
@@ -166,7 +166,7 @@ const GeneratedFormIdentificationEditorView: React.FC<{
     const basePrimaryPaths = (word.primary_form_paths || (word.form_path ? [word.form_path] : [])) as Array<
       Record<string, string | undefined>
     >;
-    return getAnswerableStepsForWord(word, editingContent.data.paradigmConfigs?.[paradigm]?.steps || [], basePrimaryPaths);
+    return getAnswerableStepsForWord(word, editor.paradigmConfigs[paradigm]?.steps || [], basePrimaryPaths);
   };
 
   return (
@@ -272,9 +272,9 @@ const GeneratedFormIdentificationEditorView: React.FC<{
       {configurationMessages.length > 0 && (
         <Alert className="border-amber-200 bg-amber-50 text-amber-900">
           <AlertTriangle className="h-4 w-4 text-amber-600" />
-          <AlertTitle>Selected form needs a question</AlertTitle>
+          <AlertTitle>No answerable morphology forms remain</AlertTitle>
           <AlertDescription>
-            <p>Choose at least one question that applies to every selected form before saving.</p>
+            <p>Add a compatible question or select a different form before saving.</p>
             <ul className="list-disc pl-4">
               {configurationMessages.map(message => (
                 <li key={message}>{message}</li>
@@ -295,7 +295,7 @@ const GeneratedFormIdentificationEditorView: React.FC<{
         <MultiParadigmConfigSection
           availableParadigms={editor.paradigmInfo.availableParadigms}
           paradigmWordCounts={editor.paradigmInfo.paradigmWordCounts}
-          paradigmConfigs={editingContent.data.paradigmConfigs ?? {}}
+          paradigmConfigs={editor.paradigmConfigs}
           onUpdateParadigmConfig={editor.handleUpdateParadigmConfig}
           onToggleParadigm={editor.handleToggleParadigm}
         />

--- a/src/components/ui/admin/content-editor/MultiParadigmConfigSection.tsx
+++ b/src/components/ui/admin/content-editor/MultiParadigmConfigSection.tsx
@@ -37,7 +37,12 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { restrictToVerticalAxis, restrictToParentElement } from '@dnd-kit/modifiers';
-import { GripVertical } from 'lucide-react';
+import { AlertTriangle, GripVertical } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/src/components/ui/alert';
+import {
+  getCompatibilityStepLabels,
+  getFormIdentificationCompatibilitySummary,
+} from '@/src/utils/exercises/formIdentificationCompatibility';
 
 interface MultiParadigmConfigSectionProps {
   availableParadigms: FormParadigm[];
@@ -80,6 +85,12 @@ const getFormSelectionProps = (paradigm: FormParadigm) => {
   }
   return { partOfSpeech: pos, pronounType: undefined, pronounPerson: undefined };
 };
+
+const getSkippedSelectionCount = (summary: ReturnType<typeof getFormIdentificationCompatibilitySummary> | null) =>
+  summary ? summary.skipped.length + summary.unknownPaths.length : 0;
+
+const getSkippedFormLabel = (label: string, count: number) =>
+  label.toLowerCase().replace(/ forms$/, count === 1 ? ' form' : ' forms');
 
 export const MultiParadigmConfigSection: React.FC<MultiParadigmConfigSectionProps> = ({
   availableParadigms,
@@ -178,6 +189,37 @@ export const MultiParadigmConfigSection: React.FC<MultiParadigmConfigSectionProp
   const currentSteps = currentConfig?.steps || [];
   const tableType = PARADIGM_TABLE_TYPE[activeParadigm];
   const relevantFilters = PARADIGM_RELEVANT_FILTERS[activeParadigm];
+  const getCompatibilitySummaryForParadigm = (paradigm: FormParadigm) => {
+    const config = paradigmConfigs[paradigm];
+    if (!config?.enabled || !config.formSelection) return null;
+    return getFormIdentificationCompatibilitySummary(
+      PARADIGM_TABLE_TYPE[paradigm],
+      config.formSelection.selectedCellPaths,
+      config.steps || []
+    );
+  };
+  const compatibilitySummary = getCompatibilitySummaryForParadigm(activeParadigm);
+  const answerableFormCount = (Object.keys(PARADIGM_TABLE_TYPE) as FormParadigm[]).reduce((total, paradigm) => {
+    return total + (getCompatibilitySummaryForParadigm(paradigm)?.answerableCount ?? 0);
+  }, 0);
+  const activeSkippedCount = getSkippedSelectionCount(compatibilitySummary);
+  const skippedGroups = compatibilitySummary
+    ? Array.from(
+        compatibilitySummary.skipped
+          .reduce((groups, selection) => {
+            const existing = groups.get(selection.support.label) ?? {
+              label: selection.support.label,
+              count: 0,
+              steps: new Set<FormIdentificationStep>(),
+            };
+            existing.count += 1;
+            selection.support.supportedSteps.forEach(step => existing.steps.add(step));
+            groups.set(selection.support.label, existing);
+            return groups;
+          }, new Map<string, { label: string; count: number; steps: Set<FormIdentificationStep> }>())
+          .values()
+      )
+    : [];
   const nonPronounAvailable = availableParadigms.filter(p => NON_PRONOUN_PARADIGMS.includes(p));
   const pronounAvailable = availableParadigms.filter(p => PRONOUN_PARADIGMS.includes(p));
 
@@ -197,6 +239,14 @@ export const MultiParadigmConfigSection: React.FC<MultiParadigmConfigSectionProp
         {wordCount !== undefined && (
           <Badge variant={isActive ? 'secondary' : 'outline'} className="text-xs">
             {wordCount}
+          </Badge>
+        )}
+        {getSkippedSelectionCount(getCompatibilitySummaryForParadigm(paradigm)) > 0 && (
+          <Badge
+            variant="outline"
+            className="border-amber-300 bg-amber-50 text-xs text-amber-800"
+            title="Selected forms that cannot be used with the current questions">
+            {getSkippedSelectionCount(getCompatibilitySummaryForParadigm(paradigm))} skipped
           </Badge>
         )}
       </Button>
@@ -356,6 +406,31 @@ export const MultiParadigmConfigSection: React.FC<MultiParadigmConfigSectionProp
 
           {currentConfig?.enabled && (
             <>
+              {compatibilitySummary && activeSkippedCount > 0 && answerableFormCount > 0 && (
+                <Alert role="status" className="border-amber-200 bg-amber-50 text-amber-900">
+                  <AlertTriangle className="h-4 w-4 text-amber-600" />
+                  <AlertTitle>Some selected forms will be skipped</AlertTitle>
+                  <AlertDescription className="space-y-1">
+                    {compatibilitySummary.unknownPaths.length > 0 && (
+                      <p>
+                        <strong>{compatibilitySummary.unknownPaths.length}</strong>{' '}
+                        {compatibilitySummary.unknownPaths.length === 1
+                          ? 'unrecognized saved form will be skipped. Select a valid form or remove it from the selection.'
+                          : 'unrecognized saved forms will be skipped. Select valid forms or remove them from the selection.'}
+                      </p>
+                    )}
+                    {skippedGroups.map(group => (
+                      <p key={group.label}>
+                        <strong>{group.count}</strong> {getSkippedFormLabel(group.label, group.count)} will not appear
+                        because none of the selected questions apply. Add{' '}
+                        {getCompatibilityStepLabels(Array.from(group.steps))} to include{' '}
+                        {group.count === 1 ? 'it' : 'them'}.
+                      </p>
+                    ))}
+                  </AlertDescription>
+                </Alert>
+              )}
+
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div>
                   <label className="block text-sm font-medium mb-3">Steps to Identify (in order)</label>
@@ -392,7 +467,6 @@ export const MultiParadigmConfigSection: React.FC<MultiParadigmConfigSectionProp
                         </DndContext>
                       </div>
                     )}
-
                   </div>
                 </div>
 

--- a/src/hooks/useFormIdentificationEditor.ts
+++ b/src/hooks/useFormIdentificationEditor.ts
@@ -12,6 +12,7 @@ import { getParadigmPOS } from '@/src/utils/paradigm';
 import type { GeneratedFormIdentificationExercise } from '@/src/types/exercises/generated-form-identification';
 import type { FormParadigm, ParadigmConfig, ParadigmConfigs } from '@/src/types/exercises/paradigm';
 import type { GeneratorFilters, FormSelection } from '@/src/types/exercises/base';
+import { buildLegacyParadigmConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
 
 export function useFormIdentificationEditor(editingContent: GeneratedFormIdentificationExercise) {
   const dispatch = useAppDispatch();
@@ -20,21 +21,29 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
   const rawConfig = editingContent.data?.generatorConfig;
   const config = useMemo(() => ensureGeneratorConfig(rawConfig), [rawConfig]);
   const isPoolWordSource = config.wordSource === 'pool';
+  const paradigmConfigs = useMemo(
+    () =>
+      editingContent.data.paradigmConfigs && Object.keys(editingContent.data.paradigmConfigs).length > 0
+        ? editingContent.data.paradigmConfigs
+        : buildLegacyParadigmConfigs(
+            editingContent.data.generatorConfig as Parameters<typeof buildLegacyParadigmConfigs>[0]
+          ),
+    [editingContent.data.paradigmConfigs, editingContent.data.generatorConfig]
+  );
 
   const paradigmInfo = useAvailableParadigms(config.wordSource, config.poolId, config.filters);
 
   const activeParadigm = useMemo(() => {
-    const paradigmConfigs = editingContent.data.paradigmConfigs ?? {};
     const enabledEntries = Object.entries(paradigmConfigs).filter(([, cfg]) => cfg?.enabled);
     if (enabledEntries.length === 1) {
       return enabledEntries[0][0] as FormParadigm;
     }
     return undefined;
-  }, [editingContent.data.paradigmConfigs]);
+  }, [paradigmConfigs]);
 
   const derivedFilters = useMemo((): GeneratorFilters => {
     if (config.wordSource === 'filters') {
-      const paradigmFilters = activeParadigm ? editingContent.data.paradigmConfigs?.[activeParadigm]?.filters : {};
+      const paradigmFilters = activeParadigm ? paradigmConfigs[activeParadigm]?.filters : {};
       return {
         ...config.filters,
         ...paradigmFilters,
@@ -47,17 +56,17 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
     const pos = getParadigmPOS(activeParadigm);
     return {
       partOfSpeech: pos,
-      ...editingContent.data.paradigmConfigs?.[activeParadigm]?.filters,
+      ...paradigmConfigs[activeParadigm]?.filters,
     };
-  }, [config.wordSource, config.filters, activeParadigm, editingContent.data.paradigmConfigs]);
+  }, [config.wordSource, config.filters, activeParadigm, paradigmConfigs]);
 
   const derivedFormSelection = useMemo(() => {
     if (!activeParadigm) return undefined;
-    return editingContent.data.paradigmConfigs?.[activeParadigm]?.formSelection;
-  }, [activeParadigm, editingContent.data.paradigmConfigs]);
+    return paradigmConfigs[activeParadigm]?.formSelection;
+  }, [activeParadigm, paradigmConfigs]);
 
   const previewResult = useGetMultiParadigmWordsQuery(
-    isPreviewOpen && editingContent.data.paradigmConfigs
+    isPreviewOpen && Object.keys(paradigmConfigs).length > 0
       ? {
           exerciseType: 'generated-form-identification',
           collection: config.collection,
@@ -65,7 +74,7 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
           poolId: config.poolId,
           poolWordLimit: config.poolWordLimit,
           count: config.count,
-          paradigmConfigs: editingContent.data.paradigmConfigs,
+          paradigmConfigs,
         }
       : skipToken
   );
@@ -93,8 +102,8 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
       const defaultSteps = PARADIGM_STEPS[paradigm];
 
       const nextContent = produce(editingContent, draft => {
-        if (!draft.data.paradigmConfigs) {
-          draft.data.paradigmConfigs = {};
+        if (!draft.data.paradigmConfigs || Object.keys(draft.data.paradigmConfigs).length === 0) {
+          draft.data.paradigmConfigs = { ...paradigmConfigs };
         }
 
         const currentConfig = draft.data.paradigmConfigs[paradigm] || {
@@ -108,7 +117,7 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
       });
       updateContent(nextContent);
     },
-    [editingContent, updateContent]
+    [editingContent, paradigmConfigs, updateContent]
   );
 
   const handleToggleParadigm = useCallback(
@@ -133,14 +142,14 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
         }
 
         if (Object.keys(paradigmFilterUpdates).length > 0) {
-          const currentFilters = editingContent.data.paradigmConfigs?.[activeParadigm]?.filters || {};
+          const currentFilters = paradigmConfigs[activeParadigm]?.filters || {};
           handleUpdateParadigmConfig(activeParadigm, {
             filters: { ...currentFilters, ...paradigmFilterUpdates },
           });
         }
       }
     },
-    [config.filters, updateConfig, activeParadigm, editingContent.data.paradigmConfigs, handleUpdateParadigmConfig]
+    [config.filters, updateConfig, activeParadigm, paradigmConfigs, handleUpdateParadigmConfig]
   );
 
   useEffect(() => {
@@ -148,7 +157,7 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
       return;
     }
 
-    const currentConfigs = editingContent.data.paradigmConfigs ?? {};
+    const currentConfigs = paradigmConfigs;
     const existingParadigms = Object.keys(currentConfigs);
     const newParadigms = paradigmInfo.availableParadigms.filter(p => !existingParadigms.includes(p));
     const shouldAutoEnable = paradigmInfo.availableParadigms.length === 1;
@@ -191,7 +200,7 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
       ...editingContent,
       data: { ...editingContent.data, paradigmConfigs: updatedConfigs },
     });
-  }, [paradigmInfo.availableParadigms, editingContent, updateContent]);
+  }, [paradigmInfo.availableParadigms, editingContent, paradigmConfigs, updateContent]);
 
   const formSelectionControls = useFormSelectionControls(
     activeParadigm ? getParadigmPOS(activeParadigm) : undefined,
@@ -208,6 +217,7 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
 
   return {
     editingContent,
+    paradigmConfigs,
     config,
     activeParadigm,
     derivedFilters,

--- a/src/lib/learning-units/learning-path-service.ts
+++ b/src/lib/learning-units/learning-path-service.ts
@@ -1,4 +1,4 @@
-import type { DocumentSnapshot, Firestore, Transaction } from 'firebase-admin/firestore';
+import type { DocumentReference, DocumentSnapshot, Firestore, Transaction } from 'firebase-admin/firestore';
 import {
   DEFAULT_LEARNING_PATH_ID,
   LEARNING_PATHS_COLLECTION,
@@ -7,16 +7,28 @@ import {
   TEST_VERSIONS_COLLECTION,
 } from '@/shared/constants/firestore';
 import { adminDb } from '@/src/services/firebase-admin';
-import type { AdminLearningPathView, LearningPathDocument, LearningUnit } from '@/src/types/learning-unit';
+import {
+  LESSON_UNIT_TYPES,
+  type AdminLearningPathView,
+  type LearningPathDocument,
+  type LearningPathLessonIssue,
+  type LearningUnit,
+  type LessonUnitType,
+} from '@/src/types/learning-unit';
 import type { RotationVersionReference } from '@/src/types/test';
 import { estimateFirestoreDocumentBytes } from '@/src/lib/tests/firestore-size';
 import { mockTestDocumentSchema } from '@/src/lib/tests/schemas';
 import { isStoredVersionReadyForStudentVisibility } from '@/src/lib/tests/persistence';
 import { validateTestAssignmentGraph } from '@/src/lib/tests/domain';
-import { normalizeLearningUnit } from './domain';
+import { isLessonDocumentData, normalizeLearningUnit } from './domain';
 import { validateLessonProgression } from '@/src/utils/lessonProgress';
 import type { Lesson } from '@/src/types/lesson';
-import { learningPathDocumentSchema, saveLearningPathInputSchema, type SaveLearningPathInput } from './schemas';
+import {
+  learningPathDocumentSchema,
+  learningUnitDocumentSchema,
+  saveLearningPathInputSchema,
+  type SaveLearningPathInput,
+} from './schemas';
 import { LearningPathServiceError } from './learning-path-errors';
 import { runVocabularyContentMutation } from '@/src/lib/vocabulary-pools/sync-lock.server';
 
@@ -58,6 +70,133 @@ function parseLearningUnitSnapshot(snapshot: DocumentSnapshot): LearningUnit {
       409
     );
   }
+}
+
+type LearningPathPlacementUnit =
+  | { id: string; kind: 'lesson'; type: LessonUnitType }
+  | Extract<LearningUnit, { kind: 'test' }>;
+
+/**
+ * Placement only needs to establish the unit's identity and delivery kind.
+ * Normal lesson content is deliberately not parsed here: legacy or damaged
+ * lesson content is surfaced by the admin audit and must not block reordering
+ * or removing units from the Learning Path. Tests remain strict because their
+ * version ownership directly controls delivery.
+ */
+function parseLearningPathPlacementUnit(snapshot: DocumentSnapshot): LearningPathPlacementUnit {
+  if (!snapshot.exists) {
+    throw new LearningPathServiceError('UNKNOWN_LEARNING_UNIT', `Learning unit ${snapshot.id} does not exist`, 400);
+  }
+
+  const data = snapshot.data();
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new LearningPathServiceError(
+      'INELIGIBLE_LEARNING_UNIT',
+      `Learning unit ${snapshot.id} contains invalid persisted data`,
+      409
+    );
+  }
+
+  const raw = data as Record<string, unknown>;
+  if (raw.kind === 'test') return parseLearningUnitSnapshot(snapshot) as Extract<LearningUnit, { kind: 'test' }>;
+  if (raw.kind !== undefined && raw.kind !== 'lesson') {
+    throw new LearningPathServiceError(
+      'INELIGIBLE_LEARNING_UNIT',
+      `Learning unit ${snapshot.id} has an unknown kind`,
+      400
+    );
+  }
+
+  const type = raw.type;
+  if (typeof type !== 'string' || !(LESSON_UNIT_TYPES as readonly string[]).includes(type)) {
+    throw new LearningPathServiceError(
+      'INELIGIBLE_LEARNING_UNIT',
+      `Lesson ${snapshot.id} has an unknown lesson type`,
+      400
+    );
+  }
+
+  return { id: snapshot.id, kind: 'lesson', type: type as LessonUnitType };
+}
+
+function isLessonProgressionIssue(message: string, path: readonly PropertyKey[] = []): boolean {
+  const isPageIdPath = path.length === 3 && path[0] === 'pages' && typeof path[1] === 'number' && path[2] === 'id';
+  const isItemIdPath =
+    path.length === 5 &&
+    path[0] === 'pages' &&
+    typeof path[1] === 'number' &&
+    path[2] === 'items' &&
+    typeof path[3] === 'number' &&
+    path[4] === 'id';
+  return (
+    message === 'Lesson must contain at least one page.' ||
+    /^Page \d+ (?:is missing an ID|has a duplicate ID)\.$/.test(message) ||
+    /^Item \d+ on page \d+ (?:is missing an ID|has a duplicate ID)\.$/.test(message) ||
+    isPageIdPath ||
+    isItemIdPath
+  );
+}
+
+function addLessonIssue(issues: LearningPathLessonIssue[], issue: LearningPathLessonIssue, seen: Set<string>): void {
+  const key = `${issue.code}:${issue.message}:${JSON.stringify(issue.path ?? [])}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  issues.push(issue);
+}
+
+function auditPlacedLessonSnapshot(snapshot: DocumentSnapshot): LearningPathLessonIssue[] {
+  if (!snapshot.exists || !isLessonDocumentData(snapshot.data())) return [];
+
+  const raw = snapshot.data() as Record<string, unknown>;
+  if (raw.type !== 'normal') return [];
+
+  const normalized = {
+    ...raw,
+    id: raw.id ?? snapshot.id,
+    kind: raw.kind ?? 'lesson',
+    description: raw.description ?? '',
+    isLive: raw.isLive ?? false,
+    liveOrder: raw.liveOrder ?? null,
+    publishedAt: raw.publishedAt ?? null,
+    publishedBy: raw.publishedBy ?? null,
+    showWordSearch: raw.showWordSearch ?? true,
+  };
+  const issues: LearningPathLessonIssue[] = [];
+  const seen = new Set<string>();
+  const parsed = learningUnitDocumentSchema.safeParse(normalized);
+
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      addLessonIssue(
+        issues,
+        {
+          code: isLessonProgressionIssue(issue.message, issue.path) ? 'INCOMPLETE_LESSON' : 'INVALID_LESSON_DATA',
+          message: issue.message,
+          ...(issue.path.length
+            ? {
+                path: issue.path.filter(
+                  (part): part is string | number => typeof part === 'string' || typeof part === 'number'
+                ),
+              }
+            : {}),
+        },
+        seen
+      );
+    }
+  }
+
+  if (Array.isArray(raw.pages)) {
+    try {
+      for (const message of validateLessonProgression({ pages: raw.pages as Lesson['pages'] })) {
+        addLessonIssue(issues, { code: 'INCOMPLETE_LESSON', message, path: ['pages'] }, seen);
+      }
+    } catch {
+      // The schema issues above contain the useful location for malformed
+      // page structures. A bad shape must never abort the whole audit.
+    }
+  }
+
+  return issues;
 }
 
 function assertDocumentSize(document: LearningPathDocument) {
@@ -252,14 +391,42 @@ export class LearningPathService {
     return learningPathFromSnapshot(await this.pathRef().get());
   }
 
+  private async auditCanonicalLessons(
+    path: LearningPathDocument | null
+  ): Promise<Record<string, LearningPathLessonIssue[]>> {
+    if (!path || path.unitIds.length === 0) return {};
+
+    const references = path.unitIds.map(unitId => this.units.doc(unitId) as unknown as DocumentReference);
+    const dbWithGetAll = this.db as Firestore & {
+      getAll?: (...refs: DocumentReference[]) => Promise<DocumentSnapshot[]>;
+    };
+    // The production Firestore client batches these reads. The fallback keeps
+    // lightweight service fakes useful in unit tests without changing the
+    // production read pattern.
+    const snapshots =
+      typeof dbWithGetAll.getAll === 'function'
+        ? await dbWithGetAll.getAll(...references)
+        : await Promise.all(references.map(reference => reference.get()));
+    const issuesById: Record<string, LearningPathLessonIssue[]> = {};
+
+    snapshots.forEach(snapshot => {
+      const issues = auditPlacedLessonSnapshot(snapshot);
+      if (issues.length > 0) issuesById[snapshot.id] = issues;
+    });
+
+    return issuesById;
+  }
+
   async getAdminView(): Promise<AdminLearningPathView> {
     const path = await this.getPath();
+    const lessonIssuesById = await this.auditCanonicalLessons(path);
 
     return {
       path,
       effectiveUnitIds: path?.unitIds ?? [],
       source: 'learning-path',
       canEdit: Boolean(path),
+      lessonIssuesById,
       ...(!path ? { editBlockedReason: 'The Learning Path is not available.' } : {}),
     };
   }
@@ -271,20 +438,12 @@ export class LearningPathService {
     const tests: Extract<LearningUnit, { kind: 'test' }>[] = [];
 
     for (const snapshot of snapshots) {
-      const unit = parseLearningUnitSnapshot(snapshot);
+      const unit = parseLearningPathPlacementUnit(snapshot);
       if (unit.kind === 'lesson') {
         if (unit.type !== 'normal') {
           throw new LearningPathServiceError(
             'INELIGIBLE_LEARNING_UNIT',
             `Lesson ${unit.id} is a practice lesson and cannot be placed in the Learning Path`,
-            400
-          );
-        }
-        const progressionErrors = validateLessonProgression(unit);
-        if (progressionErrors.length > 0) {
-          throw new LearningPathServiceError(
-            'INELIGIBLE_LEARNING_UNIT',
-            `Lesson ${unit.id} is incomplete: ${progressionErrors.join(' ')}`,
             400
           );
         }
@@ -339,6 +498,9 @@ export class LearningPathService {
     ]);
     try {
       const allTests = allTestSnapshots.docs
+        .filter(
+          snapshot => snapshot.exists && (snapshot.data() as Record<string, unknown> | undefined)?.kind === 'test'
+        )
         .map(parseLearningUnitSnapshot)
         .filter((unit): unit is Extract<LearningUnit, { kind: 'test' }> => unit.kind === 'test');
       const mocks = activeMockSnapshots.docs.map(snapshot =>

--- a/src/lib/tests/generated-exercises.ts
+++ b/src/lib/tests/generated-exercises.ts
@@ -8,6 +8,7 @@ import type {
 import type { PartOfSpeech, PronounPerson, PronounType } from '@/shared/types/vocabulary/schemas/enums';
 import { deriveParadigm } from '@/src/utils/paradigm';
 import { hasSelectedForm, getExerciseDisplayForm } from '@/src/utils/exercises/formSelection';
+import { buildLegacyParadigmConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
 import {
   splitTranslationAnswers,
   type GeneratedTranslationItem,
@@ -23,6 +24,7 @@ import {
   getAcceptedAnswersForStep,
   getAnswerableStepsForWord,
   getDisplayForm,
+  getFallbackAnswerableStepsForWord,
   getHintForStep,
 } from '@/src/utils/exercises/formIdentificationHelpers';
 
@@ -48,13 +50,40 @@ const getPreparedPaths = (exercise: GeneratedFormIdentificationExercise, word: E
     data.pronoun_type as PronounType | undefined,
     data.person as PronounPerson | undefined
   );
-  const config = paradigm ? exercise.data.paradigmConfigs?.[paradigm] : undefined;
+  const paradigmConfigs =
+    exercise.data.paradigmConfigs && Object.keys(exercise.data.paradigmConfigs).length > 0
+      ? exercise.data.paradigmConfigs
+      : buildLegacyParadigmConfigs(exercise.data.generatorConfig as Parameters<typeof buildLegacyParadigmConfigs>[0]);
+  const config = paradigm ? paradigmConfigs[paradigm] : undefined;
   const paths = getPaths(word);
-  const candidateSteps = getAnswerableStepsForWord(word, config?.steps || [], paths.primary);
-  const enrichedPrimary = enrichPathsWithSteps(paths.primary, word, candidateSteps);
+  const configuredSteps = config?.steps || [];
+  let candidateSteps = getAnswerableStepsForWord(word, configuredSteps, paths.primary);
+  const preferredPath = (word.form_path || paths.primary[0]) as Record<string, string | undefined> | undefined;
+
+  // A selected path can be answerable even when a syncretic alternative in
+  // `primary_form_paths` cannot answer any of the same questions (for example
+  // a finite form and a gerund with the same spelling). Fall back to the
+  // selected interpretation and discard incompatible alternatives below.
+  if (candidateSteps.length === 0) {
+    candidateSteps = getFallbackAnswerableStepsForWord(word, configuredSteps, preferredPath);
+  }
+
+  let enrichedPrimary = enrichPathsWithSteps(paths.primary, word, candidateSteps);
   const steps = candidateSteps.filter(
-    step => enrichedPrimary.length > 0 && enrichedPrimary.every(path => Boolean(path[step]))
+    step => enrichedPrimary.length > 0 && enrichedPrimary.some(path => Boolean(path[step]))
   );
+
+  if (steps.length > 0) {
+    enrichedPrimary = enrichedPrimary.filter(path => steps.every(step => Boolean(path[step])));
+  }
+
+  // Older responses may omit `primary_form_paths` while still carrying the
+  // selected `form_path`; preserve that selected path as the answer key.
+  if (enrichedPrimary.length === 0 && preferredPath && steps.length > 0) {
+    enrichedPrimary = enrichPathsWithSteps([preferredPath], word, steps).filter(path =>
+      steps.every(step => Boolean(path[step]))
+    );
+  }
 
   if (steps.length === 0) {
     return { steps, primary: [], optional: [] };

--- a/src/lib/tests/generated-word-loader.server.ts
+++ b/src/lib/tests/generated-word-loader.server.ts
@@ -4,6 +4,7 @@ import { getReadableVocabularyPool, loadVocabularyPoolWords } from '@/src/lib/vo
 import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-responses';
 import type { GeneratorFilters, FormSelection } from '@/src/types/exercises/base';
 import type { FormParadigm, ParadigmConfigs } from '@/src/types/exercises/paradigm';
+import type { FormIdentificationStep } from '@/src/types/exercises/schemas/form-identification';
 import { PARADIGM_POS_GROUP, PARADIGM_TABLE_TYPE } from '@/src/config/paradigmDefinitions';
 import { parseFormPathFromString } from '@/src/utils/exerciseFormPaths';
 import { TABLE_TYPE_CONFIG, type TableType } from '@/src/utils/schema-helpers';
@@ -11,6 +12,7 @@ import { categorizeMatchingPaths, scanTableForMatchingForms } from '@/src/utils/
 import { deriveTableTypeFromPOS } from '@/src/utils/generated/tableType';
 import { filterOverlappingPronounParadigms } from '@/src/utils/generated/pronounParadigmFiltering';
 import { stripMacrons } from '@/src/utils/exercises/helpers';
+import { getApplicableStepsForFormPath } from '@/src/utils/exercises/formIdentificationCompatibility';
 import {
   buildLegacyParadigmConfigs,
   buildLegacyPosConfigs,
@@ -23,6 +25,7 @@ interface WordQuerySpec {
   filters: Omit<GeneratorFilters, 'partOfSpeech'>;
   formSelection?: FormSelection;
   tableType?: TableType;
+  steps?: FormIdentificationStep[];
 }
 
 const shuffle = <T>(values: T[]): T[] => {
@@ -106,6 +109,7 @@ const getQuerySpecs = (exercise: GeneratedExercise): WordQuerySpec[] => {
         filters,
         formSelection: value.formSelection,
         tableType: PARADIGM_TABLE_TYPE[paradigm],
+        steps: value.steps,
       };
     });
 };
@@ -120,19 +124,28 @@ const getPathValues = (value: Record<string, unknown>, path: string): string[] =
   return Array.isArray(current) ? current.filter((entry): entry is string => typeof entry === 'string') : [];
 };
 
-function selectForm(word: Record<string, unknown>, tableType: TableType, selectedPaths: string[]) {
+function selectForm(
+  word: Record<string, unknown>,
+  tableType: TableType,
+  selectedPaths: string[],
+  steps?: readonly FormIdentificationStep[]
+) {
   const tableField = TABLE_TYPE_CONFIG[tableType];
   const table = word[tableField];
   if (!table) return null;
 
-  const candidates = selectedPaths.flatMap(path =>
+  const compatiblePaths =
+    steps && tableType
+      ? selectedPaths.filter(path => (getApplicableStepsForFormPath(path, tableType, steps)?.applicableSteps.length ?? 0) > 0)
+      : selectedPaths;
+  const candidates = compatiblePaths.flatMap(path =>
     getPathValues(word, `${tableField}.${path}`).map(form => ({ form, path }))
   );
   if (!candidates.length) return null;
 
   const selected = candidates[Math.floor(Math.random() * candidates.length)];
   const matchingPaths = scanTableForMatchingForms(table, selected.form, tableType);
-  const paths = categorizeMatchingPaths(matchingPaths, selectedPaths);
+  const paths = categorizeMatchingPaths(matchingPaths, compatiblePaths);
   if (!paths.primaryPaths.includes(selected.path)) paths.primaryPaths.unshift(selected.path);
   return { selected, ...paths };
 }
@@ -140,7 +153,8 @@ function selectForm(word: Record<string, unknown>, tableType: TableType, selecte
 function mapWord(doc: QueryDocumentSnapshot, spec: WordQuerySpec): ExerciseWordResponse | null {
   const data = doc.data() as Record<string, unknown>;
   const selectedPaths = spec.formSelection?.selectedCellPaths || [];
-  const selection = spec.tableType && selectedPaths.length ? selectForm(data, spec.tableType, selectedPaths) : null;
+  const selection =
+    spec.tableType && selectedPaths.length ? selectForm(data, spec.tableType, selectedPaths, spec.steps) : null;
   if (selectedPaths.length && !selection) return null;
 
   const parsedTableType = spec.tableType;

--- a/src/store/api/advancedVocabularyApi.ts
+++ b/src/store/api/advancedVocabularyApi.ts
@@ -540,6 +540,9 @@ export const advancedVocabularyApi = createApi({
             if (cfg.formSelection?.selectedCellPaths && cfg.formSelection.selectedCellPaths.length > 0) {
               params.append('cellPaths', cfg.formSelection.selectedCellPaths.join(','));
             }
+            if (cfg.steps?.length) {
+              params.append('steps', cfg.steps.join(','));
+            }
             if (tableType) {
               params.append('tableType', tableType);
             }

--- a/src/store/api/lessonApi.ts
+++ b/src/store/api/lessonApi.ts
@@ -114,6 +114,7 @@ export const lessonApi = appApi.injectEndpoints({
               { type: 'Lesson', id: lesson.id },
               { type: 'LessonList', id: 'LIST' },
               { type: 'StudentLesson', id: lesson.id },
+              { type: 'LearningPath', id: 'default' },
               STUDENT_DASHBOARD_TAG,
             ],
     }),

--- a/src/types/learning-unit.ts
+++ b/src/types/learning-unit.ts
@@ -54,12 +54,26 @@ export interface LearningPathDocument {
   updatedBy: string;
 }
 
+export type LearningPathLessonIssueCode = 'INVALID_LESSON_DATA' | 'INCOMPLETE_LESSON';
+
+export interface LearningPathLessonIssue {
+  code: LearningPathLessonIssueCode;
+  message: string;
+  path?: Array<string | number>;
+}
+
 export interface AdminLearningPathView {
   path: LearningPathDocument | null;
   effectiveUnitIds: string[];
   source: 'learning-path';
   canEdit: boolean;
   editBlockedReason?: string;
+  /**
+   * Non-blocking content warnings for the normal lessons currently in the
+   * canonical path. This is optional for compatibility with older clients;
+   * the admin endpoint always returns an object.
+   */
+  lessonIssuesById?: Record<string, LearningPathLessonIssue[]>;
 }
 
 export interface TestUnitCompletionProgress {

--- a/src/utils/exercises/formIdentificationCompatibility.ts
+++ b/src/utils/exercises/formIdentificationCompatibility.ts
@@ -1,0 +1,154 @@
+import type { FormIdentificationStep } from '@/src/types/exercises/schemas/form-identification';
+import type { TableType } from '@/src/utils/schema-helpers';
+import { getSupportedVerbFormStepsForPath, getSupportedVerbFormStepsForParsedPath } from './verbFormStepCompatibility';
+
+export interface FormPathStepSupport {
+  label: string;
+  supportedSteps: readonly FormIdentificationStep[];
+}
+
+export interface FormPathCompatibility {
+  path: string;
+  support: FormPathStepSupport;
+  applicableSteps: FormIdentificationStep[];
+}
+
+export interface FormIdentificationCompatibilitySummary {
+  selectedCount: number;
+  answerableCount: number;
+  skipped: FormPathCompatibility[];
+  unknownPaths: string[];
+}
+
+const NOUN_STEPS: readonly FormIdentificationStep[] = ['declension', 'case', 'number', 'gender'];
+const ADJECTIVE_STEPS: readonly FormIdentificationStep[] = ['declension', 'degree', 'case', 'number', 'gender'];
+const PERSONAL_PRONOUN_STEPS: readonly FormIdentificationStep[] = ['pronoun_type', 'person', 'case', 'number'];
+const GENDERED_PRONOUN_STEPS: readonly FormIdentificationStep[] = [
+  'pronoun_type',
+  'person',
+  'gender',
+  'case',
+  'number',
+];
+
+const supportForTableType = (tableType: TableType): FormPathStepSupport => {
+  switch (tableType) {
+    case 'declension':
+      return { label: 'Noun forms', supportedSteps: NOUN_STEPS };
+    case 'adjective-declension':
+      return { label: 'Adjective forms', supportedSteps: ADJECTIVE_STEPS };
+    case 'pronoun-declension':
+      return { label: 'Personal pronoun forms', supportedSteps: PERSONAL_PRONOUN_STEPS };
+    case 'pronoun-adjective-declension':
+      return { label: 'Gendered pronoun forms', supportedSteps: GENDERED_PRONOUN_STEPS };
+    case 'conjugation':
+      // A conjugation path is parsed below so that finite/non-finite forms
+      // retain their different sets of answerable questions.
+      return { label: 'Verb forms', supportedSteps: [] };
+  }
+};
+
+/**
+ * Returns the grammatical fields a selected table path can answer. This is
+ * deliberately path based: a saved selection can contain a mixture of finite
+ * verbs, infinitives, participles, gerunds, and supines.
+ */
+export function getFormPathStepSupport(path: string, tableType: TableType): FormPathStepSupport | null {
+  if (tableType === 'conjugation') return getSupportedVerbFormStepsForPath(path);
+
+  const parts = path.split('.');
+  const isValid =
+    (tableType === 'declension' && parts.length === 2) ||
+    (tableType === 'adjective-declension' && (parts.length === 2 || parts.length === 4)) ||
+    (tableType === 'pronoun-declension' && parts.length === 2) ||
+    (tableType === 'pronoun-adjective-declension' && (parts.length === 2 || parts.length === 3));
+
+  return isValid ? supportForTableType(tableType) : null;
+}
+
+/**
+ * Same compatibility lookup for paths already parsed into a generated word.
+ * The editor uses string paths while student generation uses parsed paths.
+ */
+export function getParsedFormPathStepSupport(
+  partOfSpeech: string,
+  path: Record<string, string | undefined>
+): FormPathStepSupport | null {
+  if (partOfSpeech === 'verb') return getSupportedVerbFormStepsForParsedPath(path);
+  if (partOfSpeech === 'noun') return supportForTableType('declension');
+  if (partOfSpeech === 'adjective') return supportForTableType('adjective-declension');
+  if (partOfSpeech === 'pronoun') {
+    return path.gender
+      ? supportForTableType('pronoun-adjective-declension')
+      : supportForTableType('pronoun-declension');
+  }
+  return null;
+}
+
+export function getApplicableStepsForFormPath(
+  path: string,
+  tableType: TableType,
+  selectedSteps: readonly FormIdentificationStep[]
+): FormPathCompatibility | null {
+  const support = getFormPathStepSupport(path, tableType);
+  if (!support) return null;
+  const selected = new Set(selectedSteps);
+  return {
+    path,
+    support,
+    applicableSteps: support.supportedSteps.filter(step => selected.has(step)),
+  };
+}
+
+export function getFormIdentificationCompatibilitySummary(
+  tableType: TableType,
+  selectedPaths: readonly string[],
+  selectedSteps: readonly FormIdentificationStep[]
+): FormIdentificationCompatibilitySummary {
+  const skipped: FormPathCompatibility[] = [];
+  const unknownPaths: string[] = [];
+  let answerableCount = 0;
+
+  selectedPaths.forEach(path => {
+    const compatibility = getApplicableStepsForFormPath(path, tableType, selectedSteps);
+    if (!compatibility) {
+      unknownPaths.push(path);
+      return;
+    }
+    if (compatibility.applicableSteps.length === 0) skipped.push(compatibility);
+    else answerableCount += 1;
+  });
+
+  return {
+    selectedCount: selectedPaths.length,
+    answerableCount,
+    skipped,
+    unknownPaths,
+  };
+}
+
+export function getSelectedFormPathCompatibility(
+  partOfSpeech: string,
+  path: Record<string, string | undefined>,
+  selectedSteps: readonly FormIdentificationStep[]
+): FormPathCompatibility | null {
+  const support = getParsedFormPathStepSupport(partOfSpeech, path);
+  if (!support) return null;
+  const selected = new Set(selectedSteps);
+  return {
+    path: '',
+    support,
+    applicableSteps: support.supportedSteps.filter(step => selected.has(step)),
+  };
+}
+
+export function getCompatibilityStepLabels(steps: readonly FormIdentificationStep[]): string {
+  const labels = steps.map(step => {
+    const humanized = step.replace(/_/g, ' ');
+    return humanized.charAt(0).toUpperCase() + humanized.slice(1);
+  });
+
+  if (labels.length <= 1) return labels[0] ?? '';
+  if (labels.length === 2) return `${labels[0]} or ${labels[1]}`;
+  return `${labels.slice(0, -1).join(', ')}, or ${labels[labels.length - 1]}`;
+}

--- a/src/utils/exercises/formIdentificationConfiguration.ts
+++ b/src/utils/exercises/formIdentificationConfiguration.ts
@@ -1,11 +1,15 @@
 import type { FormIdentificationStep } from '@/src/types/exercises/schemas/form-identification';
-import { getVerbFormSelectionValidationMessages } from './verbFormStepCompatibility';
+import type { FormParadigm, ParadigmConfigs } from '@/src/types/exercises/paradigm';
+import { PARADIGM_TABLE_TYPE } from '@/src/config/paradigmDefinitions';
+import { buildLegacyParadigmConfigs } from './legacyExerciseCompat';
+import {
+  getCompatibilityStepLabels,
+  getFormIdentificationCompatibilitySummary,
+  type FormIdentificationCompatibilitySummary,
+} from './formIdentificationCompatibility';
 
 type RecordValue = Record<string, unknown>;
-
-type PageLike = {
-  items?: readonly unknown[];
-};
+type PageLike = { items?: readonly unknown[] };
 
 export type FormIdentificationConfigurationIssue = {
   pageIndex: number;
@@ -13,32 +17,111 @@ export type FormIdentificationConfigurationIssue = {
   message: string;
 };
 
-const isRecord = (value: unknown): value is RecordValue => typeof value === 'object' && value !== null;
+export type FormIdentificationConfigurationWarning = {
+  paradigm: FormParadigm;
+  label: string;
+  skippedCount: number;
+  selectedCount: number;
+  answerableCount: number;
+  supportedSteps: readonly FormIdentificationStep[];
+  kind: 'incompatible' | 'unrecognized';
+};
 
+const isRecord = (value: unknown): value is RecordValue => typeof value === 'object' && value !== null;
 const getStringArray = (value: unknown): string[] =>
   Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
 
-/**
- * Selected questions are authoritative. This only rejects a selected verb
- * form when it would produce no question at all.
- */
+const getEffectiveParadigmConfigs = (data: RecordValue): ParadigmConfigs => {
+  if (isRecord(data.paradigmConfigs) && Object.keys(data.paradigmConfigs).length > 0) {
+    return data.paradigmConfigs as ParadigmConfigs;
+  }
+  return buildLegacyParadigmConfigs(data.generatorConfig as Parameters<typeof buildLegacyParadigmConfigs>[0]);
+};
+
+const getSummaryForConfig = (
+  paradigm: FormParadigm,
+  config: unknown
+): FormIdentificationCompatibilitySummary | null => {
+  if (!isRecord(config) || config.enabled !== true || !isRecord(config.formSelection)) return null;
+  const selectedPaths = getStringArray(config.formSelection.selectedCellPaths);
+  if (selectedPaths.length === 0) return null;
+  const steps = getStringArray(config.steps) as FormIdentificationStep[];
+  return getFormIdentificationCompatibilitySummary(PARADIGM_TABLE_TYPE[paradigm], selectedPaths, steps);
+};
+
+export function getGeneratedFormIdentificationConfigurationSummaries(exercise: unknown): Array<{
+  paradigm: FormParadigm;
+  summary: FormIdentificationCompatibilitySummary;
+}> {
+  if (!isRecord(exercise) || exercise.type !== 'generated-form-identification' || !isRecord(exercise.data)) return [];
+  const configs = getEffectiveParadigmConfigs(exercise.data);
+  return (Object.keys(PARADIGM_TABLE_TYPE) as FormParadigm[]).flatMap(paradigm => {
+    const summary = getSummaryForConfig(paradigm, configs[paradigm]);
+    return summary ? [{ paradigm, summary }] : [];
+  });
+}
+
+/** Partial incompatibility is informational; only an entirely unusable paradigm is blocking. */
 export function getGeneratedFormIdentificationConfigurationMessages(exercise: unknown): string[] {
-  if (!isRecord(exercise) || exercise.type !== 'generated-form-identification' || !isRecord(exercise.data)) {
-    return [];
-  }
+  const summaries = getGeneratedFormIdentificationConfigurationSummaries(exercise);
+  const answerableCount = summaries.reduce((total, { summary }) => total + summary.answerableCount, 0);
+  if (answerableCount > 0) return [];
+  return summaries
+    .filter(({ summary }) => summary.selectedCount > 0)
+    .map(({ summary }) => {
+      if (summary.unknownPaths.length > 0) {
+        return summary.skipped.length > 0
+          ? 'No answerable selected forms remain. Add a compatible question or select valid forms before saving.'
+          : 'Saved form selections are unrecognized. Select valid forms before saving.';
+      }
+      return `${summary.skipped[0]?.support.label ?? 'Selected forms'} have no applicable selected questions.`;
+    });
+}
 
-  const paradigmConfigs = exercise.data.paradigmConfigs;
-  if (!isRecord(paradigmConfigs)) return [];
-
-  const verbConfig = paradigmConfigs['verb-conjugation'];
-  if (!isRecord(verbConfig) || verbConfig.enabled !== true || !isRecord(verbConfig.formSelection)) {
-    return [];
-  }
-
-  const selectedCellPaths = getStringArray(verbConfig.formSelection.selectedCellPaths);
-  const steps = getStringArray(verbConfig.steps) as FormIdentificationStep[];
-
-  return getVerbFormSelectionValidationMessages(selectedCellPaths, steps);
+export function getGeneratedFormIdentificationConfigurationWarnings(
+  exercise: unknown
+): FormIdentificationConfigurationWarning[] {
+  const summaries = getGeneratedFormIdentificationConfigurationSummaries(exercise);
+  const answerableCount = summaries.reduce((total, { summary }) => total + summary.answerableCount, 0);
+  if (answerableCount === 0) return [];
+  return summaries.flatMap(({ paradigm, summary }) => {
+    if (summary.skipped.length === 0 && summary.unknownPaths.length === 0) return [];
+    const groups = new Map<string, FormIdentificationConfigurationWarning>();
+    summary.skipped.forEach(selection => {
+      const existing = groups.get(selection.support.label);
+      if (existing) {
+        existing.skippedCount += 1;
+        selection.support.supportedSteps.forEach(step => {
+          if (!existing.supportedSteps.includes(step)) {
+            existing.supportedSteps = [...existing.supportedSteps, step];
+          }
+        });
+        return;
+      }
+      groups.set(selection.support.label, {
+        paradigm,
+        label: selection.support.label,
+        skippedCount: 1,
+        selectedCount: summary.selectedCount,
+        answerableCount: summary.answerableCount,
+        supportedSteps: [...selection.support.supportedSteps],
+        kind: 'incompatible',
+      });
+    });
+    const warnings = Array.from(groups.values());
+    if (summary.unknownPaths.length > 0) {
+      warnings.push({
+        paradigm,
+        label: 'Unrecognized saved forms',
+        skippedCount: summary.unknownPaths.length,
+        selectedCount: summary.selectedCount,
+        answerableCount: summary.answerableCount,
+        supportedSteps: [],
+        kind: 'unrecognized',
+      });
+    }
+    return warnings;
+  });
 }
 
 export function getGeneratedFormIdentificationConfigurationIssues<T extends PageLike>(
@@ -46,15 +129,22 @@ export function getGeneratedFormIdentificationConfigurationIssues<T extends Page
 ): FormIdentificationConfigurationIssue[] {
   return pages.flatMap((page, pageIndex) =>
     (page.items ?? []).flatMap((item, itemIndex) =>
-      getGeneratedFormIdentificationConfigurationMessages(item).map(message => ({
-        pageIndex,
-        itemIndex,
-        message,
-      }))
+      getGeneratedFormIdentificationConfigurationMessages(item).map(message => ({ pageIndex, itemIndex, message }))
     )
   );
 }
 
 export function formatFormIdentificationConfigurationIssue(issue: FormIdentificationConfigurationIssue): string {
   return `Morphology exercise ${issue.itemIndex + 1} on page ${issue.pageIndex + 1}: ${issue.message}`;
+}
+
+export function formatFormIdentificationConfigurationWarning(warning: FormIdentificationConfigurationWarning): string {
+  if (warning.kind === 'unrecognized') {
+    const formLabel = warning.skippedCount === 1 ? 'form' : 'forms';
+    return `${warning.skippedCount} unrecognized saved ${formLabel} will be skipped. Select a valid form or remove the selection.`;
+  }
+
+  const label = warning.label.toLowerCase().replace(/ forms$/, warning.skippedCount === 1 ? ' form' : ' forms');
+  const pronoun = warning.skippedCount === 1 ? 'it' : 'them';
+  return `${warning.skippedCount} ${label} will not appear because none of the selected questions apply. Add ${getCompatibilityStepLabels(warning.supportedSteps)} to include ${pronoun}.`;
 }

--- a/src/utils/exercises/formIdentificationHelpers.ts
+++ b/src/utils/exercises/formIdentificationHelpers.ts
@@ -19,6 +19,7 @@ import {
   getSupportedVerbFormStepsForParsedPath,
   getVerbFormKindForParsedPath,
 } from './verbFormStepCompatibility';
+import { getSelectedFormPathCompatibility, getParsedFormPathStepSupport } from './formIdentificationCompatibility';
 
 type VerbWordResponse = Extract<ExerciseWordResponse, { part_of_speech: 'verb' }>;
 type NounWordResponse = Extract<ExerciseWordResponse, { part_of_speech: 'noun' }>;
@@ -158,11 +159,19 @@ export function getAnswerableStepsForWord(
   steps: FormIdentificationStep[],
   formPaths: Array<Record<string, string | undefined>>
 ): FormIdentificationStep[] {
-  if (!isVerb(word)) {
-    return steps;
-  }
-
   if (formPaths.length === 0) return [];
+
+  if (!isVerb(word)) {
+    const supports = formPaths.map(path => getParsedFormPathStepSupport(word.part_of_speech, path));
+    if (supports.some(support => support === null)) return [];
+
+    return steps.filter(step =>
+      supports.every(support => {
+        if (!support?.supportedSteps.includes(step)) return false;
+        return true;
+      })
+    );
+  }
 
   const supports = formPaths.map(path => getSupportedVerbFormStepsForParsedPath(path));
 
@@ -171,6 +180,23 @@ export function getAnswerableStepsForWord(
   const supportedStepSets = supports.map(support => new Set<FormIdentificationStep>(support!.supportedSteps));
 
   return steps.filter(step => supportedStepSets.every(supportedSteps => supportedSteps.has(step)));
+}
+
+/**
+ * Select one path's applicable questions when a word has no shared question
+ * across all of its syncretic interpretations. This keeps a selected form
+ * answerable while later path preparation removes incompatible alternatives.
+ */
+export function getFallbackAnswerableStepsForWord(
+  word: ExerciseWordResponse,
+  steps: FormIdentificationStep[],
+  preferredPath: Record<string, string | undefined> | null | undefined
+): FormIdentificationStep[] {
+  if (!preferredPath) return [];
+  if (isVerb(word)) {
+    return getSelectedFormPathCompatibility('verb', preferredPath, steps)?.applicableSteps ?? [];
+  }
+  return getSelectedFormPathCompatibility(word.part_of_speech, preferredPath, steps)?.applicableSteps ?? [];
 }
 
 /**

--- a/src/utils/lessonSummary.ts
+++ b/src/utils/lessonSummary.ts
@@ -7,13 +7,26 @@ export function getLessonContentCounts(lesson: Pick<Lesson, 'pages'>): {
   totalItems: number;
   totalExercises: number;
 } {
-  const pages = lesson.pages || [];
+  // Inventory summaries are intentionally more defensive than the strict
+  // lesson authoring schema. The Learning Path organizer must still render a
+  // repair link when an older persisted lesson has a damaged page shape.
+  const rawPages = (lesson as unknown as { pages?: unknown }).pages;
+  const pages = Array.isArray(rawPages) ? rawPages : [];
 
   return pages.reduce(
     (counts, page) => {
-      const items = page.items || [];
+      const items =
+        page && typeof page === 'object' && !Array.isArray(page) && Array.isArray((page as { items?: unknown }).items)
+          ? (page as { items: unknown[] }).items
+          : [];
       counts.totalItems += items.length;
-      counts.totalExercises += items.filter(item => isExerciseType(item.type)).length;
+      counts.totalExercises += items.filter(
+        item =>
+          item &&
+          typeof item === 'object' &&
+          typeof (item as { type?: unknown }).type === 'string' &&
+          isExerciseType((item as { type: string }).type)
+      ).length;
       return counts;
     },
     {
@@ -40,15 +53,15 @@ export function toLessonSummary(id: string, data: Partial<Lesson>): LessonSummar
   return {
     id,
     kind: 'lesson',
-    title: data.title || '',
-    description: data.description,
-    type: data.type || 'normal',
+    title: typeof data.title === 'string' ? data.title : '',
+    description: typeof data.description === 'string' ? data.description : '',
+    type: typeof data.type === 'string' ? data.type : 'normal',
     vocabulary_pool: data.vocabulary_pool,
     showWordSearch: data.showWordSearch !== false,
-    isLive: data.isLive || false,
-    liveOrder: data.liveOrder ?? null,
-    publishedAt: data.publishedAt ?? null,
-    publishedBy: data.publishedBy ?? null,
+    isLive: data.isLive === true,
+    liveOrder: typeof data.liveOrder === 'number' ? data.liveOrder : null,
+    publishedAt: typeof data.publishedAt === 'string' ? data.publishedAt : null,
+    publishedBy: typeof data.publishedBy === 'string' ? data.publishedBy : null,
     createdAt: data.createdAt,
     createdBy: data.createdBy,
     updatedAt: data.updatedAt,

--- a/tests/formIdentificationConfiguration.test.ts
+++ b/tests/formIdentificationConfiguration.test.ts
@@ -1,9 +1,15 @@
 import {
   getGeneratedFormIdentificationConfigurationIssues,
   getGeneratedFormIdentificationConfigurationMessages,
+  getGeneratedFormIdentificationConfigurationWarnings,
+  formatFormIdentificationConfigurationWarning,
 } from '@/src/utils/exercises/formIdentificationConfiguration';
 import { lessonAuthoringInputSchema } from '@/src/lib/learning-units/schemas';
 import { testVersionDraftInputSchema } from '@/src/lib/tests/schemas';
+import {
+  getFormIdentificationCompatibilitySummary,
+  getFormPathStepSupport,
+} from '@/src/utils/exercises/formIdentificationCompatibility';
 
 const finitePath = 'subjunctive.active.present.singular.first';
 const infinitivePath = 'nonFinite.infinitive.present.active';
@@ -83,5 +89,112 @@ describe('generated form-identification configuration validation', () => {
     expect(result.error?.issues.map(issue => issue.message)).toContain(
       'Morphology exercise 1 on page 1: Participle forms have no applicable selected questions.'
     );
+  });
+
+  it('keeps mixed selections saveable and reports only the skipped family', () => {
+    const exercise = makeExercise(
+      [finitePath, infinitivePath, participlePath, 'gerund.genitive'],
+      ['person', 'number', 'mood']
+    );
+
+    expect(getGeneratedFormIdentificationConfigurationMessages(exercise)).toEqual([]);
+    expect(getGeneratedFormIdentificationConfigurationWarnings(exercise)).toEqual([
+      expect.objectContaining({
+        label: 'Infinitive forms',
+        skippedCount: 1,
+        answerableCount: 2,
+      }),
+      expect.objectContaining({
+        label: 'Gerund forms',
+        skippedCount: 1,
+        answerableCount: 2,
+      }),
+    ]);
+
+    const lessonResult = lessonAuthoringInputSchema.safeParse({
+      id: 'lesson-mixed',
+      title: 'Mixed morphology',
+      description: '',
+      type: 'normal',
+      pages: [{ id: 'page-1', items: [exercise] }],
+    });
+    expect(lessonResult.success).toBe(true);
+  });
+
+  it('removes the editor warning as soon as a compatible question is added', () => {
+    const exercise = makeExercise(['gerund.genitive'], ['mood']);
+    expect(getGeneratedFormIdentificationConfigurationMessages(exercise)).toEqual([
+      'Gerund forms have no applicable selected questions.',
+    ]);
+
+    exercise.data.paradigmConfigs['verb-conjugation'].steps.push('case');
+
+    expect(getGeneratedFormIdentificationConfigurationMessages(exercise)).toEqual([]);
+    expect(getGeneratedFormIdentificationConfigurationWarnings(exercise)).toEqual([]);
+  });
+
+  it('does not block an exercise when another enabled paradigm remains answerable', () => {
+    const exercise = makeExercise(['gerund.genitive'], ['mood']);
+    (exercise.data.paradigmConfigs as Record<string, unknown>)['noun-declension'] = {
+      enabled: true,
+      filters: {},
+      formSelection: { tableType: 'declension', selectedCellPaths: ['nominative.singular'] },
+      steps: ['case'],
+    };
+
+    expect(getGeneratedFormIdentificationConfigurationMessages(exercise)).toEqual([]);
+    expect(getGeneratedFormIdentificationConfigurationWarnings(exercise)).toEqual([
+      expect.objectContaining({ label: 'Gerund forms', skippedCount: 1 }),
+    ]);
+  });
+
+  it('treats unrecognized saved paths like skipped selections when another form is answerable', () => {
+    const exercise = makeExercise([finitePath, 'legacy.saved.path'], ['mood']);
+
+    expect(getGeneratedFormIdentificationConfigurationMessages(exercise)).toEqual([]);
+    const warnings = getGeneratedFormIdentificationConfigurationWarnings(exercise);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        label: 'Unrecognized saved forms',
+        skippedCount: 1,
+        kind: 'unrecognized',
+        answerableCount: 1,
+      }),
+    ]);
+    expect(formatFormIdentificationConfigurationWarning(warnings[0])).toBe(
+      '1 unrecognized saved form will be skipped. Select a valid form or remove the selection.'
+    );
+  });
+
+  it('keeps an all-unrecognized saved selection blocked', () => {
+    const exercise = makeExercise(['legacy.saved.path'], ['mood']);
+
+    expect(getGeneratedFormIdentificationConfigurationMessages(exercise)).toEqual([
+      'Saved form selections are unrecognized. Select valid forms before saving.',
+    ]);
+    expect(getGeneratedFormIdentificationConfigurationWarnings(exercise)).toEqual([]);
+  });
+
+  it('uses humanized step labels and plural wording for grouped warnings', () => {
+    const exercise = makeExercise([finitePath, 'gerund.genitive', 'gerund.accusative'], ['mood']);
+    const warning = getGeneratedFormIdentificationConfigurationWarnings(exercise).find(
+      entry => entry.kind === 'incompatible'
+    );
+
+    expect(warning).toBeDefined();
+    expect(formatFormIdentificationConfigurationWarning(warning!)).toBe(
+      '2 gerund forms will not appear because none of the selected questions apply. Add Conjugation, Verb form, or Case to include them.'
+    );
+  });
+
+  it.each([
+    ['declension', ['nominative.singular'], ['tense'], 'Noun forms'],
+    ['adjective-declension', ['positive.nominative.masculine.singular'], ['degree'], 'Adjective forms'],
+    ['pronoun-declension', ['nominative.singular'], ['gender'], 'Personal pronoun forms'],
+    ['pronoun-adjective-declension', ['nominative.masculine.singular'], ['gender'], 'Gendered pronoun forms'],
+  ] as const)('applies compatibility to %s selections', (tableType, paths, steps, label) => {
+    const summary = getFormIdentificationCompatibilitySummary(tableType, paths, steps);
+    expect(summary.answerableCount).toBe(label === 'Noun forms' || label === 'Personal pronoun forms' ? 0 : 1);
+    expect(getFormPathStepSupport(paths[0], tableType)?.label).toBe(label);
   });
 });

--- a/tests/generatedFormIdentificationFailureModes.test.ts
+++ b/tests/generatedFormIdentificationFailureModes.test.ts
@@ -173,10 +173,7 @@ describe('generated form-identification failure boundaries', () => {
     });
     const word = makeVerbWord({ id: 'infinitive', formPath: infinitivePath });
 
-    expect(stepsForWord(createGeneratedFormIdentificationItems(exercise, [word]), word.id)).toEqual([
-      'tense',
-      'voice',
-    ]);
+    expect(stepsForWord(createGeneratedFormIdentificationItems(exercise, [word]), word.id)).toEqual(['tense', 'voice']);
   });
 
   it('adapts mixed selections per generated form instead of taking a global intersection', () => {
@@ -206,6 +203,43 @@ describe('generated form-identification failure boundaries', () => {
       'case',
       'gender',
     ]);
+  });
+
+  it('excludes incompatible selected gerunds while retaining answerable finite forms', () => {
+    const exercise = makeExercise({
+      steps: ['mood'],
+      selectedCellPaths: [selectedFinitePath, 'gerund.genitive'],
+    });
+    const finite = makeVerbWord({ id: 'finite', formPath: finitePath });
+    const gerund = makeVerbWord({
+      id: 'gerund',
+      formPath: { verb_form: 'gerund', tense: '', voice: '', mood: '', person: '', number: '', case: 'genitive' },
+    });
+
+    const items = createGeneratedFormIdentificationItems(exercise, [finite, gerund]);
+
+    expect(items.map(item => item.wordId)).toEqual(['finite']);
+    expect(stepsForWord(items, 'finite')).toEqual(['mood']);
+  });
+
+  it('uses the selected gerund interpretation when a syncretic finite path is also present', () => {
+    const exercise = makeExercise({
+      steps: ['mood', 'case'],
+      selectedCellPaths: [selectedFinitePath, 'gerund.genitive'],
+    });
+    const gerund = makeVerbWord({
+      id: 'gerund-syncretic',
+      formPath: { verb_form: 'gerund', tense: '', voice: '', mood: '', person: '', number: '', case: 'genitive' },
+      primaryFormPaths: [
+        { verb_form: 'gerund', tense: '', voice: '', mood: '', person: '', number: '', case: 'genitive' },
+        finitePath,
+      ],
+    });
+
+    const items = createGeneratedFormIdentificationItems(exercise, [gerund]);
+
+    expect(stepsForWord(items, gerund.id)).toEqual(['case']);
+    expect(items[0]?.primaryFormPaths).toEqual([expect.objectContaining({ case: 'genitive' })]);
   });
 
   it('uses the shared steps when one spelling has finite and participle primary paths', () => {

--- a/tests/generatedVocabularyRoute.test.ts
+++ b/tests/generatedVocabularyRoute.test.ts
@@ -126,6 +126,45 @@ describe('student generated vocabulary route', () => {
     expect(archiveRef.collection).toHaveBeenCalledWith('words');
   });
 
+  it('filters incompatible selected verb forms before choosing a generated form', async () => {
+    mockVerifyAuthenticatedAccess.mockResolvedValue({ uid: 'student-1' });
+    mockCollection.mockReturnValue(query);
+    query.get.mockResolvedValue({
+      docs: [
+        {
+          id: 'word-1',
+          data: () => ({
+            word: 'amo',
+            part_of_speech: 'verb',
+            conjugation: '1',
+            conjugation_table: {
+              indicative: { active: { present: { singular: { first: ['amo'] } } } },
+              gerund: { genitive: ['amandi'] },
+            },
+          }),
+        },
+      ],
+      size: 1,
+      empty: false,
+    });
+
+    const response = await GET({
+      url: 'http://localhost/api/words/generated?collection=vocabulary_words_v5&exerciseMode=true&limit=1&tableType=conjugation&cellPaths=indicative.active.present.singular.first,gerund.genitive&steps=mood',
+      headers: new Headers({ authorization: 'Bearer student-token' }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    const payload = (response as unknown as { body: { data: { words: Array<Record<string, unknown>> } } }).body;
+    expect(payload.data.words).toHaveLength(1);
+    expect(payload.data.words[0]).toMatchObject({
+      selected_form: 'amo',
+      form_path: { verb_form: 'finite' },
+    });
+    expect(payload.data.words[0].primary_form_paths).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ verb_form: 'gerund' })])
+    );
+  });
+
   it.each([
     ['fetchAll', 'exerciseMode=true&fetchAll=true'],
     ['oversized limit', 'exerciseMode=true&limit=201'],

--- a/tests/learningPathService.test.ts
+++ b/tests/learningPathService.test.ts
@@ -200,6 +200,7 @@ describe('LearningPathService', () => {
       effectiveUnitIds: [],
       source: 'learning-path',
       canEdit: false,
+      lessonIssuesById: {},
       editBlockedReason: 'The Learning Path is not available.',
     });
 
@@ -298,17 +299,6 @@ describe('LearningPathService', () => {
       code: 'INELIGIBLE_LEARNING_UNIT',
     },
     {
-      name: 'incomplete normal lesson',
-      records: {
-        lessons: {
-          incomplete: lesson({ isLive: false, liveOrder: null, pages: [] }),
-        },
-        learningPaths: { default: path() },
-      },
-      input: { expectedRevision: 2, unitIds: ['incomplete'] },
-      code: 'INELIGIBLE_LEARNING_UNIT',
-    },
-    {
       name: 'test before Phase 6',
       records: {
         lessons: {
@@ -331,6 +321,194 @@ describe('LearningPathService', () => {
 
     await expect(service.save(input, 'admin')).rejects.toMatchObject({ code });
     expect(db.writes).toHaveLength(0);
+  });
+
+  it('allows an incomplete normal lesson and reports its content issue in the admin audit', async () => {
+    const db = new FakeFirestore({
+      lessons: {
+        incomplete: lesson({ isLive: false, liveOrder: null, pages: [] }),
+      },
+      learningPaths: { default: path({ unitIds: ['incomplete'] }) },
+    });
+    const service = new LearningPathService(db as never);
+
+    await expect(service.save({ expectedRevision: 2, unitIds: ['incomplete'] }, 'admin')).resolves.toMatchObject({
+      revision: 3,
+      unitIds: ['incomplete'],
+    });
+    await expect(service.getAdminView()).resolves.toMatchObject({
+      effectiveUnitIds: ['incomplete'],
+      lessonIssuesById: {
+        incomplete: [
+          expect.objectContaining({
+            code: 'INCOMPLETE_LESSON',
+            message: 'Lesson must contain at least one page.',
+          }),
+        ],
+      },
+    });
+    expect(db.writes).toHaveLength(1);
+  });
+
+  it('allows a newly added incomplete normal lesson without blocking the path save', async () => {
+    const db = new FakeFirestore({
+      lessons: {
+        existing: lesson(),
+        newlyAdded: lesson({ isLive: false, liveOrder: null, pages: [] }),
+      },
+      learningPaths: { default: path({ unitIds: ['existing'] }) },
+    });
+    const service = new LearningPathService(db as never);
+
+    await expect(
+      service.save({ expectedRevision: 2, unitIds: ['existing', 'newlyAdded'] }, 'admin')
+    ).resolves.toMatchObject({
+      revision: 3,
+      unitIds: ['existing', 'newlyAdded'],
+    });
+    expect(db.writes).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: 'a missing lesson type',
+      unit: { kind: 'lesson', title: 'Untyped lesson', pages: [] },
+    },
+    {
+      name: 'an unknown lesson type',
+      unit: { kind: 'lesson', type: 'unknown', title: 'Unknown lesson', pages: [] },
+    },
+    {
+      name: 'an unknown unit kind',
+      unit: { kind: 'mystery', type: 'normal', title: 'Mystery unit', pages: [] },
+    },
+  ])('keeps $name as a hard placement blocker', async ({ unit }) => {
+    const db = new FakeFirestore({
+      lessons: { invalid: unit },
+      learningPaths: { default: path({ unitIds: [] }) },
+    });
+    const service = new LearningPathService(db as never);
+
+    await expect(service.save({ expectedRevision: 2, unitIds: ['invalid'] }, 'admin')).rejects.toMatchObject({
+      code: 'INELIGIBLE_LEARNING_UNIT',
+    });
+    expect(db.writes).toHaveLength(0);
+  });
+
+  it('classifies page and item ID failures as incomplete lesson issues', async () => {
+    const db = new FakeFirestore({
+      lessons: {
+        ids: lesson({
+          isLive: false,
+          liveOrder: null,
+          pages: [
+            { id: '', items: [{ id: '', type: 'text' }] },
+            { id: 'page-1', items: [{ id: 'item-1', type: 'text' }] },
+            { id: 'page-1', items: [{ id: 'item-1', type: 'text' }] },
+          ],
+        }),
+      },
+      learningPaths: { default: path({ unitIds: ['ids'] }) },
+    });
+    const service = new LearningPathService(db as never);
+
+    const issues = (await service.getAdminView()).lessonIssuesById?.ids ?? [];
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'INCOMPLETE_LESSON', message: 'Page 1 is missing an ID.' }),
+        expect.objectContaining({ code: 'INCOMPLETE_LESSON', message: 'Item 1 on page 1 is missing an ID.' }),
+        expect.objectContaining({ code: 'INCOMPLETE_LESSON', message: 'Page 3 has a duplicate ID.' }),
+        expect.objectContaining({ code: 'INCOMPLETE_LESSON', message: 'Item 1 on page 3 has a duplicate ID.' }),
+      ])
+    );
+    expect(issues.filter(issue => issue.code === 'INVALID_LESSON_DATA')).toHaveLength(0);
+  });
+
+  it('surfaces morphology configuration failures with their page and item location', async () => {
+    const db = new FakeFirestore({
+      lessons: {
+        morphology: lesson({
+          pages: [
+            {
+              id: 'page-1',
+              items: [
+                {
+                  id: 'morphology-1',
+                  type: 'generated-form-identification',
+                  title: 'Morphology',
+                  data: {
+                    paradigmConfigs: {
+                      'verb-conjugation': {
+                        enabled: true,
+                        formSelection: {
+                          selectedCellPaths: ['nonFinite.infinitive.present.active'],
+                        },
+                        steps: ['mood'],
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      },
+      learningPaths: { default: path({ unitIds: ['morphology'] }) },
+    });
+    const service = new LearningPathService(db as never);
+
+    const view = await service.getAdminView();
+    expect(view.lessonIssuesById?.morphology).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'INVALID_LESSON_DATA',
+          message: 'Morphology exercise 1 on page 1: Infinitive forms have no applicable selected questions.',
+          path: ['pages', 0, 'items', 0, 'data', 'paradigmConfigs', 'verb-conjugation'],
+        }),
+      ])
+    );
+  });
+
+  it('does not surface a Learning Path issue for a partially incompatible morphology selection', async () => {
+    const db = new FakeFirestore({
+      lessons: {
+        morphology: lesson({
+          pages: [
+            {
+              id: 'page-1',
+              items: [
+                {
+                  id: 'morphology-1',
+                  type: 'generated-form-identification',
+                  title: 'Morphology',
+                  data: {
+                    paradigmConfigs: {
+                      'verb-conjugation': {
+                        enabled: true,
+                        formSelection: {
+                          selectedCellPaths: [
+                            'indicative.active.present.singular.first',
+                            'gerund.genitive',
+                          ],
+                        },
+                        steps: ['mood'],
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      },
+      learningPaths: { default: path({ unitIds: ['morphology'] }) },
+    });
+    const service = new LearningPathService(db as never);
+
+    const view = await service.getAdminView();
+    expect(view.lessonIssuesById?.morphology ?? []).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: 'INVALID_LESSON_DATA' })])
+    );
   });
 
   it('guards deletion whenever the canonical path contains the unit', async () => {

--- a/tests/liveLessonsPage.test.tsx
+++ b/tests/liveLessonsPage.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import LiveLessonsPage from '@/src/app/admin/(shell)/lessons/live/page';
 import type { AdminLearningPathView } from '@/src/types/learning-unit';
+import type { LearningPathLessonIssue } from '@/src/types/learning-unit';
 import type { LessonSummary } from '@/src/types/lesson';
 import type { TestUnitSummary } from '@/src/types/test';
 
@@ -88,13 +89,24 @@ jest.mock('@/src/components/admin/SortableLearningPathLesson', () => ({
     unit,
     onRemove,
     disabled,
+    issues = [],
   }: {
     unit: LessonSummary | TestUnitSummary;
     onRemove: () => void;
     disabled: boolean;
+    issues?: LearningPathLessonIssue[];
   }) => (
     <div>
       <span>{unit.title}</span>
+      {issues.length > 0 && (
+        <>
+          <span>Needs attention</span>
+          {issues.map(issue => (
+            <span key={issue.message}>{issue.message}</span>
+          ))}
+          <button>Fix lesson</button>
+        </>
+      )}
       <button onClick={onRemove} disabled={disabled} aria-label={`Remove ${unit.title} from Learning Path`}>
         Remove
       </button>
@@ -188,6 +200,53 @@ describe('Learning delivery organizer', () => {
         unitIds: ['lesson-1', 'lesson-2'],
       })
     );
+  });
+
+  it('shows non-blocking lesson issues and keeps path saving available', async () => {
+    const refetchPath = jest.fn().mockResolvedValue({ data: canonicalPathView() });
+    mockUseGetLearningPathQuery.mockReturnValue({
+      data: canonicalPathView({
+        lessonIssuesById: {
+          'lesson-1': [
+            {
+              code: 'INVALID_LESSON_DATA',
+              message: 'Morphology exercise 1 on page 1: Infinitive forms have no applicable selected questions.',
+            },
+          ],
+        },
+      }),
+      isLoading: false,
+      refetch: refetchPath,
+    });
+    mockSaveLearningPath.mockReturnValue({
+      unwrap: jest.fn().mockResolvedValue({
+        path: {
+          ...canonicalPathView().path,
+          revision: 4,
+          unitIds: ['lesson-1', 'lesson-2'],
+        },
+      }),
+    });
+
+    render(<LiveLessonsPage />);
+
+    expect(screen.getByText('1 lesson needs attention')).toBeInTheDocument();
+    expect(screen.getAllByText('Needs attention').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('Morphology exercise 1 on page 1: Infinitive forms have no applicable selected questions.')
+        .length
+    ).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Lesson one from Learning Path' }));
+    expect(screen.queryByText('1 lesson needs attention')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+    expect(screen.getByText('1 lesson needs attention')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Lesson two to Learning Path' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save Learning Path' }));
+
+    await waitFor(() => expect(mockSaveLearningPath).toHaveBeenCalled());
+    expect(refetchPath).toHaveBeenCalled();
   });
 
   it('inserts an eligible test at an exact position and saves the mixed sequence', async () => {

--- a/tests/multiParadigmConfigSection.test.tsx
+++ b/tests/multiParadigmConfigSection.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MultiParadigmConfigSection } from '@/src/components/ui/admin/content-editor/MultiParadigmConfigSection';
+
+describe('MultiParadigmConfigSection compatibility feedback', () => {
+  it('shows a non-blocking grouped warning for skipped forms', () => {
+    render(
+      <MultiParadigmConfigSection
+        availableParadigms={['verb-conjugation']}
+        paradigmWordCounts={{ 'verb-conjugation': 2 }}
+        paradigmConfigs={{
+          'verb-conjugation': {
+            enabled: true,
+            filters: {},
+            formSelection: {
+              tableType: 'conjugation',
+              selectedCellPaths: ['indicative.active.present.singular.first', 'gerund.genitive'],
+            },
+            steps: ['mood'],
+          },
+        }}
+        onUpdateParadigmConfig={jest.fn()}
+        onToggleParadigm={jest.fn()}
+      />
+    );
+
+    const warning = screen.getByText('Some selected forms will be skipped').closest('[role="status"]');
+    expect(warning).toBeInTheDocument();
+    expect(warning).toHaveTextContent(/1 gerund form will not appear/);
+    expect(warning).toHaveTextContent(/Add Conjugation, Verb form, or Case to include it/);
+  });
+
+  it('does not turn a partial warning into a disabled authoring control', () => {
+    const onUpdate = jest.fn();
+    render(
+      <MultiParadigmConfigSection
+        availableParadigms={['verb-conjugation']}
+        paradigmConfigs={{
+          'verb-conjugation': {
+            enabled: true,
+            filters: {},
+            formSelection: {
+              tableType: 'conjugation',
+              selectedCellPaths: ['indicative.active.present.singular.first', 'gerund.genitive'],
+            },
+            steps: ['mood'],
+          },
+        }}
+        onUpdateParadigmConfig={onUpdate}
+        onToggleParadigm={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Enabled')).toBeEnabled();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('marks skipped forms on an inactive paradigm tab and explains them when selected', () => {
+    render(
+      <MultiParadigmConfigSection
+        availableParadigms={['noun-declension', 'verb-conjugation']}
+        paradigmConfigs={{
+          'noun-declension': {
+            enabled: true,
+            filters: {},
+            formSelection: {
+              tableType: 'declension',
+              selectedCellPaths: ['nominative.singular'],
+            },
+            steps: ['case'],
+          },
+          'verb-conjugation': {
+            enabled: true,
+            filters: {},
+            formSelection: {
+              tableType: 'conjugation',
+              selectedCellPaths: ['indicative.active.present.singular.first', 'gerund.genitive'],
+            },
+            steps: ['mood'],
+          },
+        }}
+        onUpdateParadigmConfig={jest.fn()}
+        onToggleParadigm={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /Verb Conjugation.*1 skipped/ })).toBeInTheDocument();
+    expect(screen.queryByText('Some selected forms will be skipped')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Verb Conjugation.*1 skipped/ }));
+
+    expect(screen.getByText('Some selected forms will be skipped')).toBeInTheDocument();
+    expect(screen.getByText('1 skipped')).toBeInTheDocument();
+  });
+
+  it('warns about unrecognized saved paths without blocking compatible forms', () => {
+    render(
+      <MultiParadigmConfigSection
+        availableParadigms={['verb-conjugation']}
+        paradigmConfigs={{
+          'verb-conjugation': {
+            enabled: true,
+            filters: {},
+            formSelection: {
+              tableType: 'conjugation',
+              selectedCellPaths: ['indicative.active.present.singular.first', 'legacy.saved.path'],
+            },
+            steps: ['mood'],
+          },
+        }}
+        onUpdateParadigmConfig={jest.fn()}
+        onToggleParadigm={jest.fn()}
+      />
+    );
+
+    const warning = screen.getByText('Some selected forms will be skipped').closest('[role="status"]');
+    expect(warning).toHaveTextContent('1 unrecognized saved form will be skipped');
+    expect(screen.getByText('Enabled')).toBeEnabled();
+  });
+});

--- a/tests/runtimeModeScoring.test.tsx
+++ b/tests/runtimeModeScoring.test.tsx
@@ -118,9 +118,9 @@ describe('exercise runtime-mode scoring', () => {
 
     fireEvent.change(screen.getByPlaceholderText(/type your answer/i), { target: { value: 'two' } });
     fireEvent.click(screen.getByRole('button', { name: /check/i }));
-    fireEvent.click(screen.getByRole('button', { name: /finish exercise/i }));
 
     expect(onComplete).toHaveBeenCalledWith(0);
+    expect(screen.queryByRole('button', { name: /finish exercise/i })).not.toBeInTheDocument();
   });
 
   it('emits a raw runtime-mode answer under the persisted exercise ID', () => {

--- a/tests/sortableLearningPathLesson.test.tsx
+++ b/tests/sortableLearningPathLesson.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { SortableLearningPathLesson } from '@/src/components/admin/SortableLearningPathLesson';
+import type { LessonSummary } from '@/src/types/lesson';
+
+jest.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+jest.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
+const lesson: LessonSummary = {
+  id: 'lesson-1',
+  kind: 'lesson',
+  title: 'Lesson one',
+  description: '',
+  type: 'normal',
+  isLive: true,
+  liveOrder: 0,
+  publishedAt: null,
+  publishedBy: null,
+  totalPages: 1,
+  totalItems: 1,
+  totalExercises: 1,
+};
+
+describe('SortableLearningPathLesson', () => {
+  it('renders a warning and links directly to the lesson editor', () => {
+    const message = 'Page 2 has a duplicate ID.';
+
+    render(
+      <SortableLearningPathLesson
+        unit={lesson}
+        index={0}
+        disabled={false}
+        onRemove={jest.fn()}
+        issues={[{ code: 'INCOMPLETE_LESSON', message }]}
+      />
+    );
+
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    expect(screen.getByText(message)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Fix lesson' })).toHaveAttribute('href', '/admin/lessons/edit/lesson-1');
+  });
+});


### PR DESCRIPTION
## What changed

This PR makes generated Morphology form-identification exercises frictionless for admins while keeping saved configurations intact. It also makes Learning Path mutations tolerant of pre-existing lesson-content problems while clearly surfacing those problems to admins.

### Root cause

Persisted form selections can mix finite verbs, infinitives, participles, gerunds, supines, and nominal or pronominal forms. The old validation treated the configured question list as if every selected form supported every question. For example, person, number, and mood do not produce an answerable question for a gerund.

### Morphology compatibility and runtime behavior

- Adds one shared compatibility model across verbs, nouns, adjectives, and pronouns.
- Uses the same rules in the editor preview, generated vocabulary API, and server-side generation.
- Asks only selected questions that apply to the generated form.
- Skips forms with no applicable question without deleting the saved selection.
- Treats unknown older persisted paths as skipped and visible to the admin.
- Blocks authoring only when no answerable selected forms remain.

### Admin UX

- Partial incompatibility is non-blocking.
- The editor groups skipped forms and suggests compatible question categories.
- Every affected paradigm tab shows an amber skipped count, including inactive tabs.
- Warnings use plain singular and plural wording and update dynamically.
- Zero-answerable exercises receive a focused blocking error.

### Learning Path health and cache behavior

- Audits normal lessons currently placed in the canonical Learning Path.
- Shows non-blocking Needs attention warnings and direct Fix lesson links.
- Allows Learning Path placement, reordering, and removal despite lesson-content defects.
- Retains strict blocking for missing units, invalid unit kinds, practice lessons, and invalid tests.
- Invalidates and refetches Learning Path health after lesson saves.

### Baseline scoring test alignment

- Updates the stale Fill exercise runtime test to match current edge behavior: the final Check action completes the exercise immediately and no redundant Finish Exercise button is rendered.

## Validation

- Full Jest on the actual PR branch: 113 suites, 756 tests passed.
- TypeScript: npx tsc --noEmit passed.
- ESLint passed.
- git diff --check passed.
