### PR TITLE
Honor generated-exercise word counts with shared replenishment

### DIFF
--- a/outstanding plans/generated-exercise-word-count-replenishment-plan.md
+++ b/outstanding plans/generated-exercise-word-count-replenishment-plan.md
@@ -1,0 +1,283 @@
+# Final Implementation Plan (v5.1)
+## Exact Usable Word Count Replenishment for Generated Exercises
+
+---
+
+## 1. What this is about
+
+Teachers configure generated exercises — morphology drills (`generated-form-identification`) and vocabulary exercises (`generated-translation`) — by picking filters, paradigm tables, cell selections, and a **word count** (e.g., 10). Today that number fails in two directions:
+
+- **Exercises come up short.** The system fetches 10 candidate words, then discards any whose inflection tables lack the selected forms. A student gets 7 questions instead of 10 — a different 7 every attempt.
+- **Multi-paradigm exercises inflate.** With nouns + verbs enabled and count=10, each paradigm fetches 10 independently → up to 20 items.
+
+Root cause: candidates are fetched with a hard limit first; eligibility filtering happens afterward with no replenishment. This feature makes the configured count a **contract**, enforced by one shared engine used identically by student delivery and admin preview.
+
+## 2. Target UX
+
+### Admin (content author)
+- Sets Word Count = 10, enables paradigms, selects cells → **Preview** → exactly 10 valid-form words for healthy configurations, every time.
+- Multi-paradigm exercises are **balanced** (verbs+nouns at 10 → ~5+5).
+- Preview uses **identical semantics, budgets, and eligibility rules** as delivery. For healthy configurations (eligible density comfortably supports the target within the scan budgets), what preview shows is what students get.
+- Near the sparsity boundary, samples may differ between preview and an individual attempt because candidate traversal is randomized — a preview shortfall diagnostic means students are *likely* (not guaranteed) to see a similar shortfall. Diagnostics (per-paradigm scanned/exhausted/limit-reached) tell the author to widen filters or pick less sparse cells.
+- Preview works on drafts mid-editing (dedicated request schema, not the stricter persisted-exercise schema).
+
+### Student
+- Every exercise contains the full number of words the teacher configured, whenever the vocabulary supports it within scan budgets.
+- In step-by-step morphology modes one word produces several interaction items — students may see more prompts than the word count. That's existing intended behavior; the guaranteed quantity is **words**.
+- Which words appear remains random per attempt; filtering itself is unchanged — invalid-form words never appear, they just no longer reduce the total.
+
+### Unchanged
+- `count: 'all'` behavior (delivery **and** editor preview), legacy `/api/admin/words` GET route, grading, rendering.
+
+## 3. The contract (precise)
+
+> Deliver **exactly `count` usable source words whenever at least `count` eligible candidates are found within the configured scan budgets**; otherwise best effort, with budget exhaustion explicitly surfaced.
+
+- `count` is a **word quota, not an item quota** — resolved interaction items may exceed `count` in multi-step modes.
+- `count` is the **total across all enabled paradigms**, fairly allocated with borrowing.
+- Contract is **cost-bounded**: budgets scale with `count`, are **identical across preview and delivery**, and exhaustion is surfaced (server log on delivery; structured diagnostics in preview).
+- Preview is **representative, not predictive**: identical semantics and budgets; randomized traversal means boundary-case outcomes may differ per invocation.
+
+## 4. Confirmed decisions
+
+| Decision | Choice |
+|---|---|
+| Multi-paradigm semantics | `count` = total usable words, fair-shared with borrowing |
+| Shortfall policy | Best effort within budgets; surfaced, never silent |
+| Scan ceilings | Hard but scaled (`≥ k × count`); terminate collection, reported in diagnostics |
+| Output cap | New product policy `MAX_GENERATED_WORD_COUNT` in shared config module — value set after auditing persisted counts; enforced in authoring + delivery validation |
+| Preview parity model | Representative (Option A): same semantics/budgets, randomized outcome |
+| `poolWordLimit` | Caps the **shared sampled pool-ID universe** (computed once); not multiplied per spec; guarantee = `min(count, eligible within cap)` |
+| Cross-spec duplicate words | Allowed (current behavior); seen-ID dedup is **per stream**, never global |
+| `count: 'all'` | Unchanged in delivery and preview |
+| Pronoun overlap | Spec-aware rejection — **flagged observable behavior change** (§8.5) |
+
+## 5. Problem summary
+
+Delivery loader (`src/lib/tests/generated-word-loader.server.ts`): fetches `count` docs per spec → `mapWord()` drops nulls → `filterOverlappingPronounParadigms()` drops more → item building drops empty-display/no-answerable-step words. No replenishment. Pool path filters after slicing. Admin preview (`/api/admin/words` exerciseMode + client-side composition in `advancedVocabularyApi.ts`) independently repeats the pattern.
+
+## 6. Architecture
+
+```
+        delivery loader                        admin preview (new POST endpoint)
+  (specs from paradigmConfigs)          (specs from draft body via normalizePreviewSpecs)
+              └───────────────┬──────────────────────────────┘
+                              ▼
+        collectGeneratedExerciseWords()     ← shared orchestration, server-only
+        ├─ injectable rng (seeded substreams)
+        ├─ fair share allocation (shuffled spec order)
+        ├─ per-spec resumable candidate streams (snapshot cursors)
+        ├─ spec-aware eligibility (mapWord + overlap + prepare)
+        ├─ borrowing round across any stream with capacity
+        ├─ shared depletable scan budget (scales with count)
+        └─ shuffle + defensive slice to count
+```
+
+Spec *construction* stays at call sites (different upstream schemas); everything downstream of normalized `WordQuerySpec[]` is shared, so counting semantics cannot drift between paths.
+
+## 7. Constant layering
+
+```ts
+// src/config/generatedExerciseLimits.ts   — shared, side-effect-free, client-safe
+export const MAX_GENERATED_WORD_COUNT = ...;   // value chosen after persisted-count audit
+
+// src/lib/tests/generated-word-composition.server.ts   — server-only
+BASE_GLOBAL_SCAN, SCAN_MULTIPLIER, PER_SPEC_* , batch sizing constants
+```
+
+Consumers of the shared constant: authoring/editor schema, active-exercise validation (where `count: z.union([z.literal('all'), z.number().int().positive()])` gets its ceiling), preview request schema, composition module (read-only).
+
+## 8. Design details
+
+### 8.1 Stateful candidate collector
+
+```ts
+interface CandidateStream<TDoc> {
+  nextBatch(limit: number): Promise<{ docs: TDoc[]; exhausted: boolean }>;
+  totalScanned: number;   // cumulative across ALL passes — borrowing can't bypass guardrails
+}
+interface CollectionResult<W> {
+  words: W[];                  // eligible mapped words taken this call
+  scanned: number;             // documents examined (reads charged), NOT accepted words
+  exhausted: boolean;          // source fully traversed
+  scanLimitReached: boolean;   // stopped deliberately by per-spec ceiling
+}
+// canContinue = !exhausted && !scanLimitReached && globalBudgetRemaining > 0
+```
+
+### 8.2 Pagination — snapshot cursors only
+
+Value cursors skip same-key documents at page boundaries (`sort_key` collisions are routine; e2e fixtures set `random_index: 0.5` everywhere). All cursors use document snapshots: `query.startAfter(lastDocSnapshot)` (pattern proven at `route.ts:363`). Random selection keeps threshold/wrap phases `[threshold,1)` → `[0,threshold)`, snapshot-paginated. Search: `orderBy('sort_key')` + snapshot cursor. Pool: chunked iteration over the shared sampled ID list.
+
+### 8.3 Allocation & borrowing
+
+```text
+Pass 0  shuffle spec order via rng (fairness for small counts: count=2, n=5 → 1,1,0,0,0 to random specs)
+        share[i] = floor(count/n) (+1 for first count % n)
+Pass 1  replenish each spec toward its share
+Pass 2  deficit = count − collected
+        while deficit > 0 and some stream canContinue:
+          round-robin streams with capacity, continue cursors past original shares
+        stop: total == count | all exhausted | global budget depleted
+Final   shuffle combined → defensive slice to count
+```
+
+**Lending rule:** quota-met streams lend; exhausted, per-spec-depleted, or globally-depleted streams do not. Filling your share never closes your stream.
+
+### 8.4 Budgets & batching
+
+- Adaptive batches: first batch = remaining share; subsequent = `clamp(2 × deficit, 4, 100)`. Healthy configs read ≈ today's cost.
+- Per-spec ceiling: `max(400, 40 × share)`, cumulative across passes.
+- Global depletable budget owned by coordinator: `max(BASE_GLOBAL_SCAN ≈ 2000, SCAN_MULTIPLIER × count)`, `SCAN_MULTIPLIER ≥ 2`.
+- `MAX_GENERATED_WORD_COUNT` caps output; budgets cap examination — neither substitutes for the other.
+
+### 8.5 Spec-aware eligibility + extracted preparation
+
+```ts
+evaluate(candidate: { doc: QueryDocumentSnapshot; spec: WordQuerySpec }): W | null
+```
+
+A candidate consumes quota only if it survives every later stage:
+1. `mapWord(doc, spec) !== null` — form selection + step compatibility;
+2. **spec-aware pronoun overlap** — reject personal 1st/2nd pronouns only from the *broad gendered* spec; the same word from the *personal* spec stays eligible;
+3. **item-buildability** — `prepareGeneratedFormIdentificationWord(exercise, word) !== null`, extracted into pure `src/utils/exercises/formIdentificationPreparation.ts`.
+
+Loader eligibility and item builder consume the **same pure preparation helper** (computed twice — cheap, deterministic; the loader's public `ExerciseWordResponse[]` contract is unchanged). Translation predicate derives from existing drop conditions (missing translations english→latin, missing root word).
+
+> ⚠️ **Behavior change:** today broad-gendered configs eliminate *all* personal 1st/2nd pronouns — including personal-spec words — despite the helper's stated dedup intent. Spec-aware rejection fixes that mismatch but changes observable behavior for those configs. Requires origin-aware test + check whether the admin UI can produce the combination.
+
+### 8.6 Injected randomness
+
+`rng?: () => number` (default `Math.random`) feeds **all five** stochastic points: spec-order shuffle, pool-ID shuffle, `random_index` threshold, form selection (`selectForm`), final shuffle. Derived substreams (`allocationRng`, `queryRng`, `formRng`, `shuffleRng`) from one seed via small non-crypto PRNG, so adding a random call early doesn't shift later seeded expectations. Tests seed and assert exact allocations.
+
+### 8.7 Pool handling — shared universe cap
+
+```ts
+const poolCandidateIds = shuffle(pool.wordDocIds, rng).slice(0, poolWordLimit ?? Infinity);
+// ONE shared sampled universe; per-spec streams traverse the SAME list
+```
+
+- The cap applies to **pool IDs drawn** — missing/deleted documents consume the cap without extending it.
+- "Pool IDs considered" and `totalScanned` (Firestore documents read) remain distinct counters.
+- One shared chunked loader (~50 IDs/chunk) loads each chunk once and evaluates it per spec.
+- Invariant: `min(count, eligible within poolWordLimit)`.
+
+## 9. Admin preview (Slice 2)
+
+New dedicated endpoint; legacy GET route keeps its CRUD role and its own `GENERATED_MAX_RESULTS = 200`:
+
+```http
+POST /api/admin/exercises/generated-preview
+{
+  "type": "generated-form-identification",
+  "data": {
+    "generatorConfig": { "...": "...", "count": 10 },
+    "paradigmConfigs": { },
+    "mode": "step-by-step"
+  }
+}
+```
+
+- **One canonical `count`** at `data.generatorConfig.count` — matching the existing contract; no top-level duplicate.
+- Pipeline mirrors delivery exactly:
+
+```text
+unknown body
+  ↓ GeneratedExercisePreviewRequestSchema      ← composed from shared generator/paradigm
+  ↓                                              sub-schemas + MAX_GENERATED_WORD_COUNT
+  ↓                                              (NOT the persisted-exercise schema verbatim;
+  ↓                                              mid-edit drafts must validate)
+  ↓ normalize generated exercise config
+  ↓ requireGeneratedVocabularyCollection() / getReadableVocabularyPool()
+  ↓                                             ← same source restrictions as delivery,
+  ↓                                               so preview can't become more permissive
+  ↓ normalizePreviewSpecs()
+  ↓ collectGeneratedExerciseWords()            ← identical orchestration + budgets
+  → words + per-spec diagnostics { collected, scanned, exhausted, scanLimitReached }
+```
+
+- `verifyAdminAccess()` required; structured errors via `createRouteErrorResponse`.
+- `count` validated against `MAX_GENERATED_WORD_COUNT` (full authorable range); `'all'` explicitly supported (the editor relies on it today).
+- Client: mutation-based preview hook replaces `getMultiPosWords`/`getMultiParadigmWords` usage in editor hooks (mutations sidestep RTK Query cache interplay).
+
+## 10. File-by-file changes
+
+| File | Change | Slice |
+|---|---|---|
+| `src/config/generatedExerciseLimits.ts` (new, shared) | `MAX_GENERATED_WORD_COUNT` | 1 |
+| `src/lib/tests/generated-word-composition.server.ts` (new, server-only) | Collector + `collectGeneratedExerciseWords()` + budget constants + rng plumbing | 1 |
+| `src/utils/exercises/formIdentificationPreparation.ts` (new, pure) | `prepareGeneratedFormIdentificationWord()` extracted from `getPreparedPaths` | 1 |
+| `src/lib/tests/generated-exercises.ts` | Consume extracted preparation; export translation usability predicate | 1 |
+| `src/lib/tests/generated-word-loader.server.ts` | Thin: build specs → orchestration; remove inline load/filter logic | 1 |
+| `src/utils/generated/pronounParadigmFiltering.ts` | Spec-aware variant; sole call site is the loader | 1 |
+| `src/lib/tests/active-exercise-validation.ts` | `count ≤ MAX_GENERATED_WORD_COUNT` (post-audit) | 1 |
+| `src/app/api/admin/exercises/generated-preview/route.ts` (new) | Endpoint per §9 | 2 |
+| `src/store/api/advancedVocabularyApi.ts` + editor hooks | Mutation-based preview replacing queryFn composition | 2 |
+
+## 11. Behavior changes / release notes
+
+1. Multi-paradigm exercises shrink from `specs × count` toward `count` (intended).
+2. Delivered counts rise to the configured target where vocabulary allows within budgets.
+3. Broad-gendered + personal pronoun configs: personal-paradigm words no longer eliminated (§8.5 flag).
+4. Preview aligns with delivery semantics/budgets; near-boundary samples may differ (representative model).
+5. New validation ceiling on `count` — audit persisted content before choosing the value; deal with outliers explicitly.
+
+## 12. Testing plan
+
+Extend `tests/generatedWordLoaderSecurity.test.ts` (mocked-Firestore chain pattern) + `tests/generatedVocabularyRoute.test.ts`; new `tests/morphologyWordReplenishment.test.ts`:
+
+**Core guarantee**
+1. Target met: mixed fixture, count=10 → exactly 10 usable words
+2. Exhaustion: fewer eligible than count → all eligible, bounded queries
+3. Borrowing: rich spec stopped on quota-met lends to sparse spec → total = count
+4. Balance: two healthy paradigms, count=10 → shares honored
+5. `count < spec count`: seeded rng → exact deterministic remainder assignment
+6. `count: 'all'` unchanged (delivery)
+7. Scan ceiling hit → terminates, best-effort, `scanLimitReached` flagged
+8. Global budget: many sparse paradigms can't collectively exceed it
+9. Adaptive batching: high-eligibility small-count case reads ≈ remaining, not a fixed minimum
+
+**Cursor integrity**
+10. Duplicate `sort_key` across batch boundary — nothing skipped
+11. Duplicate `random_index` across wrap boundary — nothing skipped
+12. Per-stream dedup only; cross-spec duplicates still allowed
+
+**Eligibility**
+13. Passes `mapWord`, fails preparation → skipped during backfill
+14. Origin-aware pronouns: personal-spec words survive broad-gendered overlap; broad-spec duplicates rejected without consuming quota
+15. Translation predicates (missing translation / root word)
+
+**End-to-end & pools**
+16. Frozen delivery resolves exactly N words from mixed fixture; multi-step mode yields > N items from exactly N words (word-vs-item semantics)
+17. Pool chunked backfill; `poolWordLimit=100`, 3 paradigms → shared universe ≤ 100 IDs; missing/deleted IDs consume cap without extending it
+18. Search-path snapshot pagination
+19. Seeded-RNG replay: same seed → identical word set across runs
+
+**Slice 2 — preview**
+20. Preview/delivery parity on healthy configs across the full authorable range (`≤ MAX_GENERATED_WORD_COUNT`)
+21. `count: 'all'` through the new preview endpoint preserves all-matching semantics
+22. Preview rejects invalid collections/pools exactly like delivery; mutation hook covered without RTK Query cache complexity
+
+## 13. Verification
+
+```bash
+npx tsc --noEmit
+npm test -- --runInBand tests/morphologyWordReplenishment.test.ts \
+  tests/generatedWordLoaderSecurity.test.ts \
+  tests/generatedVocabularyRoute.test.ts \
+  tests/advancedVocabularyPagination.test.ts \
+  tests/generatedFormIdentificationFailureModes.test.ts
+npm run lint && git diff --check
+# full suite (cross-cutting change); no Firestore rule changes → rules suite n/a
+```
+
+Manual: morphology exercise, specific cells (e.g., 3rd-conj future active indicative), count=10 → preview shows exactly 10 valid-form words; verbs+nouns → 10 total balanced; student playback progression matches 10 selected words; sparse-filter exercise → preview diagnostics explain the shortfall.
+
+## 14. Rollout sequence
+
+```text
+audit persisted counts → choose MAX_GENERATED_WORD_COUNT above reality
+  → deal with outliers explicitly
+  → Slice 1: shared engine + delivery loader + regression suite (ships independently)
+  → Slice 2: preview endpoint + client hook + parity suite
+```

--- a/src/app/admin/(standalone)/lessons/preview/[id]/page.tsx
+++ b/src/app/admin/(standalone)/lessons/preview/[id]/page.tsx
@@ -85,7 +85,11 @@ function AdminLessonPreviewPage() {
           <h2 className="text-2xl font-serif text-gray-800 mb-6">
             <SimpleRichDisplay content={previewLesson.title} />
           </h2>
-          <LessonPlayer lesson={previewLesson} trackProgress={false} />
+          <LessonPlayer
+            lesson={previewLesson}
+            trackProgress={false}
+            generatedExerciseContext={{ kind: 'admin-preview' }}
+          />
         </div>
       </main>
     </div>

--- a/src/app/api/admin/exercises/generated-preview/route.ts
+++ b/src/app/api/admin/exercises/generated-preview/route.ts
@@ -1,26 +1,61 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteErrorResponse } from '@/src/lib/route-error-response';
-import { verifyAdminAccess, verifyAuthenticatedAccess } from '@/src/lib/verifyAdminAccess';
-import { GeneratedExercisePreviewRequestSchema } from '@/src/lib/tests/generated-preview-schema';
+import { verifyAdminAccess } from '@/src/lib/verifyAdminAccess';
+import { verifyRequestAuth } from '@/src/lib/verifyRequestAuth';
+import {
+  GeneratedExercisePlaybackRequestSchema,
+  GeneratedExercisePreviewRequestSchema,
+} from '@/src/lib/tests/generated-preview-schema';
 import type { GeneratedExercise } from '@/src/lib/tests/generated-exercises';
 import { collectWordsForGeneratedExerciseRequest } from '@/src/lib/tests/generated-word-loader.server';
 import { GeneratedVocabularySourceError } from '@/src/lib/tests/generated-word-composition.server';
+import { studentDashboardService } from '@/src/lib/learning-units/student-dashboard-service';
 import { adminDb } from '@/src/services/firebase-admin';
 
 export const dynamic = 'force-dynamic';
 
 const routeErrorResponse = createRouteErrorResponse(GeneratedVocabularySourceError);
 
-export async function handleGeneratedExerciseWordsPOST(
-  request: NextRequest,
-  audience: 'admin' | 'generated'
-) {
+export async function handleGeneratedExerciseWordsPOST(request: NextRequest, audience: 'admin' | 'generated') {
   try {
-    if (audience === 'admin') await verifyAdminAccess(request);
-    else await verifyAuthenticatedAccess(request);
+    let exercise: GeneratedExercise;
 
-    const body = GeneratedExercisePreviewRequestSchema.parse(await request.json().catch(() => null));
-    const result = await collectWordsForGeneratedExerciseRequest(adminDb, body as unknown as GeneratedExercise);
+    if (audience === 'admin') {
+      await verifyAdminAccess(request);
+      const requestBody = await request.json().catch(() => null);
+      exercise = GeneratedExercisePreviewRequestSchema.parse(requestBody) as unknown as GeneratedExercise;
+    } else {
+      const student = await verifyRequestAuth(request);
+      if (!student) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+      const requestBody = await request.json().catch(() => null);
+      const source = GeneratedExercisePlaybackRequestSchema.parse(requestBody);
+      const lesson = await studentDashboardService.getLesson(student.uid, source.lessonId);
+      const item = lesson.pages[source.pageIndex]?.items[source.itemIndex];
+      if (
+        !item ||
+        item.id !== source.exerciseId ||
+        (item.type !== 'generated-translation' && item.type !== 'generated-form-identification')
+      ) {
+        throw new GeneratedVocabularySourceError(
+          'Generated exercise was not found in the authorized lesson',
+          404,
+          'GENERATED_EXERCISE_NOT_FOUND'
+        );
+      }
+
+      const parsedExercise = GeneratedExercisePreviewRequestSchema.safeParse(item);
+      if (!parsedExercise.success) {
+        throw new GeneratedVocabularySourceError(
+          'Generated exercise contains invalid persisted data',
+          409,
+          'INVALID_GENERATED_EXERCISE'
+        );
+      }
+      exercise = parsedExercise.data as unknown as GeneratedExercise;
+    }
+
+    const result = await collectWordsForGeneratedExerciseRequest(adminDb, exercise);
 
     return NextResponse.json({
       words: result.words,

--- a/src/app/api/admin/exercises/generated-preview/route.ts
+++ b/src/app/api/admin/exercises/generated-preview/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteErrorResponse } from '@/src/lib/route-error-response';
+import { verifyAdminAccess, verifyAuthenticatedAccess } from '@/src/lib/verifyAdminAccess';
+import { GeneratedExercisePreviewRequestSchema } from '@/src/lib/tests/generated-preview-schema';
+import type { GeneratedExercise } from '@/src/lib/tests/generated-exercises';
+import { collectWordsForGeneratedExerciseRequest } from '@/src/lib/tests/generated-word-loader.server';
+import { GeneratedVocabularySourceError } from '@/src/lib/tests/generated-word-composition.server';
+import { adminDb } from '@/src/services/firebase-admin';
+
+export const dynamic = 'force-dynamic';
+
+const routeErrorResponse = createRouteErrorResponse(GeneratedVocabularySourceError);
+
+export async function handleGeneratedExerciseWordsPOST(
+  request: NextRequest,
+  audience: 'admin' | 'generated'
+) {
+  try {
+    if (audience === 'admin') await verifyAdminAccess(request);
+    else await verifyAuthenticatedAccess(request);
+
+    const body = GeneratedExercisePreviewRequestSchema.parse(await request.json().catch(() => null));
+    const result = await collectWordsForGeneratedExerciseRequest(adminDb, body as unknown as GeneratedExercise);
+
+    return NextResponse.json({
+      words: result.words,
+      diagnostics: result.diagnostics,
+      requestedCount: result.requestedCount,
+      collected: result.words.length,
+      globalScanLimitReached: result.globalScanLimitReached,
+    });
+  } catch (error) {
+    return routeErrorResponse(
+      error,
+      audience === 'admin' ? 'preview generated exercise' : 'collect generated exercise words'
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return handleGeneratedExerciseWordsPOST(request, 'admin');
+}

--- a/src/app/api/words/generated-exercise/route.ts
+++ b/src/app/api/words/generated-exercise/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server';
+import { handleGeneratedExerciseWordsPOST } from '@/src/app/api/admin/exercises/generated-preview/route';
+
+export const dynamic = 'force-dynamic';
+
+/** Authenticated lesson-playback collection using the same engine as frozen tests and admin preview. */
+export async function POST(request: NextRequest) {
+  return handleGeneratedExerciseWordsPOST(request, 'generated');
+}

--- a/src/components/ui/admin/content-editor/GeneratedFormIdentificationEditor.tsx
+++ b/src/components/ui/admin/content-editor/GeneratedFormIdentificationEditor.tsx
@@ -12,23 +12,21 @@ import { ExerciseFeedbackSection } from './ExerciseFeedbackSection';
 import { AudioUploadSection } from './AudioUploadSection';
 import { AdvancedFiltersPanel } from '../vocabulary/AdvancedFiltersPanel';
 import { VocabularyPoolSelector } from '../vocabulary-pools/VocabularyPoolSelector';
-import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-responses';
-import {
-  extractStepValue,
-  getAcceptedAnswersForStep,
-  getDisplayForm,
-  enrichPathsWithSteps,
-  getAnswerableStepsForWord,
-} from '@/src/utils/exercises/formIdentificationHelpers';
 import { WordSourceSection } from './WordSourceSection';
 import { MultiParadigmConfigSection } from './MultiParadigmConfigSection';
 import { useFormIdentificationEditor } from '@/src/hooks/useFormIdentificationEditor';
 import type { PartOfSpeech, PronounType, PronounPerson } from '@/shared/types/vocabulary/schemas/enums';
 import { parseMultiFilterValue, serializeMultiFilterValue } from '@/src/utils/wordFilters';
-import { deriveParadigm } from '@/src/utils/paradigm';
-import type { FormIdentificationStep } from '@/src/types/exercises/schemas/form-identification';
+import {
+  extractStepValue,
+  getAcceptedAnswersForStep,
+  getDisplayForm,
+} from '@/src/utils/exercises/formIdentificationHelpers';
 import { getExerciseDisplayForm, hasSelectedForm } from '@/src/utils/exercises/formSelection';
 import { getGeneratedFormIdentificationConfigurationMessages } from '@/src/utils/exercises/formIdentificationConfiguration';
+import { prepareGeneratedFormIdentificationWord } from '@/src/utils/exercises/formIdentificationPreparation';
+import { formatGeneratedPreviewDiagnostics } from '@/src/utils/generated/generatedExercisePreview';
+import { getApiErrorMessage } from '@/src/store/api/baseQuery';
 import { AlertTriangle, Loader2 } from 'lucide-react';
 
 export const GeneratedFormIdentificationEditor: React.FC = () => {
@@ -156,18 +154,7 @@ const GeneratedFormIdentificationEditorView: React.FC<{
     </div>
   );
 
-  const previewWords = editor.previewData?.words as ExerciseWordResponse[] | undefined;
-
-  const getWordSteps = (word: ExerciseWordResponse): FormIdentificationStep[] => {
-    const pronounType = word.part_of_speech === 'pronoun' ? (word.pronoun_type as PronounType | undefined) : undefined;
-    const pronounPerson = word.part_of_speech === 'pronoun' ? (word.person as PronounPerson | undefined) : undefined;
-    const paradigm = deriveParadigm(word.part_of_speech as PartOfSpeech, pronounType, pronounPerson);
-    if (!paradigm) return [];
-    const basePrimaryPaths = (word.primary_form_paths || (word.form_path ? [word.form_path] : [])) as Array<
-      Record<string, string | undefined>
-    >;
-    return getAnswerableStepsForWord(word, editor.paradigmConfigs[paradigm]?.steps || [], basePrimaryPaths);
-  };
+  const previewWords = editor.previewData?.words;
 
   return (
     <div className="space-y-6">
@@ -321,52 +308,37 @@ const GeneratedFormIdentificationEditorView: React.FC<{
                 : `Preview Sample Items${editor.config.count !== 'all' ? ` (${editor.config.count})` : ''}`}
             </Button>
 
+            {editor.isPreviewOpen && editor.previewError ? (
+              <div className="text-sm text-red-600 mt-4">
+                {getApiErrorMessage(editor.previewError, 'Failed to load preview')}
+              </div>
+            ) : null}
+
+            {editor.isPreviewOpen && editor.previewData?.diagnostics?.length ? (
+              <p className="text-xs text-gray-500 mt-2">
+                {formatGeneratedPreviewDiagnostics(editor.previewData)}
+              </p>
+            ) : null}
+
             {editor.isPreviewOpen && previewWords && previewWords.length > 0 && (
               <div className="space-y-2 mt-4">
                 <label className="block text-sm font-medium">Preview ({previewWords.length} items)</label>
                 {previewWords.map((word, index) => {
-                  const wordWithPath = word;
-                  const wordSteps = getWordSteps(word);
+                  const prepared = prepareGeneratedFormIdentificationWord(editingContent, word);
+                  const wordSteps = prepared?.steps ?? [];
 
                   let primaryAnswersDisplay = '';
                   let optionalAnswersDisplay = '';
 
-                  if (isSingleField) {
-                    const basePrimaryPaths = (word.primary_form_paths ||
-                      (word.form_path ? [word.form_path] : [])) as Array<Record<string, string | undefined>>;
-                    const baseOptionalPaths = (word.optional_form_paths || []) as Array<
-                      Record<string, string | undefined>
-                    >;
+                  if (isSingleField && prepared) {
+                    const formatPath = (path: Record<string, string | undefined>) =>
+                      wordSteps
+                        .map(step => (path[step] ? getDisplayForm(path[step]) : null))
+                        .filter(Boolean)
+                        .join(',');
 
-                    const enrichedPrimaryPaths = enrichPathsWithSteps(basePrimaryPaths, wordWithPath, wordSteps);
-                    const enrichedOptionalPaths = enrichPathsWithSteps(baseOptionalPaths, wordWithPath, wordSteps);
-
-                    const primaryDisplays = enrichedPrimaryPaths
-                      .map(path => {
-                        const pathValues = wordSteps
-                          .map(step => {
-                            const val = path[step];
-                            return val ? getDisplayForm(val) : null;
-                          })
-                          .filter(Boolean);
-                        return pathValues.join(',');
-                      })
-                      .filter(display => display.length > 0);
-
-                    const optionalDisplays = enrichedOptionalPaths
-                      .map(path => {
-                        const pathValues = wordSteps
-                          .map(step => {
-                            const val = path[step];
-                            return val ? getDisplayForm(val) : null;
-                          })
-                          .filter(Boolean);
-                        return pathValues.join(',');
-                      })
-                      .filter(display => display.length > 0);
-
-                    primaryAnswersDisplay = primaryDisplays.join(';');
-                    optionalAnswersDisplay = optionalDisplays.join(';');
+                    primaryAnswersDisplay = prepared.primary.map(formatPath).filter(Boolean).join(';');
+                    optionalAnswersDisplay = prepared.optional.map(formatPath).filter(Boolean).join(';');
                   }
 
                   const displayWord = getExerciseDisplayForm(word);
@@ -391,50 +363,42 @@ const GeneratedFormIdentificationEditorView: React.FC<{
                               )}
                             </>
                           ) : (
-                            (() => {
-                              const basePrimaryPaths = (word.primary_form_paths ||
-                                (word.form_path ? [word.form_path] : [])) as Array<Record<string, string | undefined>>;
-                              const baseOptionalPaths = (word.optional_form_paths || []) as Array<
-                                Record<string, string | undefined>
-                              >;
+                            wordSteps.map(step => {
+                              const primaryValues = (prepared?.primary ?? [])
+                                .map(path => path[step])
+                                .filter((value): value is string => Boolean(value));
+                              const optionalValues = (prepared?.optional ?? [])
+                                .map(path => path[step])
+                                .filter((value): value is string => Boolean(value));
 
-                              return wordSteps.map(step => {
-                                const primaryValues = basePrimaryPaths
-                                  .map(path => path[step])
-                                  .filter((v): v is string => !!v);
-                                const optionalValues = baseOptionalPaths
-                                  .map(path => path[step])
-                                  .filter((v): v is string => !!v);
+                              const uniquePrimaryValues = Array.from(new Set(primaryValues));
+                              const uniqueOptionalValues = Array.from(
+                                new Set(optionalValues.filter(value => !uniquePrimaryValues.includes(value)))
+                              );
 
-                                const uniquePrimaryValues = Array.from(new Set(primaryValues));
-                                const uniqueOptionalValues = Array.from(
-                                  new Set(optionalValues.filter(v => !uniquePrimaryValues.includes(v)))
-                                );
+                              const displayValue =
+                                uniquePrimaryValues.length > 0
+                                  ? uniquePrimaryValues.join(' OR ')
+                                  : extractStepValue(word, step);
 
-                                const displayValue =
-                                  uniquePrimaryValues.length > 0
-                                    ? uniquePrimaryValues.join(' OR ')
-                                    : extractStepValue(wordWithPath, step);
+                              if (!displayValue) return null;
 
-                                if (!displayValue) return null;
+                              const answers = getAcceptedAnswersForStep(
+                                uniquePrimaryValues.length > 0 ? uniquePrimaryValues[0] : displayValue
+                              );
 
-                                const answers = getAcceptedAnswersForStep(
-                                  uniquePrimaryValues.length > 0 ? uniquePrimaryValues[0] : displayValue
-                                );
-
-                                return (
-                                  <div key={step} className="text-gray-600">
-                                    <strong className="capitalize">{step.replace(/_/g, ' ')}:</strong> {displayValue}{' '}
-                                    {answers.length > 1 && `(or ${answers.slice(1).join(', ')})`}
-                                    {uniqueOptionalValues.length > 0 && (
-                                      <span className="text-gray-400 text-xs ml-1">
-                                        [optional: {uniqueOptionalValues.join(' OR ')}]
-                                      </span>
-                                    )}
-                                  </div>
-                                );
-                              });
-                            })()
+                              return (
+                                <div key={step} className="text-gray-600">
+                                  <strong className="capitalize">{step.replace(/_/g, ' ')}:</strong> {displayValue}{' '}
+                                  {answers.length > 1 && `(or ${answers.slice(1).join(', ')})`}
+                                  {uniqueOptionalValues.length > 0 && (
+                                    <span className="text-gray-400 text-xs ml-1">
+                                      [optional: {uniqueOptionalValues.join(' OR ')}]
+                                    </span>
+                                  )}
+                                </div>
+                              );
+                            })
                           )}
                         </div>
                       </CardContent>

--- a/src/components/ui/admin/content-editor/GeneratedTranslationEditor.tsx
+++ b/src/components/ui/admin/content-editor/GeneratedTranslationEditor.tsx
@@ -17,8 +17,9 @@ import { splitTranslationAnswers } from '@/src/utils/exercises/generatedTranslat
 import type { TranslationDirection } from '@/src/types/exercises/generated-translation';
 import type { PartOfSpeech, PronounType, PronounPerson } from '@/shared/types/vocabulary/schemas/enums';
 import { parseMultiFilterValue, serializeMultiFilterValue } from '@/src/utils/wordFilters';
-import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-responses';
 import { getExerciseDisplayForm, hasSelectedForm } from '@/src/utils/exercises/formSelection';
+import { formatGeneratedPreviewDiagnostics } from '@/src/utils/generated/generatedExercisePreview';
+import { getApiErrorMessage } from '@/src/store/api/baseQuery';
 
 export const GeneratedTranslationEditor: React.FC = () => {
   const editingContent = useAppSelector(
@@ -134,7 +135,7 @@ const GeneratedTranslationEditorView: React.FC<{ editingContent: GeneratedTransl
     </div>
   );
 
-  const previewWords = editor.previewData?.words as ExerciseWordResponse[] | undefined;
+  const previewWords = editor.previewData?.words;
 
   return (
     <div className="space-y-6">
@@ -217,6 +218,18 @@ const GeneratedTranslationEditorView: React.FC<{ editingContent: GeneratedTransl
             <Button type="button" onClick={() => editor.setIsPreviewOpen(true)} disabled={editor.isPreviewFetching}>
               {editor.isPreviewFetching ? 'Loading Preview...' : 'Preview Sample Items'}
             </Button>
+
+            {editor.isPreviewOpen && editor.previewError ? (
+              <div className="text-sm text-red-600 mt-4">
+                {getApiErrorMessage(editor.previewError, 'Failed to load preview')}
+              </div>
+            ) : null}
+
+            {editor.isPreviewOpen && editor.previewData?.diagnostics?.length ? (
+              <p className="text-xs text-gray-500 mt-2">
+                {formatGeneratedPreviewDiagnostics(editor.previewData)}
+              </p>
+            ) : null}
 
             {editor.isPreviewOpen && previewWords && previewWords.length > 0 && (
               <div className="space-y-2 mt-4">

--- a/src/components/ui/admin/lesson-builder/LessonPreview.tsx
+++ b/src/components/ui/admin/lesson-builder/LessonPreview.tsx
@@ -21,7 +21,12 @@ export const LessonPreview: React.FC<LessonPreviewProps> = ({ lesson }) => {
       </div>
       <div className="p-4 pb-6">
         {hasContent ? (
-          <LessonPlayer lesson={lesson} navigationPlacement="contained" trackProgress={false} />
+          <LessonPlayer
+            lesson={lesson}
+            navigationPlacement="contained"
+            trackProgress={false}
+            generatedExerciseContext={{ kind: 'admin-preview' }}
+          />
         ) : (
           <div className="flex items-center justify-center h-64 border-2 border-dashed border-gray-300 rounded-lg">
             <div className="text-center">

--- a/src/components/ui/exercises/generated-form-identification-exercise.tsx
+++ b/src/components/ui/exercises/generated-form-identification-exercise.tsx
@@ -9,9 +9,8 @@ import { ExerciseInput, FeedbackDisplay } from '../feedback';
 import { ExerciseProgress } from './exercise-progress';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
-import { useGetMultiParadigmWordsQuery } from '@/src/store/api/advancedVocabularyApi';
+import { useGetGeneratedExerciseWordsQuery } from '@/src/store/api/advancedVocabularyApi';
 import { Card, CardContent } from '../card';
-import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-responses';
 import {
   FormIdentificationItemSchema,
   type FormIdentificationItem,
@@ -29,7 +28,6 @@ import {
   normalize,
 } from '@/src/utils/exercises/generatedFormIdentificationExercise';
 import { formatLabel } from '@/src/utils/label-formatter';
-import { normalizeCollection, buildLegacyParadigmConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
 import type { ExerciseAnswer, ExerciseAnswerHandler, RuntimeMode } from '@/src/types/runtime-mode';
 import { getContentTypeLabel } from '@/src/lib/content/registry';
 import { createGeneratedFormIdentificationItems } from '@/src/lib/tests/generated-exercises';
@@ -70,35 +68,14 @@ const GeneratedFormIdentificationExerciseComponent: React.FC<Props> = ({
   const [wordAnswers, setWordAnswers] = useState<Record<string, Record<string, string>>>({});
   const [multiAnswerSlots, setMultiAnswerSlots] = useState<Record<string, string[][]>>({});
 
-  const config = exercise.data.generatorConfig ?? {
-    collection: '',
-    wordSource: 'filters' as const,
-    count: 0,
-  };
   const isSingleField = exercise.data.mode === 'single-field';
   const requireAllPrimaryAnswers = exercise.data.requireAllPrimaryAnswers ?? false;
   const isMultiAnswerMode = !isSingleField && requireAllPrimaryAnswers;
 
-  // Backward compat: old exercises stored filters/formSelection in generatorConfig
-  // with no paradigmConfigs, wordSource, or poolId
-  const hasNewFormatParadigmConfigs =
-    exercise.data.paradigmConfigs &&
-    typeof exercise.data.paradigmConfigs === 'object' &&
-    Object.keys(exercise.data.paradigmConfigs).length > 0;
-
-  const paradigmConfigs = hasNewFormatParadigmConfigs
-    ? exercise.data.paradigmConfigs
-    : buildLegacyParadigmConfigs(config as Parameters<typeof buildLegacyParadigmConfigs>[0]);
-
-  const { data, isLoading, isError } = useGetMultiParadigmWordsQuery(
+  const { data, isLoading, isError } = useGetGeneratedExerciseWordsQuery(
     {
-      exerciseType: 'generated-form-identification',
-      collection: normalizeCollection(config.collection),
-      wordSource: config.wordSource || 'filters',
-      poolId: config.poolId ?? null,
-      poolWordLimit: config.poolWordLimit ?? null,
-      count: config.count,
-      paradigmConfigs,
+      type: 'generated-form-identification',
+      data: exercise.data,
     },
     { skip: (mode === 'test' && !allowGeneratedExerciseQueries) || resolvedItems !== undefined }
   );
@@ -106,11 +83,7 @@ const GeneratedFormIdentificationExerciseComponent: React.FC<Props> = ({
   const items: ItemType[] = useMemo(() => {
     if (resolvedItems) return resolvedItems;
     if (!data?.words) return [];
-    return createGeneratedFormIdentificationItems(
-      exercise,
-      data.words as unknown as ExerciseWordResponse[],
-      wordAnswers
-    );
+    return createGeneratedFormIdentificationItems(exercise, data.words, wordAnswers);
   }, [data?.words, exercise, wordAnswers, resolvedItems]);
 
   const validatedItems = useMemo(() => {

--- a/src/components/ui/exercises/generated-form-identification-exercise.tsx
+++ b/src/components/ui/exercises/generated-form-identification-exercise.tsx
@@ -9,7 +9,10 @@ import { ExerciseInput, FeedbackDisplay } from '../feedback';
 import { ExerciseProgress } from './exercise-progress';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
-import { useGetGeneratedExerciseWordsQuery } from '@/src/store/api/advancedVocabularyApi';
+import {
+  useGetGeneratedExerciseWordsQuery,
+  type GeneratedExerciseQuerySource,
+} from '@/src/store/api/advancedVocabularyApi';
 import { Card, CardContent } from '../card';
 import {
   FormIdentificationItemSchema,
@@ -42,6 +45,7 @@ interface Props {
   initialAnswer?: ExerciseAnswer;
   resolvedItems?: Array<FormIdentificationItem | SingleFieldFormIdentificationItem | MultiAnswerFormIdentificationItem>;
   allowGeneratedExerciseQueries?: boolean;
+  generatedExerciseSource?: GeneratedExerciseQuerySource;
 }
 
 type ItemType = FormIdentificationItem | SingleFieldFormIdentificationItem | MultiAnswerFormIdentificationItem;
@@ -61,6 +65,7 @@ const GeneratedFormIdentificationExerciseComponent: React.FC<Props> = ({
   initialAnswer,
   resolvedItems,
   allowGeneratedExerciseQueries = false,
+  generatedExerciseSource,
 }) => {
   const mode = runtimeMode ?? 'practice';
   const assessmentMode = mode !== 'practice';
@@ -74,10 +79,18 @@ const GeneratedFormIdentificationExerciseComponent: React.FC<Props> = ({
 
   const { data, isLoading, isError } = useGetGeneratedExerciseWordsQuery(
     {
-      type: 'generated-form-identification',
-      data: exercise.data,
+      exercise: {
+        type: 'generated-form-identification',
+        data: exercise.data,
+      },
+      source: generatedExerciseSource ?? { kind: 'admin-preview' },
     },
-    { skip: (mode === 'test' && !allowGeneratedExerciseQueries) || resolvedItems !== undefined }
+    {
+      skip:
+        (!generatedExerciseSource && !allowGeneratedExerciseQueries) ||
+        (mode === 'test' && !allowGeneratedExerciseQueries) ||
+        resolvedItems !== undefined,
+    }
   );
 
   const items: ItemType[] = useMemo(() => {

--- a/src/components/ui/exercises/generated-translation-exercise.tsx
+++ b/src/components/ui/exercises/generated-translation-exercise.tsx
@@ -9,7 +9,10 @@ import { ExerciseInput, FeedbackDisplay } from '../feedback';
 import { ExerciseProgress } from './exercise-progress';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
-import { useGetGeneratedExerciseWordsQuery } from '@/src/store/api/advancedVocabularyApi';
+import {
+  useGetGeneratedExerciseWordsQuery,
+  type GeneratedExerciseQuerySource,
+} from '@/src/store/api/advancedVocabularyApi';
 import { Card, CardContent } from '../card';
 import {
   validateGeneratedTranslationExercise,
@@ -29,6 +32,7 @@ interface Props {
   initialAnswer?: ExerciseAnswer;
   resolvedItems?: GeneratedTranslationItem[];
   allowGeneratedExerciseQueries?: boolean;
+  generatedExerciseSource?: GeneratedExerciseQuerySource;
 }
 
 const GeneratedTranslationExerciseComponent: React.FC<Props> = ({
@@ -39,6 +43,7 @@ const GeneratedTranslationExerciseComponent: React.FC<Props> = ({
   initialAnswer,
   resolvedItems,
   allowGeneratedExerciseQueries = false,
+  generatedExerciseSource,
 }) => {
   const mode = runtimeMode ?? 'practice';
   const assessmentMode = mode !== 'practice';
@@ -48,11 +53,19 @@ const GeneratedTranslationExerciseComponent: React.FC<Props> = ({
 
   const { data, isLoading, isError } = useGetGeneratedExerciseWordsQuery(
     {
-      type: 'generated-translation',
-      translationDirection,
-      data: exercise.data,
+      exercise: {
+        type: 'generated-translation',
+        translationDirection,
+        data: exercise.data,
+      },
+      source: generatedExerciseSource ?? { kind: 'admin-preview' },
     },
-    { skip: (mode === 'test' && !allowGeneratedExerciseQueries) || resolvedItems !== undefined }
+    {
+      skip:
+        (!generatedExerciseSource && !allowGeneratedExerciseQueries) ||
+        (mode === 'test' && !allowGeneratedExerciseQueries) ||
+        resolvedItems !== undefined,
+    }
   );
 
   const items: GeneratedTranslationItem[] = useMemo(() => {

--- a/src/components/ui/exercises/generated-translation-exercise.tsx
+++ b/src/components/ui/exercises/generated-translation-exercise.tsx
@@ -9,14 +9,12 @@ import { ExerciseInput, FeedbackDisplay } from '../feedback';
 import { ExerciseProgress } from './exercise-progress';
 import AudioPlayButton from '@/src/components/ui/core/audio-play-button';
 import { SimpleRichDisplay } from '../core/simple-rich-display';
-import { useGetMultiPosWordsQuery } from '@/src/store/api/advancedVocabularyApi';
+import { useGetGeneratedExerciseWordsQuery } from '@/src/store/api/advancedVocabularyApi';
 import { Card, CardContent } from '../card';
-import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-responses';
 import {
   validateGeneratedTranslationExercise,
   type GeneratedTranslationItem,
 } from '@/src/utils/exercises/generatedTranslationExercise';
-import { normalizeCollection, buildLegacyPosConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
 import type { ExerciseAnswer, ExerciseAnswerHandler, RuntimeMode } from '@/src/types/runtime-mode';
 import { getContentTypeLabel } from '@/src/lib/content/registry';
 import { createGeneratedTranslationItems } from '@/src/lib/tests/generated-exercises';
@@ -46,32 +44,13 @@ const GeneratedTranslationExerciseComponent: React.FC<Props> = ({
   const assessmentMode = mode !== 'practice';
   const testAnswerMode = mode === 'test';
 
-  const config = exercise.data.generatorConfig ?? {
-    collection: '',
-    wordSource: 'filters' as const,
-    count: 0,
-  };
   const translationDirection = exercise.translationDirection || 'latin-to-english';
-  // Backward compat: old exercises stored filters/formSelection in generatorConfig
-  // with no posConfigs, wordSource, or poolId
-  const hasNewFormatPosConfigs =
-    exercise.data.posConfigs &&
-    typeof exercise.data.posConfigs === 'object' &&
-    Object.keys(exercise.data.posConfigs).length > 0;
 
-  const posConfigs = hasNewFormatPosConfigs
-    ? exercise.data.posConfigs
-    : buildLegacyPosConfigs(config as Parameters<typeof buildLegacyPosConfigs>[0]);
-
-  const { data, isLoading, isError } = useGetMultiPosWordsQuery(
+  const { data, isLoading, isError } = useGetGeneratedExerciseWordsQuery(
     {
-      exerciseType: 'generated-translation',
-      collection: normalizeCollection(config.collection),
-      wordSource: config.wordSource || 'filters',
-      poolId: config.poolId ?? null,
-      poolWordLimit: config.poolWordLimit ?? null,
-      count: config.count,
-      posConfigs,
+      type: 'generated-translation',
+      translationDirection,
+      data: exercise.data,
     },
     { skip: (mode === 'test' && !allowGeneratedExerciseQueries) || resolvedItems !== undefined }
   );
@@ -79,7 +58,7 @@ const GeneratedTranslationExerciseComponent: React.FC<Props> = ({
   const items: GeneratedTranslationItem[] = useMemo(() => {
     if (resolvedItems) return resolvedItems;
     if (!data?.words) return [];
-    return createGeneratedTranslationItems(exercise, data.words as unknown as ExerciseWordResponse[]);
+    return createGeneratedTranslationItems(exercise, data.words);
   }, [data, exercise, resolvedItems]);
   const restoredAnswers = initialAnswer?.type === 'generated-translation' ? initialAnswer.answers : [];
   const firstIncompleteIndex = items.findIndex((_, index) => !restoredAnswers[index]?.trim());

--- a/src/components/ui/lesson/content-renderer.tsx
+++ b/src/components/ui/lesson/content-renderer.tsx
@@ -50,10 +50,13 @@ import type {
   SingleFieldFormIdentificationItem,
 } from '@/src/types/exercises/schemas/form-identification';
 import type { VocabularyPoolStudyData } from '@/src/types/vocabulary';
+import type { GeneratedExerciseQuerySource } from '@/src/store/api/advancedVocabularyApi';
 
 export interface ResolvedGeneratedExerciseState {
   items: unknown[];
 }
+
+export type GeneratedExerciseRenderContext = { kind: 'admin-preview' } | { kind: 'lesson'; lessonId: string };
 
 interface ContentRendererProps {
   content: ContentItem;
@@ -63,6 +66,7 @@ interface ContentRendererProps {
   initialAnswer?: ExerciseAnswer;
   resolvedExerciseState?: ResolvedGeneratedExerciseState;
   allowGeneratedExerciseQueries?: boolean;
+  generatedExerciseContext?: GeneratedExerciseRenderContext;
   vocabularyPoolId?: string | null;
   resolvedVocabularyPool?: VocabularyPoolStudyData;
   pageIndex?: number;
@@ -80,6 +84,7 @@ export const ContentRenderer: React.FC<ContentRendererProps> = ({
   initialAnswer,
   resolvedExerciseState,
   allowGeneratedExerciseQueries = false,
+  generatedExerciseContext,
   vocabularyPoolId,
   resolvedVocabularyPool,
   onDiagrammingAttempt,
@@ -93,6 +98,18 @@ export const ContentRenderer: React.FC<ContentRendererProps> = ({
     ? answer => onAnswer({ exerciseId: content.id, answer, pageIndex, itemIndex })
     : undefined;
   const modeProps = { runtimeMode: mode, onAnswer: handleAnswer, initialAnswer };
+  const generatedExerciseSource: GeneratedExerciseQuerySource | undefined =
+    generatedExerciseContext?.kind === 'lesson' && pageIndex !== undefined && itemIndex !== undefined
+      ? {
+          kind: 'lesson',
+          lessonId: generatedExerciseContext.lessonId,
+          pageIndex,
+          itemIndex,
+          exerciseId: content.id,
+        }
+      : generatedExerciseContext?.kind === 'admin-preview' || allowGeneratedExerciseQueries
+        ? { kind: 'admin-preview' }
+        : undefined;
 
   switch (renderedContent.type) {
     case 'text':
@@ -203,6 +220,7 @@ export const ContentRenderer: React.FC<ContentRendererProps> = ({
           onComplete={onComplete}
           {...modeProps}
           allowGeneratedExerciseQueries={allowGeneratedExerciseQueries}
+          generatedExerciseSource={generatedExerciseSource}
           resolvedItems={resolvedExerciseState?.items as GeneratedTranslationItem[] | undefined}
         />
       );
@@ -214,6 +232,7 @@ export const ContentRenderer: React.FC<ContentRendererProps> = ({
           onComplete={onComplete}
           {...modeProps}
           allowGeneratedExerciseQueries={allowGeneratedExerciseQueries}
+          generatedExerciseSource={generatedExerciseSource}
           resolvedItems={
             resolvedExerciseState?.items as
               | Array<FormIdentificationItem | MultiAnswerFormIdentificationItem | SingleFieldFormIdentificationItem>

--- a/src/components/ui/lesson/lesson-player.tsx
+++ b/src/components/ui/lesson/lesson-player.tsx
@@ -22,7 +22,7 @@ import { DiagramAuditSubmission } from '@/src/features/sentence-diagramming';
 import { RequiredExercise } from '@/src/utils/lessonProgress';
 import { stripHtmlTags } from '@/src/utils/exercises';
 import type { ExerciseAnswerEvent, RuntimeMode } from '@/src/types/runtime-mode';
-import type { ResolvedGeneratedExerciseState } from './content-renderer';
+import type { GeneratedExerciseRenderContext, ResolvedGeneratedExerciseState } from './content-renderer';
 
 interface LessonPlayerProps {
   lesson: LessonWithProgress;
@@ -32,6 +32,7 @@ interface LessonPlayerProps {
   onAnswer?: (event: ExerciseAnswerEvent) => void;
   resolvedExerciseState?: Record<string, ResolvedGeneratedExerciseState>;
   testAttemptId?: string;
+  generatedExerciseContext?: GeneratedExerciseRenderContext;
 }
 
 export const LessonPlayer: React.FC<LessonPlayerProps> = ({
@@ -42,6 +43,7 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
   onAnswer,
   resolvedExerciseState,
   testAttemptId,
+  generatedExerciseContext,
 }) => {
   // Lesson previews should preserve the normal student feedback experience.
   // `trackProgress` controls persistence independently; assessment callers pass
@@ -61,6 +63,7 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
 
   const currentPage = lesson.pages[currentPageIndex];
   const totalPages = lesson.pages.length;
+  const resolvedGeneratedExerciseContext = generatedExerciseContext ?? { kind: 'lesson' as const, lessonId: lesson.id };
 
   useEffect(() => {
     if (!shouldTrackProgress || !user?.uid || !currentPage?.id || lastVisitedPageId.current === currentPage.id) return;
@@ -209,6 +212,7 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
                 runtimeMode={effectiveRuntimeMode}
                 onAnswer={onAnswer}
                 resolvedExerciseState={resolvedExerciseState}
+                generatedExerciseContext={resolvedGeneratedExerciseContext}
                 onExerciseComplete={handleExerciseComplete}
                 onPageComplete={handlePageComplete}
                 onDiagrammingAttempt={handleDiagrammingAttempt}

--- a/src/components/ui/lesson/page-template.tsx
+++ b/src/components/ui/lesson/page-template.tsx
@@ -9,7 +9,7 @@ import { SimpleRichDisplay } from '../core/simple-rich-display';
 import { isExerciseType } from '@/src/utils/lessonUtils';
 import { DiagramAuditSubmission } from '@/src/features/sentence-diagramming';
 import type { ExerciseAnswer, ExerciseAnswerEvent, RuntimeMode } from '@/src/types/runtime-mode';
-import type { ResolvedGeneratedExerciseState } from './content-renderer';
+import type { GeneratedExerciseRenderContext, ResolvedGeneratedExerciseState } from './content-renderer';
 import type { VocabularyPoolStudyData } from '@/src/types/vocabulary';
 
 interface PageTemplateProps {
@@ -21,6 +21,7 @@ interface PageTemplateProps {
   answers?: Record<string, ExerciseAnswer>;
   resolvedExerciseState?: Record<string, ResolvedGeneratedExerciseState>;
   allowGeneratedExerciseQueries?: boolean;
+  generatedExerciseContext?: GeneratedExerciseRenderContext;
   vocabularyPoolId?: string | null;
   resolvedVocabularyPool?: VocabularyPoolStudyData;
   onPageComplete?: () => void;
@@ -36,6 +37,7 @@ export const PageTemplate: React.FC<PageTemplateProps> = ({
   answers,
   resolvedExerciseState,
   allowGeneratedExerciseQueries = false,
+  generatedExerciseContext,
   vocabularyPoolId,
   resolvedVocabularyPool,
   onPageComplete,
@@ -101,6 +103,7 @@ export const PageTemplate: React.FC<PageTemplateProps> = ({
               initialAnswer={answers?.[item.id]}
               resolvedExerciseState={resolvedExerciseState?.[item.id]}
               allowGeneratedExerciseQueries={allowGeneratedExerciseQueries}
+              generatedExerciseContext={generatedExerciseContext}
               vocabularyPoolId={vocabularyPoolId}
               resolvedVocabularyPool={resolvedVocabularyPool}
               onComplete={(score: number) => handleItemComplete(index, score)}

--- a/src/config/generatedExerciseLimits.ts
+++ b/src/config/generatedExerciseLimits.ts
@@ -1,0 +1,9 @@
+/**
+ * Product ceiling for generated-exercise `count` (usable source words).
+ * Chosen at/above the existing generated-words API page ceiling (200) and
+ * typical authored values (default 5). `count: 'all'` is not subject to this cap.
+ */
+export const MAX_GENERATED_WORD_COUNT = 200;
+
+/** Firestore `in` operand ceiling; comma-separated filter lists must stay within it. */
+export const MAX_GENERATED_FILTER_OPERANDS = 30;

--- a/src/hooks/useFormIdentificationEditor.ts
+++ b/src/hooks/useFormIdentificationEditor.ts
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { skipToken } from '@reduxjs/toolkit/query';
+import { useCallback, useEffect, useMemo } from 'react';
 import { produce } from 'immer';
 import { useAppDispatch } from '@/src/store/hooks';
 import { updateEditingContent } from '@/src/store/slices/lessonEditorSlice';
-import { useGetMultiParadigmWordsQuery } from '@/src/store/api/advancedVocabularyApi';
 import { useAvailableParadigms } from '@/src/hooks/useAvailableParadigms';
 import { useFormSelectionControls } from '@/src/hooks/useFormSelection';
+import { useGeneratedExercisePreview } from '@/src/hooks/useGeneratedExercisePreview';
 import { ensureGeneratorConfig, DEFAULT_POS_FILTERS } from '@/src/utils/exercises/generatorConfigDefaults';
 import { PARADIGM_STEPS, PARADIGM_TABLE_TYPE, PARADIGM_RELEVANT_FILTERS } from '@/src/config/paradigmDefinitions';
 import { getParadigmPOS } from '@/src/utils/paradigm';
@@ -16,7 +15,6 @@ import { buildLegacyParadigmConfigs } from '@/src/utils/exercises/legacyExercise
 
 export function useFormIdentificationEditor(editingContent: GeneratedFormIdentificationExercise) {
   const dispatch = useAppDispatch();
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
   const rawConfig = editingContent.data?.generatorConfig;
   const config = useMemo(() => ensureGeneratorConfig(rawConfig), [rawConfig]);
@@ -65,19 +63,15 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
     return paradigmConfigs[activeParadigm]?.formSelection;
   }, [activeParadigm, paradigmConfigs]);
 
-  const previewResult = useGetMultiParadigmWordsQuery(
-    isPreviewOpen && Object.keys(paradigmConfigs).length > 0
-      ? {
-          exerciseType: 'generated-form-identification',
-          collection: config.collection,
-          wordSource: config.wordSource,
-          poolId: config.poolId,
-          poolWordLimit: config.poolWordLimit,
-          count: config.count,
-          paradigmConfigs,
-        }
-      : skipToken
+  const previewRequest = useMemo(
+    () => ({
+      type: 'generated-form-identification' as const,
+      data: editingContent.data,
+    }),
+    [editingContent.data]
   );
+  const { isPreviewOpen, setIsPreviewOpen, previewData, isPreviewFetching, previewError } =
+    useGeneratedExercisePreview(previewRequest);
 
   const updateContent = useCallback(
     (updates: Partial<GeneratedFormIdentificationExercise>) => {
@@ -232,7 +226,8 @@ export function useFormIdentificationEditor(editingContent: GeneratedFormIdentif
     handleToggleParadigm,
     handleGlobalFiltersChange,
     formSelectionControls,
-    previewData: previewResult.data,
-    isPreviewFetching: previewResult.isFetching,
+    previewData,
+    isPreviewFetching,
+    previewError,
   };
 }

--- a/src/hooks/useGeneratedExerciseEditor.ts
+++ b/src/hooks/useGeneratedExerciseEditor.ts
@@ -1,10 +1,13 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { skipToken } from '@reduxjs/toolkit/query';
+import { useCallback, useEffect, useMemo } from 'react';
 import { produce } from 'immer';
 import { useAppDispatch } from '@/src/store/hooks';
 import { updateEditingContent } from '@/src/store/slices/lessonEditorSlice';
-import { useGetMultiPosWordsQuery } from '@/src/store/api/advancedVocabularyApi';
+import type {
+  GeneratedExercisePreviewRequest,
+  GeneratedExercisePreviewResult,
+} from '@/src/store/api/advancedVocabularyApi';
 import { useFormSelectionControls } from '@/src/hooks/useFormSelection';
+import { useGeneratedExercisePreview } from '@/src/hooks/useGeneratedExercisePreview';
 import { usePoolPOSSummary } from '@/src/hooks/usePoolPOSSummary';
 import { ensureGeneratorConfig, DEFAULT_POS_FILTERS } from '@/src/utils/exercises/generatorConfigDefaults';
 import { deriveTableTypeFromPOS } from '@/src/utils/generated/tableType';
@@ -19,7 +22,8 @@ import type {
 import type { FormIdentificationPosConfig } from '@/src/types/exercises/base';
 import type { GeneratedExerciseType } from '@/src/config/exerciseSelectFields';
 import type { PartOfSpeech } from '@/shared/types/vocabulary/schemas/enums';
-import type { GetAdvancedWordsResponse } from '@/src/store/api/advancedVocabularyApi';
+import type { GeneratedFormIdentificationExercise } from '@/src/types/exercises/generated-form-identification';
+import type { GeneratedTranslationExercise } from '@/src/types/exercises/generated-translation';
 
 interface UseGeneratedExerciseEditorOptions {
   exerciseType: GeneratedExerciseType;
@@ -61,8 +65,9 @@ export interface UseGeneratedExerciseEditorReturn<T extends GeneratedExercise> {
     handleSelectAll: () => void;
     handleClearSelection: () => void;
   };
-  previewData: GetAdvancedWordsResponse['data'] | undefined;
+  previewData: GeneratedExercisePreviewResult | undefined;
   isPreviewFetching: boolean;
+  previewError: unknown;
 }
 
 export function useGeneratedExerciseEditor<T extends GeneratedExercise>(
@@ -70,7 +75,6 @@ export function useGeneratedExerciseEditor<T extends GeneratedExercise>(
   options: UseGeneratedExerciseEditorOptions
 ): UseGeneratedExerciseEditorReturn<T> {
   const dispatch = useAppDispatch();
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
   const rawConfig = editingContent.data?.generatorConfig;
   const config = useMemo(() => ensureGeneratorConfig(rawConfig), [rawConfig]);
@@ -112,22 +116,24 @@ export function useGeneratedExerciseEditor<T extends GeneratedExercise>(
     return editingContent.data.posConfigs?.[activePOS]?.formSelection;
   }, [activePOS, editingContent.data.posConfigs]);
 
-  const previewResult = useGetMultiPosWordsQuery(
-    isPreviewOpen && editingContent.data.posConfigs
-      ? {
-          exerciseType: options.exerciseType,
-          collection: config.collection,
-          wordSource: config.wordSource,
-          poolId: config.poolId,
-          poolWordLimit: config.poolWordLimit,
-          count: config.count,
-          posConfigs: editingContent.data.posConfigs,
-        }
-      : skipToken
-  );
-
-  const previewData = previewResult.data;
-  const isPreviewFetching = previewResult.isFetching;
+  const previewRequest = useMemo((): GeneratedExercisePreviewRequest => {
+    if (options.exerciseType === 'generated-form-identification') {
+      return {
+        type: 'generated-form-identification',
+        data: editingContent.data as GeneratedFormIdentificationExercise['data'],
+      };
+    }
+    return {
+      type: 'generated-translation',
+      translationDirection:
+        'translationDirection' in editingContent
+          ? (editingContent.translationDirection as GeneratedTranslationExercise['translationDirection'])
+          : undefined,
+      data: editingContent.data as GeneratedTranslationExercise['data'],
+    };
+  }, [editingContent, options.exerciseType]);
+  const { isPreviewOpen, setIsPreviewOpen, previewData, isPreviewFetching, previewError } =
+    useGeneratedExercisePreview(previewRequest);
 
   const updateContent = useCallback(
     (updates: Partial<T>) => {
@@ -359,5 +365,6 @@ export function useGeneratedExerciseEditor<T extends GeneratedExercise>(
     formSelectionControls,
     previewData,
     isPreviewFetching,
+    previewError,
   };
 }

--- a/src/hooks/useGeneratedExercisePreview.ts
+++ b/src/hooks/useGeneratedExercisePreview.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  usePreviewGeneratedExerciseMutation,
+  type GeneratedExercisePreviewRequest,
+} from '@/src/store/api/advancedVocabularyApi';
+import {
+  fingerprintGeneratedExercisePreviewRequest,
+  matchingGeneratedPreviewData,
+} from '@/src/utils/generated/generatedExercisePreview';
+
+export function useGeneratedExercisePreview(previewRequest: GeneratedExercisePreviewRequest) {
+  const [isPreviewOpen, setPreviewOpen] = useState(false);
+  const [previewGeneratedExercise, previewResult] = usePreviewGeneratedExerciseMutation();
+  const resetPreview = previewResult.reset;
+
+  const previewFingerprint = useMemo(
+    () => fingerprintGeneratedExercisePreviewRequest(previewRequest),
+    [previewRequest]
+  );
+  const previousPreviewFingerprint = useRef(previewFingerprint);
+
+  useEffect(() => {
+    if (previousPreviewFingerprint.current === previewFingerprint) return;
+    previousPreviewFingerprint.current = previewFingerprint;
+    setPreviewOpen(false);
+    resetPreview();
+  }, [previewFingerprint, resetPreview]);
+
+  const setIsPreviewOpen = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        setPreviewOpen(false);
+        resetPreview();
+        return;
+      }
+      setPreviewOpen(true);
+      void previewGeneratedExercise(previewRequest);
+    },
+    [previewGeneratedExercise, previewRequest, resetPreview]
+  );
+
+  const previewData = isPreviewOpen
+    ? matchingGeneratedPreviewData(previewFingerprint, previewResult.originalArgs, previewResult.data)
+    : undefined;
+
+  return {
+    isPreviewOpen,
+    setIsPreviewOpen,
+    previewData,
+    isPreviewFetching: isPreviewOpen && previewResult.isLoading,
+    previewError: isPreviewOpen ? previewResult.error : undefined,
+  };
+}

--- a/src/lib/tests/active-exercise-validation.ts
+++ b/src/lib/tests/active-exercise-validation.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { generatedWordCountSchema } from '@/src/lib/tests/generated-preview-schema';
 import { PARADIGM_AVAILABLE_STEPS } from '@/src/config/paradigmDefinitions';
 import { validateSentenceDiagramDocument } from '@/src/features/sentence-diagramming/validation';
 import type { SentenceDiagramDocument } from '@/src/features/sentence-diagramming/model';
@@ -147,7 +148,7 @@ const generatorConfigSchema = z
     wordSource: z.enum(['filters', 'pool']).default('filters'),
     poolId: z.string().trim().min(1).nullable().optional(),
     poolWordLimit: z.number().int().positive().nullable().optional(),
-    count: z.union([z.literal('all'), z.number().int().positive()]),
+    count: generatedWordCountSchema,
     filters: looseObjectSchema.optional(),
     formSelection: formSelectionSchema.optional(),
   })

--- a/src/lib/tests/generated-exercises.ts
+++ b/src/lib/tests/generated-exercises.ts
@@ -5,26 +5,20 @@ import type {
   MultiAnswerFormIdentificationItem,
   SingleFieldFormIdentificationItem,
 } from '@/src/types/exercises/schemas/form-identification';
-import type { PartOfSpeech, PronounPerson, PronounType } from '@/shared/types/vocabulary/schemas/enums';
-import { deriveParadigm } from '@/src/utils/paradigm';
 import { hasSelectedForm, getExerciseDisplayForm } from '@/src/utils/exercises/formSelection';
-import { buildLegacyParadigmConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
 import {
   splitTranslationAnswers,
   type GeneratedTranslationItem,
 } from '@/src/utils/exercises/generatedTranslationExercise';
+import { prepareGeneratedFormIdentificationWord } from '@/src/utils/exercises/formIdentificationPreparation';
 import {
-  deduplicatePathsBySteps,
-  enrichPathsWithSteps,
   extractStepValue,
   extractStepValuesFromPaths,
   filterPathsByPreviousAnswers,
   formatPrimaryAnswersDisplay,
   getAcceptedAnswersForMultipleValues,
   getAcceptedAnswersForStep,
-  getAnswerableStepsForWord,
   getDisplayForm,
-  getFallbackAnswerableStepsForWord,
   getHintForStep,
 } from '@/src/utils/exercises/formIdentificationHelpers';
 
@@ -36,69 +30,17 @@ export type ResolvedFormIdentificationItem =
 
 export type GeneratedWordLoader = (exercise: GeneratedExercise) => Promise<ExerciseWordResponse[]>;
 
-const getPaths = (word: ExerciseWordResponse) => ({
-  primary: (word.primary_form_paths || (word.form_path ? [word.form_path] : [])) as Array<
-    Record<string, string | undefined>
-  >,
-  optional: (word.optional_form_paths || []) as Array<Record<string, string | undefined>>,
-});
-
-const getPreparedPaths = (exercise: GeneratedFormIdentificationExercise, word: ExerciseWordResponse) => {
-  const data = word as Record<string, unknown>;
-  const paradigm = deriveParadigm(
-    word.part_of_speech as PartOfSpeech,
-    data.pronoun_type as PronounType | undefined,
-    data.person as PronounPerson | undefined
-  );
-  const paradigmConfigs =
-    exercise.data.paradigmConfigs && Object.keys(exercise.data.paradigmConfigs).length > 0
-      ? exercise.data.paradigmConfigs
-      : buildLegacyParadigmConfigs(exercise.data.generatorConfig as Parameters<typeof buildLegacyParadigmConfigs>[0]);
-  const config = paradigm ? paradigmConfigs[paradigm] : undefined;
-  const paths = getPaths(word);
-  const configuredSteps = config?.steps || [];
-  let candidateSteps = getAnswerableStepsForWord(word, configuredSteps, paths.primary);
-  const preferredPath = (word.form_path || paths.primary[0]) as Record<string, string | undefined> | undefined;
-
-  // A selected path can be answerable even when a syncretic alternative in
-  // `primary_form_paths` cannot answer any of the same questions (for example
-  // a finite form and a gerund with the same spelling). Fall back to the
-  // selected interpretation and discard incompatible alternatives below.
-  if (candidateSteps.length === 0) {
-    candidateSteps = getFallbackAnswerableStepsForWord(word, configuredSteps, preferredPath);
+export function isUsableGeneratedTranslationWord(
+  exercise: GeneratedTranslationExercise,
+  word: ExerciseWordResponse
+): boolean {
+  const translations = splitTranslationAnswers(word.translation);
+  if (translations.length === 0) return false;
+  if (exercise.translationDirection === 'english-to-latin') {
+    return Boolean(word.root_word);
   }
-
-  let enrichedPrimary = enrichPathsWithSteps(paths.primary, word, candidateSteps);
-  const steps = candidateSteps.filter(
-    step => enrichedPrimary.length > 0 && enrichedPrimary.some(path => Boolean(path[step]))
-  );
-
-  if (steps.length > 0) {
-    enrichedPrimary = enrichedPrimary.filter(path => steps.every(step => Boolean(path[step])));
-  }
-
-  // Older responses may omit `primary_form_paths` while still carrying the
-  // selected `form_path`; preserve that selected path as the answer key.
-  if (enrichedPrimary.length === 0 && preferredPath && steps.length > 0) {
-    enrichedPrimary = enrichPathsWithSteps([preferredPath], word, steps).filter(path =>
-      steps.every(step => Boolean(path[step]))
-    );
-  }
-
-  if (steps.length === 0) {
-    return { steps, primary: [], optional: [] };
-  }
-
-  const enrichedOptional = enrichPathsWithSteps(paths.optional, word, steps).filter(path =>
-    steps.every(step => Boolean(path[step]))
-  );
-
-  return {
-    steps,
-    primary: deduplicatePathsBySteps(enrichedPrimary, steps),
-    optional: deduplicatePathsBySteps(enrichedOptional, steps),
-  };
-};
+  return getExerciseDisplayForm(word).trim().length > 0;
+}
 
 export function createGeneratedTranslationItems(
   exercise: GeneratedTranslationExercise,
@@ -107,11 +49,11 @@ export function createGeneratedTranslationItems(
   const direction = exercise.translationDirection || 'latin-to-english';
 
   return words.flatMap<GeneratedTranslationItem>(word => {
+    if (!isUsableGeneratedTranslationWord(exercise, word)) return [];
     const translations = splitTranslationAnswers(word.translation);
     const hint = word.definitions?.length ? word.definitions.join(', ') : undefined;
 
     if (direction === 'english-to-latin') {
-      if (translations.length === 0 || !word.root_word) return [];
       return [
         {
           text: translations.join(', '),
@@ -123,7 +65,6 @@ export function createGeneratedTranslationItems(
       ];
     }
 
-    if (translations.length === 0) return [];
     return [{ text: getExerciseDisplayForm(word), acceptedAnswers: translations, hint, stripInfinitive: true }];
   });
 }
@@ -137,8 +78,8 @@ export function createGeneratedFormIdentificationItems(
 
   if (exercise.data.mode === 'single-field') {
     return usableWords.flatMap<SingleFieldFormIdentificationItem>(word => {
-      const paths = getPreparedPaths(exercise, word);
-      if (paths.steps.length === 0 || paths.primary.length === 0) return [];
+      const paths = prepareGeneratedFormIdentificationWord(exercise, word);
+      if (!paths) return [];
 
       const correctAnswerDisplay = paths.primary
         .map(path => paths.steps.map(step => (path[step] ? getDisplayForm(path[step]!) : '')).join(','))
@@ -166,7 +107,8 @@ export function createGeneratedFormIdentificationItems(
 
   if (exercise.data.requireAllPrimaryAnswers) {
     return usableWords.flatMap(word => {
-      const paths = getPreparedPaths(exercise, word);
+      const paths = prepareGeneratedFormIdentificationWord(exercise, word);
+      if (!paths) return [];
       return paths.steps.map((step, stepIndex) => ({
         id: `${word.id}-${step}`,
         wordId: word.id,
@@ -192,7 +134,8 @@ export function createGeneratedFormIdentificationItems(
   }
 
   return usableWords.flatMap(word => {
-    const paths = getPreparedPaths(exercise, word);
+    const paths = prepareGeneratedFormIdentificationWord(exercise, word);
+    if (!paths) return [];
     const answered = previousAnswers[word.id] || {};
 
     return paths.steps.map(step => {

--- a/src/lib/tests/generated-preview-schema.ts
+++ b/src/lib/tests/generated-preview-schema.ts
@@ -12,6 +12,7 @@ import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-respons
 import type { GeneratedFormIdentificationExercise } from '@/src/types/exercises/generated-form-identification';
 import type { GeneratedTranslationExercise } from '@/src/types/exercises/generated-translation';
 import { FormIdentificationStepSchema } from '@/src/types/exercises/schemas/form-identification';
+import { firestoreDocumentIdSchema } from '@/src/lib/learning-units/schemas';
 
 export const generatedWordCountSchema = z.union([
   z.literal('all'),
@@ -123,6 +124,15 @@ export const GeneratedExercisePreviewRequestSchema = z.discriminatedUnion('type'
     .passthrough(),
 ]);
 
+export const GeneratedExercisePlaybackRequestSchema = z
+  .object({
+    lessonId: firestoreDocumentIdSchema,
+    pageIndex: z.number().int().nonnegative(),
+    itemIndex: z.number().int().nonnegative(),
+    exerciseId: firestoreDocumentIdSchema,
+  })
+  .strict();
+
 export type GeneratedExercisePreviewRequest =
   | Pick<GeneratedFormIdentificationExercise, 'type' | 'data'>
   | {
@@ -130,6 +140,8 @@ export type GeneratedExercisePreviewRequest =
       translationDirection?: GeneratedTranslationExercise['translationDirection'];
       data: GeneratedTranslationExercise['data'];
     };
+
+export type GeneratedExercisePlaybackRequest = z.infer<typeof GeneratedExercisePlaybackRequestSchema>;
 
 export type GeneratedExercisePreviewDiagnostics = {
   specId: string;

--- a/src/lib/tests/generated-preview-schema.ts
+++ b/src/lib/tests/generated-preview-schema.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod';
+import {
+  AdjectiveDeclensionSchema,
+  NounDeclensionSchema,
+  PartOfSpeechSchema,
+  PronounPersonSchema,
+  PronounTypeSchema,
+  VerbConjugationSchema,
+} from '@/shared/types/vocabulary/schemas/enums';
+import { MAX_GENERATED_FILTER_OPERANDS, MAX_GENERATED_WORD_COUNT } from '@/src/config/generatedExerciseLimits';
+import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-responses';
+import type { GeneratedFormIdentificationExercise } from '@/src/types/exercises/generated-form-identification';
+import type { GeneratedTranslationExercise } from '@/src/types/exercises/generated-translation';
+import { FormIdentificationStepSchema } from '@/src/types/exercises/schemas/form-identification';
+
+export const generatedWordCountSchema = z.union([
+  z.literal('all'),
+  z.number().int().positive().max(MAX_GENERATED_WORD_COUNT),
+]);
+
+const formSelectionSchema = z
+  .object({
+    tableType: z.string().trim().min(1),
+    selectedCellPaths: z.array(z.string()).default([]),
+  })
+  .optional();
+
+function commaSeparatedEnumSchema(allowed: readonly string[]) {
+  const allowedValues = new Set(allowed);
+  return z.string().superRefine((value, ctx) => {
+    if (!value || value === 'all') return;
+    const parts = value
+      .split(',')
+      .map(part => part.trim())
+      .filter(Boolean);
+    if (parts.length === 0) {
+      ctx.addIssue({ code: 'custom', message: 'Filter value cannot be blank' });
+      return;
+    }
+    if (parts.length > MAX_GENERATED_FILTER_OPERANDS) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Filter cannot include more than ${MAX_GENERATED_FILTER_OPERANDS} values`,
+      });
+      return;
+    }
+    for (const part of parts) {
+      if (!allowedValues.has(part)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Invalid filter value: ${part}`,
+        });
+      }
+    }
+  });
+}
+
+export const generatedPreviewFiltersSchema = z.object({
+  partOfSpeech: z.union([z.literal('all'), PartOfSpeechSchema]).optional(),
+  search: z.string().max(200).optional(),
+  verbConjugation: commaSeparatedEnumSchema(VerbConjugationSchema.options).optional(),
+  isDeponent: z.enum(['true', 'false', 'both', 'all']).optional(),
+  nounDeclension: commaSeparatedEnumSchema(NounDeclensionSchema.options).optional(),
+  adjectiveDeclension: commaSeparatedEnumSchema(AdjectiveDeclensionSchema.options).optional(),
+  pronounType: commaSeparatedEnumSchema(PronounTypeSchema.options).optional(),
+  pronounPerson: commaSeparatedEnumSchema(PronounPersonSchema.options).optional(),
+});
+
+export const generatedPreviewGeneratorConfigSchema = z
+  .object({
+    collection: z.string().optional(),
+    wordSource: z.enum(['filters', 'pool']).default('filters'),
+    poolId: z.string().trim().min(1).nullable().optional(),
+    poolWordLimit: z.number().int().positive().nullable().optional(),
+    count: generatedWordCountSchema,
+    filters: generatedPreviewFiltersSchema.optional(),
+    formSelection: formSelectionSchema,
+  })
+  .passthrough();
+
+const generatedPreviewPosConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    filters: generatedPreviewFiltersSchema.default({}),
+    formSelection: formSelectionSchema,
+  })
+  .passthrough();
+
+const generatedPreviewParadigmConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    steps: z.array(FormIdentificationStepSchema).default([]),
+    filters: generatedPreviewFiltersSchema.default({}),
+    formSelection: formSelectionSchema,
+  })
+  .passthrough();
+
+export const GeneratedExercisePreviewRequestSchema = z.discriminatedUnion('type', [
+  z
+    .object({
+      type: z.literal('generated-form-identification'),
+      data: z
+        .object({
+          mode: z.enum(['step-by-step', 'single-field']).default('step-by-step'),
+          requireAllPrimaryAnswers: z.boolean().optional(),
+          generatorConfig: generatedPreviewGeneratorConfigSchema,
+          paradigmConfigs: z.record(z.string(), generatedPreviewParadigmConfigSchema).default({}),
+        })
+        .passthrough(),
+    })
+    .passthrough(),
+  z
+    .object({
+      type: z.literal('generated-translation'),
+      translationDirection: z.enum(['latin-to-english', 'english-to-latin']).optional(),
+      data: z
+        .object({
+          generatorConfig: generatedPreviewGeneratorConfigSchema,
+          posConfigs: z.record(z.string(), generatedPreviewPosConfigSchema).default({}),
+        })
+        .passthrough(),
+    })
+    .passthrough(),
+]);
+
+export type GeneratedExercisePreviewRequest =
+  | Pick<GeneratedFormIdentificationExercise, 'type' | 'data'>
+  | {
+      type: 'generated-translation';
+      translationDirection?: GeneratedTranslationExercise['translationDirection'];
+      data: GeneratedTranslationExercise['data'];
+    };
+
+export type GeneratedExercisePreviewDiagnostics = {
+  specId: string;
+  collected: number;
+  scanned: number;
+  exhausted: boolean;
+  scanLimitReached: boolean;
+};
+
+export type GeneratedExercisePreviewResult = {
+  words: ExerciseWordResponse[];
+  diagnostics: GeneratedExercisePreviewDiagnostics[];
+  requestedCount: number | 'all';
+  collected: number;
+  globalScanLimitReached: boolean;
+};

--- a/src/lib/tests/generated-word-composition.server.ts
+++ b/src/lib/tests/generated-word-composition.server.ts
@@ -1,0 +1,644 @@
+import type { Firestore, Query, QueryDocumentSnapshot } from 'firebase-admin/firestore';
+import { MAX_GENERATED_FILTER_OPERANDS, MAX_GENERATED_WORD_COUNT } from '@/src/config/generatedExerciseLimits';
+import { getReadableVocabularyPool, loadVocabularyPoolWords } from '@/src/lib/vocabulary-pools/archive.server';
+import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-responses';
+import type { FormSelection, GeneratorFilters } from '@/src/types/exercises/base';
+import type { FormParadigm, ParadigmConfigs } from '@/src/types/exercises/paradigm';
+import type { FormIdentificationStep } from '@/src/types/exercises/schemas/form-identification';
+import { parseFormPathFromString } from '@/src/utils/exerciseFormPaths';
+import { TABLE_TYPE_CONFIG, type TableType } from '@/src/utils/schema-helpers';
+import { categorizeMatchingPaths, scanTableForMatchingForms } from '@/src/utils/tableScanner';
+import { stripMacrons } from '@/src/utils/exercises/helpers';
+import { getApplicableStepsForFormPath } from '@/src/utils/exercises/formIdentificationCompatibility';
+import { getExerciseDisplayForm } from '@/src/utils/exercises/formSelection';
+import { prepareGeneratedFormIdentificationWord } from '@/src/utils/exercises/formIdentificationPreparation';
+import { isRejectedBySpecAwarePronounOverlap } from '@/src/utils/generated/pronounParadigmFiltering';
+import type { GeneratedExercisePreviewDiagnostics } from './generated-preview-schema';
+import {
+  isUsableGeneratedTranslationWord,
+  type GeneratedExercise,
+} from './generated-exercises';
+
+export const PER_SPEC_SCAN_FLOOR = 400;
+const BASE_GLOBAL_SCAN = 2000;
+const SCAN_MULTIPLIER = 2;
+const PER_SPEC_SCAN_MULTIPLIER = 40;
+const MIN_ADAPTIVE_BATCH = 4;
+const MAX_ADAPTIVE_BATCH = 100;
+const POOL_STREAM_CHUNK = 50;
+
+export interface WordQuerySpec {
+  id: string;
+  partOfSpeech?: string;
+  filters: Omit<GeneratorFilters, 'partOfSpeech'>;
+  formSelection?: FormSelection;
+  tableType?: TableType;
+  steps?: FormIdentificationStep[];
+  paradigm?: FormParadigm;
+}
+
+export interface CollectGeneratedExerciseWordsResult {
+  words: ExerciseWordResponse[];
+  diagnostics: GeneratedExercisePreviewDiagnostics[];
+  globalScanLimitReached: boolean;
+  requestedCount: number | 'all';
+}
+
+export class GeneratedVocabularySourceError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(message: string, status = 400, code = 'GENERATED_SOURCE_INVALID') {
+    super(message);
+    this.name = 'GeneratedVocabularySourceError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export const applyValueFilter = (query: Query, field: string, value?: unknown): Query => {
+  if (typeof value !== 'string' || !value || value === 'all' || value === 'both') return query;
+  const values = value
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean)
+    .slice(0, MAX_GENERATED_FILTER_OPERANDS);
+  if (values.length === 0) return query;
+  return values.length === 1 ? query.where(field, '==', values[0]) : query.where(field, 'in', values);
+};
+
+function applyFilters(query: Query, spec: WordQuerySpec): Query {
+  const filters = spec.filters;
+  if (spec.partOfSpeech) query = query.where('part_of_speech', '==', spec.partOfSpeech);
+
+  if (spec.partOfSpeech === 'verb') {
+    query = applyValueFilter(query, 'conjugation', filters.verbConjugation);
+    if (filters.isDeponent === 'true') query = query.where('is_deponent', '==', true);
+    if (filters.isDeponent === 'false') query = query.where('is_deponent', '==', false);
+  } else if (spec.partOfSpeech === 'noun') {
+    query = applyValueFilter(query, 'declension', filters.nounDeclension);
+  } else if (spec.partOfSpeech === 'adjective') {
+    query = applyValueFilter(query, 'declension', filters.adjectiveDeclension);
+  } else if (spec.partOfSpeech === 'pronoun') {
+    query = applyValueFilter(query, 'pronoun_type', filters.pronounType);
+    query = applyValueFilter(query, 'person', filters.pronounPerson);
+  }
+
+  return query;
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function createGeneratedExerciseRng(seed: number): () => number {
+  return mulberry32(seed >>> 0);
+}
+
+const deriveSubstream = (rng: () => number): (() => number) => mulberry32(Math.floor(rng() * 0xffffffff));
+
+const shuffleWithRng = <T>(values: T[], rng: () => number): T[] => {
+  const result = [...values];
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const other = Math.floor(rng() * (index + 1));
+    [result[index], result[other]] = [result[other], result[index]];
+  }
+  return result;
+};
+
+export function allocateFairShares(specCount: number, count: number, rng: () => number): number[] {
+  if (specCount <= 0) return [];
+  const order = shuffleWithRng(
+    Array.from({ length: specCount }, (_, index) => index),
+    rng
+  );
+  const base = Math.floor(count / specCount);
+  const remainder = count % specCount;
+  const shares = Array.from({ length: specCount }, () => base);
+  for (let index = 0; index < remainder; index += 1) {
+    shares[order[index]] += 1;
+  }
+  return shares;
+}
+
+export function perSpecScanCeiling(share: number): number {
+  return Math.max(PER_SPEC_SCAN_FLOOR, PER_SPEC_SCAN_MULTIPLIER * Math.max(share, 1));
+}
+
+function globalScanBudget(count: number): number {
+  return Math.max(BASE_GLOBAL_SCAN, SCAN_MULTIPLIER * count);
+}
+
+function adaptiveBatchSize(remainingShare: number, isFirstBatch: boolean, deficit: number): number {
+  if (isFirstBatch) return Math.max(1, remainingShare);
+  return Math.min(MAX_ADAPTIVE_BATCH, Math.max(MIN_ADAPTIVE_BATCH, 2 * deficit));
+}
+
+const getPathValues = (value: Record<string, unknown>, path: string): string[] => {
+  let current: unknown = value;
+  for (const key of path.split('.')) {
+    if (!current || typeof current !== 'object' || !(key in current)) return [];
+    current = (current as Record<string, unknown>)[key];
+  }
+  if (typeof current === 'string') return [current];
+  return Array.isArray(current) ? current.filter((entry): entry is string => typeof entry === 'string') : [];
+};
+
+function selectForm(
+  word: Record<string, unknown>,
+  tableType: TableType,
+  selectedPaths: string[],
+  formRng: () => number,
+  steps?: readonly FormIdentificationStep[]
+) {
+  const tableField = TABLE_TYPE_CONFIG[tableType];
+  const table = word[tableField];
+  if (!table) return null;
+
+  const compatiblePaths =
+    steps && tableType
+      ? selectedPaths.filter(
+          path => (getApplicableStepsForFormPath(path, tableType, steps)?.applicableSteps.length ?? 0) > 0
+        )
+      : selectedPaths;
+  const candidates = compatiblePaths.flatMap(path =>
+    getPathValues(word, `${tableField}.${path}`).map(form => ({ form, path }))
+  );
+  if (!candidates.length) return null;
+
+  const selected = candidates[Math.floor(formRng() * candidates.length)];
+  const matchingPaths = scanTableForMatchingForms(table, selected.form, tableType);
+  const paths = categorizeMatchingPaths(matchingPaths, compatiblePaths);
+  if (!paths.primaryPaths.includes(selected.path)) paths.primaryPaths.unshift(selected.path);
+  return { selected, ...paths };
+}
+
+function mapWord(
+  doc: QueryDocumentSnapshot,
+  spec: WordQuerySpec,
+  formRng: () => number
+): ExerciseWordResponse | null {
+  const data = doc.data() as Record<string, unknown>;
+  const selectedPaths = spec.formSelection?.selectedCellPaths || [];
+  const selection =
+    spec.tableType && selectedPaths.length
+      ? selectForm(data, spec.tableType, selectedPaths, formRng, spec.steps)
+      : null;
+  if (selectedPaths.length && !selection) return null;
+
+  const parsedTableType = spec.tableType;
+  const formPath =
+    selection && parsedTableType ? parseFormPathFromString(selection.selected.path, parsedTableType) : null;
+  const primary =
+    selection && parsedTableType
+      ? selection.primaryPaths.map(path => parseFormPathFromString(path, parsedTableType)).filter(Boolean)
+      : undefined;
+  const optional =
+    selection && parsedTableType
+      ? selection.optionalPaths.map(path => parseFormPathFromString(path, parsedTableType)).filter(Boolean)
+      : undefined;
+
+  return {
+    id: doc.id,
+    root_word: String(data.word || ''),
+    dictionary_entry: typeof data.dictionary_entry === 'string' ? data.dictionary_entry : null,
+    selected_form: selection?.selected.form || String(data.word || ''),
+    part_of_speech: data.part_of_speech,
+    form_path: formPath,
+    primary_form_paths: primary?.length ? primary : undefined,
+    optional_form_paths: optional?.length ? optional : undefined,
+    ...(typeof data.conjugation === 'string' ? { conjugation: data.conjugation } : {}),
+    ...(typeof data.declension === 'string' ? { declension: data.declension } : {}),
+    ...(Array.isArray(data.definitions)
+      ? { definitions: data.definitions.filter(value => typeof value === 'string') }
+      : {}),
+    ...(typeof data.is_deponent === 'boolean' ? { is_deponent: data.is_deponent } : {}),
+    ...(typeof data.translation === 'string' ? { translation: data.translation } : {}),
+    ...(typeof data.gender === 'string' ? { gender: data.gender } : {}),
+    ...(typeof data.pronoun_type === 'string' ? { pronoun_type: data.pronoun_type } : {}),
+    ...(typeof data.person === 'string' || data.person === null ? { person: data.person } : {}),
+  } as ExerciseWordResponse;
+}
+
+function evaluateCandidate(
+  doc: QueryDocumentSnapshot,
+  spec: WordQuerySpec,
+  exercise: GeneratedExercise,
+  formRng: () => number,
+  paradigmConfigs: ParadigmConfigs
+): ExerciseWordResponse | null {
+  const word = mapWord(doc, spec, formRng);
+  if (!word) return null;
+  if (isRejectedBySpecAwarePronounOverlap(word, spec.paradigm, paradigmConfigs)) return null;
+  if (exercise.type === 'generated-form-identification') {
+    if (getExerciseDisplayForm(word).trim().length === 0) return null;
+    if (!prepareGeneratedFormIdentificationWord(exercise, word)) return null;
+    return word;
+  }
+  return isUsableGeneratedTranslationWord(exercise, word) ? word : null;
+}
+
+interface CandidateStream {
+  readonly spec: WordQuerySpec;
+  readonly scanCeiling: number;
+  totalScanned: number;
+  exhausted: boolean;
+  scanLimitReached: boolean;
+  unread: QueryDocumentSnapshot[];
+  fetchedOnce: boolean;
+  nextBatch(limit: number): Promise<QueryDocumentSnapshot[]>;
+}
+
+const canStreamContinue = (stream: CandidateStream, globalBudgetRemaining: number) =>
+  !stream.exhausted && !stream.scanLimitReached && globalBudgetRemaining > 0;
+
+class QueryCandidateStream implements CandidateStream {
+  totalScanned = 0;
+  exhausted = false;
+  scanLimitReached = false;
+  unread: QueryDocumentSnapshot[] = [];
+  fetchedOnce = false;
+  private lastSnapshot: QueryDocumentSnapshot | null = null;
+  private wrapPhase: 'high' | 'low' | 'done' | null = null;
+  private threshold = 0;
+  private readonly seenIds = new Set<string>();
+  private initialized = false;
+
+  constructor(
+    readonly spec: WordQuerySpec,
+    readonly scanCeiling: number,
+    private readonly db: Firestore,
+    private readonly collection: string,
+    private readonly queryRng: () => number,
+    private readonly unbounded: boolean
+  ) {}
+
+  async nextBatch(limit: number): Promise<QueryDocumentSnapshot[]> {
+    if (this.exhausted || this.scanLimitReached || limit <= 0) return [];
+    const remainingCeiling = this.unbounded
+      ? limit
+      : Math.max(0, this.scanCeiling - this.totalScanned);
+    if (!this.unbounded && remainingCeiling <= 0) {
+      this.scanLimitReached = true;
+      return [];
+    }
+    const fetchLimit = Math.min(limit, remainingCeiling);
+    this.ensureInitialized();
+    if (this.spec.filters.search) return this.nextSearchBatch(fetchLimit);
+    if (this.unbounded) return this.nextUnboundedRandomBatch(fetchLimit);
+    return this.nextRandomBatch(fetchLimit);
+  }
+
+  private ensureInitialized() {
+    if (this.initialized) return;
+    this.initialized = true;
+    if (!this.spec.filters.search && !this.unbounded) {
+      this.threshold = this.queryRng();
+      this.wrapPhase = 'high';
+    }
+  }
+
+  private baseQuery(): Query {
+    return applyFilters(this.db.collection(this.collection), this.spec);
+  }
+
+  private async nextSearchBatch(limit: number): Promise<QueryDocumentSnapshot[]> {
+    const search = stripMacrons(this.spec.filters.search || '');
+    let query: Query = this.baseQuery()
+      .where('sort_key', '>=', search)
+      .where('sort_key', '<=', `${search}\uf8ff`)
+      .orderBy('sort_key');
+    if (this.lastSnapshot) query = query.startAfter(this.lastSnapshot);
+    query = query.limit(limit);
+    const snapshot = await query.get();
+    this.totalScanned += snapshot.docs.length;
+    if (!this.unbounded && this.totalScanned >= this.scanCeiling) this.scanLimitReached = true;
+    if (snapshot.docs.length > 0) this.lastSnapshot = snapshot.docs[snapshot.docs.length - 1];
+    if (snapshot.docs.length < limit) this.exhausted = true;
+    return this.dedupe(snapshot.docs);
+  }
+
+  private async nextUnboundedRandomBatch(limit: number): Promise<QueryDocumentSnapshot[]> {
+    let query: Query = this.baseQuery().orderBy('random_index');
+    if (this.lastSnapshot) query = query.startAfter(this.lastSnapshot);
+    query = query.limit(limit);
+    const snapshot = await query.get();
+    this.totalScanned += snapshot.docs.length;
+    if (snapshot.docs.length > 0) this.lastSnapshot = snapshot.docs[snapshot.docs.length - 1];
+    if (snapshot.docs.length < limit) this.exhausted = true;
+    return this.dedupe(snapshot.docs);
+  }
+
+  private async nextRandomBatch(limit: number): Promise<QueryDocumentSnapshot[]> {
+    const docs: QueryDocumentSnapshot[] = [];
+    let remaining = limit;
+    while (remaining > 0 && !this.exhausted && this.wrapPhase !== 'done') {
+      const phase = this.wrapPhase;
+      if (phase !== 'high' && phase !== 'low') break;
+
+      let query = this.baseQuery().orderBy('random_index');
+      query =
+        phase === 'high'
+          ? query.where('random_index', '>=', this.threshold)
+          : query.where('random_index', '<', this.threshold);
+      if (this.lastSnapshot) query = query.startAfter(this.lastSnapshot);
+
+      const snapshot = await query.limit(remaining).get();
+      this.totalScanned += snapshot.docs.length;
+      if (this.totalScanned >= this.scanCeiling) this.scanLimitReached = true;
+      docs.push(...snapshot.docs);
+      if (snapshot.docs.length > 0) this.lastSnapshot = snapshot.docs[snapshot.docs.length - 1];
+
+      if (snapshot.docs.length < remaining) {
+        this.advancePhase();
+        remaining = limit - docs.length;
+        if (this.scanLimitReached) break;
+        continue;
+      }
+      remaining = 0;
+    }
+    return this.dedupe(docs);
+  }
+
+  private advancePhase() {
+    if (this.wrapPhase === 'high') {
+      this.wrapPhase = 'low';
+      this.lastSnapshot = null;
+      return;
+    }
+    this.wrapPhase = 'done';
+    this.exhausted = true;
+  }
+
+  private dedupe(docs: QueryDocumentSnapshot[]): QueryDocumentSnapshot[] {
+    return docs.filter(doc => {
+      if (this.seenIds.has(doc.id)) return false;
+      this.seenIds.add(doc.id);
+      return true;
+    });
+  }
+}
+
+class PoolCandidateStream implements CandidateStream {
+  totalScanned = 0;
+  exhausted = false;
+  scanLimitReached = false;
+  unread: QueryDocumentSnapshot[] = [];
+  fetchedOnce = false;
+  private cursor = 0;
+  private readonly seenIds = new Set<string>();
+
+  constructor(
+    readonly spec: WordQuerySpec,
+    readonly scanCeiling: number,
+    private readonly ids: string[],
+    private readonly loadDocs: (ids: string[]) => Promise<QueryDocumentSnapshot[]>,
+    private readonly unbounded: boolean
+  ) {}
+
+  async nextBatch(limit: number): Promise<QueryDocumentSnapshot[]> {
+    if (this.exhausted || this.scanLimitReached || limit <= 0) return [];
+    if (!this.unbounded && this.totalScanned >= this.scanCeiling) {
+      this.scanLimitReached = true;
+      return [];
+    }
+
+    const docs: QueryDocumentSnapshot[] = [];
+    while (docs.length < limit && this.cursor < this.ids.length) {
+      const remainingScan = this.unbounded
+        ? POOL_STREAM_CHUNK
+        : Math.max(0, this.scanCeiling - this.totalScanned);
+      if (!this.unbounded && remainingScan <= 0) {
+        this.scanLimitReached = true;
+        break;
+      }
+      // Examine up to a chunk (or remaining ceiling), not only the remaining
+      // match quota — sparse POS still needs to scan mixed IDs to find hits.
+      const sliceSize = Math.min(POOL_STREAM_CHUNK, remainingScan);
+      if (sliceSize <= 0) break;
+
+      const slice = this.ids.slice(this.cursor, this.cursor + sliceSize);
+      this.cursor += slice.length;
+      const loaded = await this.loadDocs(slice);
+      this.totalScanned += loaded.length;
+      if (!this.unbounded && this.totalScanned >= this.scanCeiling) this.scanLimitReached = true;
+
+      for (const doc of loaded) {
+        if (this.seenIds.has(doc.id)) continue;
+        if (this.spec.partOfSpeech && doc.data().part_of_speech !== this.spec.partOfSpeech) continue;
+        this.seenIds.add(doc.id);
+        docs.push(doc);
+        if (docs.length >= limit) break;
+      }
+      if (this.scanLimitReached) break;
+    }
+    if (this.cursor >= this.ids.length) this.exhausted = true;
+    return docs;
+  }
+}
+
+function createSharedPoolLoader(pool: NonNullable<Awaited<ReturnType<typeof getReadableVocabularyPool>>>) {
+  const cache = new Map<string, QueryDocumentSnapshot | null>();
+  return async (ids: string[]): Promise<QueryDocumentSnapshot[]> => {
+    const missing = ids.filter(id => !cache.has(id));
+    if (missing.length > 0) {
+      const loaded = await loadVocabularyPoolWords(pool, missing);
+      const found = new Set(loaded.map(doc => doc.id));
+      loaded.forEach(doc => cache.set(doc.id, doc));
+      missing.filter(id => !found.has(id)).forEach(id => cache.set(id, null));
+    }
+    return ids
+      .map(id => cache.get(id))
+      .filter((doc): doc is QueryDocumentSnapshot => Boolean(doc));
+  };
+}
+
+async function takeEligible(
+  stream: CandidateStream,
+  target: number,
+  exercise: GeneratedExercise,
+  formRng: () => number,
+  paradigmConfigs: ParadigmConfigs,
+  budget: { remaining: number },
+  deficit: number,
+  unbounded: boolean
+): Promise<ExerciseWordResponse[]> {
+  const accepted: ExerciseWordResponse[] = [];
+  while (
+    accepted.length < target &&
+    (unbounded || budget.remaining > 0) &&
+    (stream.unread.length > 0 || canStreamContinue(stream, unbounded ? 1 : budget.remaining))
+  ) {
+    if (stream.unread.length === 0) {
+      const remaining = target - accepted.length;
+      const batchSize = unbounded
+        ? Math.min(MAX_ADAPTIVE_BATCH, Math.max(remaining, MIN_ADAPTIVE_BATCH))
+        : Math.min(adaptiveBatchSize(remaining, !stream.fetchedOnce, deficit), budget.remaining);
+      const docs = await stream.nextBatch(batchSize);
+      stream.fetchedOnce = true;
+      stream.unread.push(...docs);
+      if (docs.length === 0) break;
+    }
+    const doc = stream.unread.shift();
+    if (!doc) break;
+    if (!unbounded) {
+      if (budget.remaining <= 0) {
+        stream.unread.unshift(doc);
+        break;
+      }
+      budget.remaining -= 1;
+    }
+    const word = evaluateCandidate(doc, stream.spec, exercise, formRng, paradigmConfigs);
+    if (word) accepted.push(word);
+  }
+  return accepted;
+}
+
+export async function collectGeneratedExerciseWords(options: {
+  db: Firestore;
+  collection: string;
+  specs: WordQuerySpec[];
+  count: number | 'all';
+  exercise: GeneratedExercise;
+  poolId?: string | null;
+  poolWordLimit?: number | null;
+  rng?: () => number;
+  paradigmConfigs?: ParadigmConfigs;
+}): Promise<CollectGeneratedExerciseWordsResult> {
+  const rng = options.rng ?? Math.random;
+  const allocationRng = deriveSubstream(rng);
+  const poolRng = deriveSubstream(rng);
+  const queryRng = deriveSubstream(rng);
+  const formRng = deriveSubstream(rng);
+  const shuffleRng = deriveSubstream(rng);
+
+  const paradigmConfigs =
+    options.paradigmConfigs ??
+    (options.exercise.type === 'generated-form-identification' ? options.exercise.data.paradigmConfigs || {} : {});
+
+  let specs = options.specs;
+  if (specs.length === 0 && options.poolId) {
+    specs = [{ id: 'pool', filters: {} }];
+  }
+
+  let poolIds: string[] | null = null;
+  let loadPoolDocs: ((ids: string[]) => Promise<QueryDocumentSnapshot[]>) | null = null;
+  if (options.poolId) {
+    const pool = await getReadableVocabularyPool(options.db, options.poolId);
+    if (!pool) {
+      throw new GeneratedVocabularySourceError(`Vocabulary pool ${options.poolId} was not found`, 404, 'POOL_NOT_FOUND');
+    }
+    const wordIds = Array.isArray(pool.data.wordDocIds)
+      ? pool.data.wordDocIds.filter((id: unknown): id is string => typeof id === 'string' && Boolean(id))
+      : [];
+    const cap = options.poolWordLimit && options.poolWordLimit > 0 ? options.poolWordLimit : Infinity;
+    poolIds = shuffleWithRng(wordIds, poolRng).slice(0, Number.isFinite(cap) ? cap : wordIds.length);
+    loadPoolDocs = createSharedPoolLoader(pool);
+  }
+
+  let numericCount = 0;
+  let requestedCount: number | 'all' = 'all';
+  const unbounded = options.count === 'all';
+  if (options.count !== 'all') {
+    numericCount = Math.min(Math.max(1, options.count), MAX_GENERATED_WORD_COUNT);
+    requestedCount = numericCount;
+  }
+  const shares = unbounded
+    ? specs.map(() => Number.POSITIVE_INFINITY)
+    : allocateFairShares(specs.length, numericCount, allocationRng);
+  const budget = {
+    remaining: unbounded ? Number.POSITIVE_INFINITY : globalScanBudget(numericCount),
+  };
+  const initialBudget = budget.remaining;
+
+  const streams: CandidateStream[] = specs.map((spec, index) => {
+    const share = unbounded ? 0 : shares[index];
+    const ceiling = unbounded ? Number.POSITIVE_INFINITY : perSpecScanCeiling(share);
+    if (poolIds && loadPoolDocs) {
+      return new PoolCandidateStream(spec, ceiling, poolIds, loadPoolDocs, unbounded);
+    }
+    return new QueryCandidateStream(spec, ceiling, options.db, options.collection, queryRng, unbounded);
+  });
+
+  const collected: ExerciseWordResponse[][] = streams.map(() => []);
+
+  if (unbounded) {
+    for (let index = 0; index < streams.length; index += 1) {
+      collected[index] = await takeEligible(
+        streams[index],
+        Number.POSITIVE_INFINITY,
+        options.exercise,
+        formRng,
+        paradigmConfigs,
+        budget,
+        1,
+        true
+      );
+    }
+  } else {
+    for (let index = 0; index < streams.length; index += 1) {
+      collected[index] = await takeEligible(
+        streams[index],
+        shares[index],
+        options.exercise,
+        formRng,
+        paradigmConfigs,
+        budget,
+        shares[index],
+        false
+      );
+    }
+
+    let total = collected.reduce((sum, words) => sum + words.length, 0);
+    const hasCapacity = (stream: CandidateStream) =>
+      stream.unread.length > 0 || canStreamContinue(stream, budget.remaining);
+    while (total < numericCount && streams.some(hasCapacity)) {
+      const deficit = numericCount - total;
+      let progressed = false;
+      for (let index = 0; index < streams.length && total < numericCount; index += 1) {
+        if (!hasCapacity(streams[index])) continue;
+        const extra = await takeEligible(
+          streams[index],
+          1,
+          options.exercise,
+          formRng,
+          paradigmConfigs,
+          budget,
+          deficit,
+          false
+        );
+        if (extra.length > 0) {
+          collected[index].push(...extra);
+          total += extra.length;
+          progressed = true;
+        }
+      }
+      if (!progressed) break;
+    }
+  }
+
+  const diagnostics: GeneratedExercisePreviewDiagnostics[] = streams.map((stream, index) => ({
+    specId: stream.spec.id,
+    collected: collected[index].length,
+    scanned: stream.totalScanned,
+    exhausted: stream.exhausted,
+    scanLimitReached: stream.scanLimitReached,
+  }));
+
+  const combined = shuffleWithRng(collected.flat(), shuffleRng);
+  const words = unbounded ? combined : combined.slice(0, numericCount);
+
+  return {
+    words,
+    diagnostics,
+    globalScanLimitReached: !unbounded && budget.remaining <= 0 && initialBudget > 0 && words.length < numericCount,
+    requestedCount,
+  };
+}

--- a/src/lib/tests/generated-word-composition.server.ts
+++ b/src/lib/tests/generated-word-composition.server.ts
@@ -253,7 +253,7 @@ interface CandidateStream {
   scanLimitReached: boolean;
   unread: QueryDocumentSnapshot[];
   fetchedOnce: boolean;
-  nextBatch(limit: number): Promise<QueryDocumentSnapshot[]>;
+  nextBatch(limit: number, scanAllowance: number): Promise<QueryDocumentSnapshot[]>;
 }
 
 const canStreamContinue = (stream: CandidateStream, globalBudgetRemaining: number) =>
@@ -280,8 +280,8 @@ class QueryCandidateStream implements CandidateStream {
     private readonly unbounded: boolean
   ) {}
 
-  async nextBatch(limit: number): Promise<QueryDocumentSnapshot[]> {
-    if (this.exhausted || this.scanLimitReached || limit <= 0) return [];
+  async nextBatch(limit: number, scanAllowance: number): Promise<QueryDocumentSnapshot[]> {
+    if (this.exhausted || this.scanLimitReached || limit <= 0 || scanAllowance <= 0) return [];
     const remainingCeiling = this.unbounded
       ? limit
       : Math.max(0, this.scanCeiling - this.totalScanned);
@@ -289,7 +289,7 @@ class QueryCandidateStream implements CandidateStream {
       this.scanLimitReached = true;
       return [];
     }
-    const fetchLimit = Math.min(limit, remainingCeiling);
+    const fetchLimit = Math.min(limit, remainingCeiling, scanAllowance);
     this.ensureInitialized();
     if (this.spec.filters.search) return this.nextSearchBatch(fetchLimit);
     if (this.unbounded) return this.nextUnboundedRandomBatch(fetchLimit);
@@ -403,25 +403,28 @@ class PoolCandidateStream implements CandidateStream {
     private readonly unbounded: boolean
   ) {}
 
-  async nextBatch(limit: number): Promise<QueryDocumentSnapshot[]> {
-    if (this.exhausted || this.scanLimitReached || limit <= 0) return [];
+  async nextBatch(limit: number, scanAllowance: number): Promise<QueryDocumentSnapshot[]> {
+    if (this.exhausted || this.scanLimitReached || limit <= 0 || scanAllowance <= 0) return [];
     if (!this.unbounded && this.totalScanned >= this.scanCeiling) {
       this.scanLimitReached = true;
       return [];
     }
 
     const docs: QueryDocumentSnapshot[] = [];
+    const initialScanned = this.totalScanned;
     while (docs.length < limit && this.cursor < this.ids.length) {
-      const remainingScan = this.unbounded
+      const remainingAllowance = this.unbounded
         ? POOL_STREAM_CHUNK
-        : Math.max(0, this.scanCeiling - this.totalScanned);
+        : scanAllowance - (this.totalScanned - initialScanned);
+      if (!this.unbounded && remainingAllowance <= 0) break;
+      const remainingScan = this.unbounded ? POOL_STREAM_CHUNK : Math.max(0, this.scanCeiling - this.totalScanned);
       if (!this.unbounded && remainingScan <= 0) {
         this.scanLimitReached = true;
         break;
       }
       // Examine up to a chunk (or remaining ceiling), not only the remaining
       // match quota — sparse POS still needs to scan mixed IDs to find hits.
-      const sliceSize = Math.min(POOL_STREAM_CHUNK, remainingScan);
+      const sliceSize = Math.min(POOL_STREAM_CHUNK, remainingScan, remainingAllowance);
       if (sliceSize <= 0) break;
 
       const slice = this.ids.slice(this.cursor, this.cursor + sliceSize);
@@ -435,7 +438,6 @@ class PoolCandidateStream implements CandidateStream {
         if (this.spec.partOfSpeech && doc.data().part_of_speech !== this.spec.partOfSpeech) continue;
         this.seenIds.add(doc.id);
         docs.push(doc);
-        if (docs.length >= limit) break;
       }
       if (this.scanLimitReached) break;
     }
@@ -473,7 +475,6 @@ async function takeEligible(
   const accepted: ExerciseWordResponse[] = [];
   while (
     accepted.length < target &&
-    (unbounded || budget.remaining > 0) &&
     (stream.unread.length > 0 || canStreamContinue(stream, unbounded ? 1 : budget.remaining))
   ) {
     if (stream.unread.length === 0) {
@@ -481,20 +482,17 @@ async function takeEligible(
       const batchSize = unbounded
         ? Math.min(MAX_ADAPTIVE_BATCH, Math.max(remaining, MIN_ADAPTIVE_BATCH))
         : Math.min(adaptiveBatchSize(remaining, !stream.fetchedOnce, deficit), budget.remaining);
-      const docs = await stream.nextBatch(batchSize);
+      const scannedBefore = stream.totalScanned;
+      const docs = await stream.nextBatch(batchSize, unbounded ? Number.POSITIVE_INFINITY : budget.remaining);
+      if (!unbounded) {
+        budget.remaining = Math.max(0, budget.remaining - (stream.totalScanned - scannedBefore));
+      }
       stream.fetchedOnce = true;
       stream.unread.push(...docs);
       if (docs.length === 0) break;
     }
     const doc = stream.unread.shift();
     if (!doc) break;
-    if (!unbounded) {
-      if (budget.remaining <= 0) {
-        stream.unread.unshift(doc);
-        break;
-      }
-      budget.remaining -= 1;
-    }
     const word = evaluateCandidate(doc, stream.spec, exercise, formRng, paradigmConfigs);
     if (word) accepted.push(word);
   }

--- a/src/lib/tests/generated-word-loader.server.ts
+++ b/src/lib/tests/generated-word-loader.server.ts
@@ -86,6 +86,13 @@ export async function collectWordsForGeneratedExerciseRequest(
   const collection = requireGeneratedVocabularyCollection(
     normalizeCollection(config.collection || VOCABULARY_WORDS_COLLECTION)
   );
+  if (config.wordSource === 'pool' && !config.poolId) {
+    throw new GeneratedVocabularySourceError(
+      'Pool-backed generated exercises require a vocabulary pool',
+      400,
+      'POOL_ID_REQUIRED'
+    );
+  }
   const poolId = config.wordSource === 'pool' ? config.poolId : null;
   return collectGeneratedExerciseWords({
     db,

--- a/src/lib/tests/generated-word-loader.server.ts
+++ b/src/lib/tests/generated-word-loader.server.ts
@@ -1,70 +1,30 @@
-import type { Firestore, Query, QueryDocumentSnapshot } from 'firebase-admin/firestore';
+import type { Firestore } from 'firebase-admin/firestore';
 import { VOCABULARY_WORDS_COLLECTION } from '@/shared/constants/firestore';
-import { getReadableVocabularyPool, loadVocabularyPoolWords } from '@/src/lib/vocabulary-pools/archive.server';
-import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-responses';
-import type { GeneratorFilters, FormSelection } from '@/src/types/exercises/base';
-import type { FormParadigm, ParadigmConfigs } from '@/src/types/exercises/paradigm';
-import type { FormIdentificationStep } from '@/src/types/exercises/schemas/form-identification';
 import { PARADIGM_POS_GROUP, PARADIGM_TABLE_TYPE } from '@/src/config/paradigmDefinitions';
-import { parseFormPathFromString } from '@/src/utils/exerciseFormPaths';
-import { TABLE_TYPE_CONFIG, type TableType } from '@/src/utils/schema-helpers';
-import { categorizeMatchingPaths, scanTableForMatchingForms } from '@/src/utils/tableScanner';
+import type { GeneratorFilters } from '@/src/types/exercises/base';
+import type { FormParadigm, ParadigmConfigs } from '@/src/types/exercises/paradigm';
 import { deriveTableTypeFromPOS } from '@/src/utils/generated/tableType';
-import { filterOverlappingPronounParadigms } from '@/src/utils/generated/pronounParadigmFiltering';
-import { stripMacrons } from '@/src/utils/exercises/helpers';
-import { getApplicableStepsForFormPath } from '@/src/utils/exercises/formIdentificationCompatibility';
 import {
   buildLegacyParadigmConfigs,
   buildLegacyPosConfigs,
   normalizeCollection,
 } from '@/src/utils/exercises/legacyExerciseCompat';
 import type { GeneratedExercise, GeneratedWordLoader } from './generated-exercises';
+import {
+  applyValueFilter,
+  collectGeneratedExerciseWords,
+  GeneratedVocabularySourceError,
+  type CollectGeneratedExerciseWordsResult,
+  type WordQuerySpec,
+} from './generated-word-composition.server';
 
-interface WordQuerySpec {
-  partOfSpeech?: string;
-  filters: Omit<GeneratorFilters, 'partOfSpeech'>;
-  formSelection?: FormSelection;
-  tableType?: TableType;
-  steps?: FormIdentificationStep[];
-}
+export { applyValueFilter, GeneratedVocabularySourceError };
+export type { WordQuerySpec };
 
-const shuffle = <T>(values: T[]): T[] => {
-  const result = [...values];
-  for (let index = result.length - 1; index > 0; index -= 1) {
-    const other = Math.floor(Math.random() * (index + 1));
-    [result[index], result[other]] = [result[other], result[index]];
-  }
-  return result;
-};
-
-export const applyValueFilter = (query: Query, field: string, value?: string): Query => {
-  if (!value || value === 'all' || value === 'both') return query;
-  const values = value
-    .split(',')
-    .map(entry => entry.trim())
-    .filter(Boolean);
-  if (values.length === 0) return query;
-  return values.length === 1 ? query.where(field, '==', values[0]) : query.where(field, 'in', values);
-};
-
-function applyFilters(query: Query, spec: WordQuerySpec): Query {
-  const filters = spec.filters;
-  if (spec.partOfSpeech) query = query.where('part_of_speech', '==', spec.partOfSpeech);
-
-  if (spec.partOfSpeech === 'verb') {
-    query = applyValueFilter(query, 'conjugation', filters.verbConjugation);
-    if (filters.isDeponent === 'true') query = query.where('is_deponent', '==', true);
-    if (filters.isDeponent === 'false') query = query.where('is_deponent', '==', false);
-  } else if (spec.partOfSpeech === 'noun') {
-    query = applyValueFilter(query, 'declension', filters.nounDeclension);
-  } else if (spec.partOfSpeech === 'adjective') {
-    query = applyValueFilter(query, 'declension', filters.adjectiveDeclension);
-  } else if (spec.partOfSpeech === 'pronoun') {
-    query = applyValueFilter(query, 'pronoun_type', filters.pronounType);
-    query = applyValueFilter(query, 'person', filters.pronounPerson);
-  }
-
-  return query;
+export function requireGeneratedVocabularyCollection(collection?: string): string {
+  if (!collection || collection === VOCABULARY_WORDS_COLLECTION) return VOCABULARY_WORDS_COLLECTION;
+  if (/^vocabulary_words_v\d+$/.test(collection)) return VOCABULARY_WORDS_COLLECTION;
+  throw new GeneratedVocabularySourceError('Generated exercises must use the configured vocabulary collection');
 }
 
 const getParadigmConfigs = (
@@ -85,6 +45,7 @@ const getQuerySpecs = (exercise: GeneratedExercise): WordQuerySpec[] => {
     return Object.entries(posConfigs)
       .filter(([, value]) => value?.enabled)
       .map(([partOfSpeech, value]) => ({
+        id: partOfSpeech,
         partOfSpeech,
         filters: value!.filters,
         formSelection: value!.formSelection,
@@ -97,7 +58,7 @@ const getQuerySpecs = (exercise: GeneratedExercise): WordQuerySpec[] => {
   return Object.entries(paradigmConfigs)
     .filter((entry): entry is [FormParadigm, NonNullable<(typeof entry)[1]>] => entry[1]?.enabled === true)
     .map(([paradigm, value]) => {
-      const filters = { ...value.filters };
+      const filters: Omit<GeneratorFilters, 'partOfSpeech'> = { ...value.filters };
       if (paradigm === 'pronoun-personal') {
         filters.pronounType = 'personal';
         filters.pronounPerson = '1st,2nd';
@@ -105,6 +66,8 @@ const getQuerySpecs = (exercise: GeneratedExercise): WordQuerySpec[] => {
         filters.pronounPerson = '3rd';
       }
       return {
+        id: paradigm,
+        paradigm,
         partOfSpeech: PARADIGM_POS_GROUP[paradigm],
         filters,
         formSelection: value.formSelection,
@@ -114,160 +77,35 @@ const getQuerySpecs = (exercise: GeneratedExercise): WordQuerySpec[] => {
     });
 };
 
-const getPathValues = (value: Record<string, unknown>, path: string): string[] => {
-  let current: unknown = value;
-  for (const key of path.split('.')) {
-    if (!current || typeof current !== 'object' || !(key in current)) return [];
-    current = (current as Record<string, unknown>)[key];
-  }
-  if (typeof current === 'string') return [current];
-  return Array.isArray(current) ? current.filter((entry): entry is string => typeof entry === 'string') : [];
-};
-
-function selectForm(
-  word: Record<string, unknown>,
-  tableType: TableType,
-  selectedPaths: string[],
-  steps?: readonly FormIdentificationStep[]
-) {
-  const tableField = TABLE_TYPE_CONFIG[tableType];
-  const table = word[tableField];
-  if (!table) return null;
-
-  const compatiblePaths =
-    steps && tableType
-      ? selectedPaths.filter(path => (getApplicableStepsForFormPath(path, tableType, steps)?.applicableSteps.length ?? 0) > 0)
-      : selectedPaths;
-  const candidates = compatiblePaths.flatMap(path =>
-    getPathValues(word, `${tableField}.${path}`).map(form => ({ form, path }))
+export async function collectWordsForGeneratedExerciseRequest(
+  db: Firestore,
+  exercise: GeneratedExercise,
+  options?: { rng?: () => number }
+): Promise<CollectGeneratedExerciseWordsResult> {
+  const config = exercise.data.generatorConfig;
+  const collection = requireGeneratedVocabularyCollection(
+    normalizeCollection(config.collection || VOCABULARY_WORDS_COLLECTION)
   );
-  if (!candidates.length) return null;
-
-  const selected = candidates[Math.floor(Math.random() * candidates.length)];
-  const matchingPaths = scanTableForMatchingForms(table, selected.form, tableType);
-  const paths = categorizeMatchingPaths(matchingPaths, compatiblePaths);
-  if (!paths.primaryPaths.includes(selected.path)) paths.primaryPaths.unshift(selected.path);
-  return { selected, ...paths };
+  const poolId = config.wordSource === 'pool' ? config.poolId : null;
+  return collectGeneratedExerciseWords({
+    db,
+    collection,
+    specs: getQuerySpecs(exercise),
+    count: config.count || 'all',
+    exercise,
+    poolId,
+    poolWordLimit: config.poolWordLimit,
+    rng: options?.rng,
+    paradigmConfigs: exercise.type === 'generated-form-identification' ? getParadigmConfigs(exercise) : {},
+  });
 }
 
-function mapWord(doc: QueryDocumentSnapshot, spec: WordQuerySpec): ExerciseWordResponse | null {
-  const data = doc.data() as Record<string, unknown>;
-  const selectedPaths = spec.formSelection?.selectedCellPaths || [];
-  const selection =
-    spec.tableType && selectedPaths.length ? selectForm(data, spec.tableType, selectedPaths, spec.steps) : null;
-  if (selectedPaths.length && !selection) return null;
-
-  const parsedTableType = spec.tableType;
-  const formPath =
-    selection && parsedTableType ? parseFormPathFromString(selection.selected.path, parsedTableType) : null;
-  const primary =
-    selection && parsedTableType
-      ? selection.primaryPaths.map(path => parseFormPathFromString(path, parsedTableType)).filter(Boolean)
-      : undefined;
-  const optional =
-    selection && parsedTableType
-      ? selection.optionalPaths.map(path => parseFormPathFromString(path, parsedTableType)).filter(Boolean)
-      : undefined;
-
-  const result = {
-    id: doc.id,
-    root_word: String(data.word || ''),
-    dictionary_entry: typeof data.dictionary_entry === 'string' ? data.dictionary_entry : null,
-    selected_form: selection?.selected.form || String(data.word || ''),
-    part_of_speech: data.part_of_speech,
-    form_path: formPath,
-    primary_form_paths: primary?.length ? primary : undefined,
-    optional_form_paths: optional?.length ? optional : undefined,
-    ...(typeof data.conjugation === 'string' ? { conjugation: data.conjugation } : {}),
-    ...(typeof data.declension === 'string' ? { declension: data.declension } : {}),
-    ...(Array.isArray(data.definitions)
-      ? { definitions: data.definitions.filter(value => typeof value === 'string') }
-      : {}),
-    ...(typeof data.is_deponent === 'boolean' ? { is_deponent: data.is_deponent } : {}),
-    ...(typeof data.translation === 'string' ? { translation: data.translation } : {}),
-    ...(typeof data.gender === 'string' ? { gender: data.gender } : {}),
-    ...(typeof data.pronoun_type === 'string' ? { pronoun_type: data.pronoun_type } : {}),
-    ...(typeof data.person === 'string' || data.person === null ? { person: data.person } : {}),
-  };
-  return result as ExerciseWordResponse;
-}
-
-export function requireGeneratedVocabularyCollection(collection?: string): string {
-  if (!collection || collection === VOCABULARY_WORDS_COLLECTION) return VOCABULARY_WORDS_COLLECTION;
-  if (/^vocabulary_words_v\d+$/.test(collection)) return VOCABULARY_WORDS_COLLECTION;
-  throw new Error('Generated exercises must use the configured vocabulary collection');
-}
-
-async function loadPoolDocuments(db: Firestore, poolId: string, limit?: number | 'all') {
-  const pool = await getReadableVocabularyPool(db, poolId);
-  if (!pool) throw new Error(`Vocabulary pool ${poolId} was not found`);
-  const wordIds = Array.isArray(pool.data.wordDocIds)
-    ? pool.data.wordDocIds.filter((id: unknown): id is string => typeof id === 'string' && Boolean(id))
-    : [];
-  const selectedWordIds =
-    limit === 'all' || limit === undefined || limit >= wordIds.length ? wordIds : shuffle(wordIds).slice(0, limit);
-  return loadVocabularyPoolWords(pool, selectedWordIds);
-}
-
-async function loadQueryDocuments(db: Firestore, collection: string, spec: WordQuerySpec, count: number | 'all') {
-  const baseQuery = () => applyFilters(db.collection(collection), spec);
-  let query = baseQuery();
-  if (spec.filters.search) {
-    const search = stripMacrons(spec.filters.search);
-    query = query.where('sort_key', '>=', search).where('sort_key', '<=', `${search}\uf8ff`).orderBy('sort_key');
-    if (count !== 'all') query = query.limit(count);
-    return (await query.get()).docs;
-  }
-
-  if (count === 'all') return (await query.orderBy('random_index').get()).docs;
-
-  const threshold = Math.random();
-  const first = await query.orderBy('random_index').where('random_index', '>=', threshold).limit(count).get();
-  if (first.size >= count) return first.docs;
-
-  const remaining = count - first.size;
-  const wrapped = await baseQuery()
-    .orderBy('random_index')
-    .where('random_index', '<', threshold)
-    .limit(remaining)
-    .get();
-  return [...first.docs, ...wrapped.docs];
-}
-
-export function createFirestoreGeneratedWordLoader(db: Firestore): GeneratedWordLoader {
+export function createFirestoreGeneratedWordLoader(
+  db: Firestore,
+  options?: { rng?: () => number }
+): GeneratedWordLoader {
   return async exercise => {
-    const config = exercise.data.generatorConfig;
-    const collection = requireGeneratedVocabularyCollection(
-      normalizeCollection(config.collection || VOCABULARY_WORDS_COLLECTION)
-    );
-    const specs = getQuerySpecs(exercise);
-    const count = config.count || 'all';
-    const poolId = config.wordSource === 'pool' ? config.poolId : null;
-
-    if (poolId) {
-      const documents = await loadPoolDocuments(db, poolId, config.poolWordLimit || 'all');
-      const activeSpecs = specs.length ? specs : [{ filters: {} }];
-      const words = activeSpecs.flatMap(spec =>
-        documents
-          .filter(doc => !spec.partOfSpeech || doc.data().part_of_speech === spec.partOfSpeech)
-          .map(doc => mapWord(doc, spec))
-          .filter((word): word is ExerciseWordResponse => word !== null)
-      );
-      return shuffle(
-        exercise.type === 'generated-form-identification'
-          ? filterOverlappingPronounParadigms(words, getParadigmConfigs(exercise))
-          : words
-      );
-    }
-
-    const documents = await Promise.all(specs.map(spec => loadQueryDocuments(db, collection, spec, count)));
-    const words = documents.flatMap((docs, index) =>
-      docs.map(doc => mapWord(doc, specs[index])).filter((word): word is ExerciseWordResponse => word !== null)
-    );
-    return shuffle(
-      exercise.type === 'generated-form-identification'
-        ? filterOverlappingPronounParadigms(words, getParadigmConfigs(exercise))
-        : words
-    );
+    const result = await collectWordsForGeneratedExerciseRequest(db, exercise, options);
+    return result.words;
   };
 }

--- a/src/store/api/advancedVocabularyApi.ts
+++ b/src/store/api/advancedVocabularyApi.ts
@@ -13,6 +13,16 @@ import { filterOverlappingPronounParadigms } from '@/src/utils/generated/pronoun
 import { normalizeCollection } from '@/src/utils/exercises/legacyExerciseCompat';
 import { PARADIGM_TABLE_TYPE, PARADIGM_POS_GROUP } from '@/src/config/paradigmDefinitions';
 import { createAuthenticatedBaseQuery } from './baseQuery';
+import type {
+  GeneratedExercisePreviewRequest,
+  GeneratedExercisePreviewResult,
+} from '@/src/lib/tests/generated-preview-schema';
+
+export type {
+  GeneratedExercisePreviewDiagnostics,
+  GeneratedExercisePreviewRequest,
+  GeneratedExercisePreviewResult,
+} from '@/src/lib/tests/generated-preview-schema';
 
 export const normalizeAdvancedVocabularyCollection = (collection?: string) => normalizeCollection(collection);
 
@@ -630,8 +640,29 @@ export const advancedVocabularyApi = createApi({
       providesTags: [{ type: 'AdvancedWordList', id: 'MULTI_PARADIGM' }],
       keepUnusedDataFor: 60,
     }),
+    previewGeneratedExercise: builder.mutation<GeneratedExercisePreviewResult, GeneratedExercisePreviewRequest>({
+      query: body => ({
+        url: '/admin/exercises/generated-preview',
+        method: 'POST',
+        body,
+      }),
+    }),
+    getGeneratedExerciseWords: builder.query<GeneratedExercisePreviewResult, GeneratedExercisePreviewRequest>({
+      query: body => ({
+        url: '/words/generated-exercise',
+        method: 'POST',
+        body,
+      }),
+      serializeQueryArgs: ({ queryArgs }) => JSON.stringify(queryArgs),
+      keepUnusedDataFor: 60,
+    }),
   }),
 });
 
-export const { useGetAdvancedWordsQuery, useGetMultiPosWordsQuery, useGetMultiParadigmWordsQuery } =
-  advancedVocabularyApi;
+export const {
+  useGetAdvancedWordsQuery,
+  useGetMultiPosWordsQuery,
+  useGetMultiParadigmWordsQuery,
+  usePreviewGeneratedExerciseMutation,
+  useGetGeneratedExerciseWordsQuery,
+} = advancedVocabularyApi;

--- a/src/store/api/advancedVocabularyApi.ts
+++ b/src/store/api/advancedVocabularyApi.ts
@@ -14,6 +14,7 @@ import { normalizeCollection } from '@/src/utils/exercises/legacyExerciseCompat'
 import { PARADIGM_TABLE_TYPE, PARADIGM_POS_GROUP } from '@/src/config/paradigmDefinitions';
 import { createAuthenticatedBaseQuery } from './baseQuery';
 import type {
+  GeneratedExercisePlaybackRequest,
   GeneratedExercisePreviewRequest,
   GeneratedExercisePreviewResult,
 } from '@/src/lib/tests/generated-preview-schema';
@@ -23,6 +24,15 @@ export type {
   GeneratedExercisePreviewRequest,
   GeneratedExercisePreviewResult,
 } from '@/src/lib/tests/generated-preview-schema';
+
+export type GeneratedExerciseQuerySource =
+  | { kind: 'admin-preview' }
+  | ({ kind: 'lesson' } & GeneratedExercisePlaybackRequest);
+
+export interface GeneratedExerciseWordsQueryArgs {
+  exercise: GeneratedExercisePreviewRequest;
+  source: GeneratedExerciseQuerySource;
+}
 
 export const normalizeAdvancedVocabularyCollection = (collection?: string) => normalizeCollection(collection);
 
@@ -647,12 +657,24 @@ export const advancedVocabularyApi = createApi({
         body,
       }),
     }),
-    getGeneratedExerciseWords: builder.query<GeneratedExercisePreviewResult, GeneratedExercisePreviewRequest>({
-      query: body => ({
-        url: '/words/generated-exercise',
-        method: 'POST',
-        body,
-      }),
+    getGeneratedExerciseWords: builder.query<GeneratedExercisePreviewResult, GeneratedExerciseWordsQueryArgs>({
+      query: ({ exercise, source }) =>
+        source.kind === 'admin-preview'
+          ? {
+              url: '/admin/exercises/generated-preview',
+              method: 'POST',
+              body: exercise,
+            }
+          : {
+              url: '/words/generated-exercise',
+              method: 'POST',
+              body: {
+                lessonId: source.lessonId,
+                pageIndex: source.pageIndex,
+                itemIndex: source.itemIndex,
+                exerciseId: source.exerciseId,
+              },
+            },
       serializeQueryArgs: ({ queryArgs }) => JSON.stringify(queryArgs),
       keepUnusedDataFor: 60,
     }),

--- a/src/utils/exercises/formIdentificationPreparation.ts
+++ b/src/utils/exercises/formIdentificationPreparation.ts
@@ -1,0 +1,91 @@
+import type { ExerciseWordResponse } from '@/src/types/api/exercise-word-responses';
+import type { GeneratedFormIdentificationExercise } from '@/src/types/exercises';
+import type { PartOfSpeech, PronounPerson, PronounType } from '@/shared/types/vocabulary/schemas/enums';
+import { deriveParadigm } from '@/src/utils/paradigm';
+import { buildLegacyParadigmConfigs } from '@/src/utils/exercises/legacyExerciseCompat';
+import {
+  deduplicatePathsBySteps,
+  enrichPathsWithSteps,
+  getAnswerableStepsForWord,
+  getFallbackAnswerableStepsForWord,
+} from '@/src/utils/exercises/formIdentificationHelpers';
+
+export interface PreparedFormIdentificationWord {
+  steps: ReturnType<typeof getAnswerableStepsForWord>;
+  primary: Array<Record<string, string | undefined>>;
+  optional: Array<Record<string, string | undefined>>;
+}
+
+const getPaths = (word: ExerciseWordResponse) => ({
+  primary: (word.primary_form_paths || (word.form_path ? [word.form_path] : [])) as Array<
+    Record<string, string | undefined>
+  >,
+  optional: (word.optional_form_paths || []) as Array<Record<string, string | undefined>>,
+});
+
+/**
+ * Resolves the answerable steps and syncretic paths for a generated morphology
+ * word. Returns null when the word cannot produce any identification item.
+ */
+export function prepareGeneratedFormIdentificationWord(
+  exercise: GeneratedFormIdentificationExercise,
+  word: ExerciseWordResponse
+): PreparedFormIdentificationWord | null {
+  const data = word as Record<string, unknown>;
+  const paradigm = deriveParadigm(
+    word.part_of_speech as PartOfSpeech,
+    data.pronoun_type as PronounType | undefined,
+    data.person as PronounPerson | undefined
+  );
+  const paradigmConfigs =
+    exercise.data.paradigmConfigs && Object.keys(exercise.data.paradigmConfigs).length > 0
+      ? exercise.data.paradigmConfigs
+      : buildLegacyParadigmConfigs(exercise.data.generatorConfig as Parameters<typeof buildLegacyParadigmConfigs>[0]);
+  const config = paradigm ? paradigmConfigs[paradigm] : undefined;
+  const paths = getPaths(word);
+  const configuredSteps = config?.steps || [];
+  let candidateSteps = getAnswerableStepsForWord(word, configuredSteps, paths.primary);
+  const preferredPath = (word.form_path || paths.primary[0]) as Record<string, string | undefined> | undefined;
+
+  // A selected path can be answerable even when a syncretic alternative in
+  // `primary_form_paths` cannot answer any of the same questions (for example
+  // a finite form and a gerund with the same spelling). Fall back to the
+  // selected interpretation and discard incompatible alternatives below.
+  if (candidateSteps.length === 0) {
+    candidateSteps = getFallbackAnswerableStepsForWord(word, configuredSteps, preferredPath);
+  }
+
+  let enrichedPrimary = enrichPathsWithSteps(paths.primary, word, candidateSteps);
+  const steps = candidateSteps.filter(
+    step => enrichedPrimary.length > 0 && enrichedPrimary.some(path => Boolean(path[step]))
+  );
+
+  if (steps.length > 0) {
+    enrichedPrimary = enrichedPrimary.filter(path => steps.every(step => Boolean(path[step])));
+  }
+
+  // Older responses may omit `primary_form_paths` while still carrying the
+  // selected `form_path`; preserve that selected path as the answer key.
+  if (enrichedPrimary.length === 0 && preferredPath && steps.length > 0) {
+    enrichedPrimary = enrichPathsWithSteps([preferredPath], word, steps).filter(path =>
+      steps.every(step => Boolean(path[step]))
+    );
+  }
+
+  if (steps.length === 0) {
+    return null;
+  }
+
+  const enrichedOptional = enrichPathsWithSteps(paths.optional, word, steps).filter(path =>
+    steps.every(step => Boolean(path[step]))
+  );
+
+  const primary = deduplicatePathsBySteps(enrichedPrimary, steps);
+  if (primary.length === 0) return null;
+
+  return {
+    steps,
+    primary,
+    optional: deduplicatePathsBySteps(enrichedOptional, steps),
+  };
+}

--- a/src/utils/generated/generatedExercisePreview.ts
+++ b/src/utils/generated/generatedExercisePreview.ts
@@ -1,0 +1,43 @@
+import type { GeneratedExercisePreviewDiagnostics } from '@/src/lib/tests/generated-preview-schema';
+
+export type GeneratedExercisePreviewFingerprintSource = {
+  type: string;
+  translationDirection?: string;
+  data: unknown;
+};
+
+export function fingerprintGeneratedExercisePreviewRequest(
+  request: GeneratedExercisePreviewFingerprintSource
+): string {
+  return JSON.stringify({
+    type: request.type,
+    translationDirection: request.translationDirection ?? null,
+    data: request.data,
+  });
+}
+
+export function matchingGeneratedPreviewData<T>(
+  currentFingerprint: string,
+  originalArgs: GeneratedExercisePreviewFingerprintSource | undefined,
+  data: T | undefined
+): T | undefined {
+  if (data === undefined || !originalArgs) return undefined;
+  return fingerprintGeneratedExercisePreviewRequest(originalArgs) === currentFingerprint ? data : undefined;
+}
+
+export function formatGeneratedPreviewDiagnostics(result: {
+  diagnostics: GeneratedExercisePreviewDiagnostics[];
+  globalScanLimitReached?: boolean;
+}): string {
+  const summary = result.diagnostics
+    .map(entry => {
+      const flags = [entry.exhausted ? 'exhausted' : null, entry.scanLimitReached ? 'scan limit' : null].filter(
+        Boolean
+      );
+      return `${entry.specId}: ${entry.collected} usable (${entry.scanned} scanned${
+        flags.length ? `, ${flags.join(', ')}` : ''
+      })`;
+    })
+    .join(' · ');
+  return result.globalScanLimitReached ? `${summary} · Global scan budget reached` : summary;
+}

--- a/src/utils/generated/pronounParadigmFiltering.ts
+++ b/src/utils/generated/pronounParadigmFiltering.ts
@@ -1,4 +1,4 @@
-import type { ParadigmConfigs } from '@/src/types/exercises/paradigm';
+import type { FormParadigm, ParadigmConfigs } from '@/src/types/exercises/paradigm';
 
 interface PronounParadigmWord {
   part_of_speech?: unknown;
@@ -6,22 +6,36 @@ interface PronounParadigmWord {
   person?: unknown;
 }
 
+const isPersonalFirstOrSecondPronoun = (word: PronounParadigmWord): boolean =>
+  word.part_of_speech === 'pronoun' &&
+  word.pronoun_type === 'personal' &&
+  (word.person === '1st' || word.person === '2nd');
+
+const hasBroadGenderedPronounOverlap = (paradigmConfigs: ParadigmConfigs): boolean => {
+  const genderedConfig = paradigmConfigs['pronoun-gendered'];
+  return Boolean(
+    genderedConfig?.enabled && (!genderedConfig.filters.pronounType || genderedConfig.filters.pronounType === 'all')
+  );
+};
+
+/**
+ * Spec-aware overlap: 1st/2nd personal pronouns are ineligible only on the
+ * broad gendered stream. The same lemma remains eligible on the personal stream.
+ */
+export const isRejectedBySpecAwarePronounOverlap = (
+  word: PronounParadigmWord,
+  specParadigm: FormParadigm | undefined,
+  paradigmConfigs: ParadigmConfigs
+): boolean =>
+  hasBroadGenderedPronounOverlap(paradigmConfigs) &&
+  specParadigm === 'pronoun-gendered' &&
+  isPersonalFirstOrSecondPronoun(word);
+
 /** Keeps the broad gendered-pronoun result from duplicating the personal-pronoun paradigm. */
 export function filterOverlappingPronounParadigms<T extends PronounParadigmWord>(
   words: T[],
   paradigmConfigs: ParadigmConfigs
 ): T[] {
-  const genderedConfig = paradigmConfigs['pronoun-gendered'];
-  const broadGenderedPronouns =
-    genderedConfig?.enabled && (!genderedConfig.filters.pronounType || genderedConfig.filters.pronounType === 'all');
-  if (!broadGenderedPronouns) return words;
-
-  return words.filter(
-    word =>
-      !(
-        word.part_of_speech === 'pronoun' &&
-        word.pronoun_type === 'personal' &&
-        (word.person === '1st' || word.person === '2nd')
-      )
-  );
+  if (!hasBroadGenderedPronounOverlap(paradigmConfigs)) return words;
+  return words.filter(word => !isPersonalFirstOrSecondPronoun(word));
 }

--- a/tests/generatedExerciseEditorPreview.test.ts
+++ b/tests/generatedExerciseEditorPreview.test.ts
@@ -1,0 +1,138 @@
+import { act, renderHook } from '@testing-library/react';
+import type { GeneratedTranslationExercise } from '@/src/types/exercises/generated-translation';
+import {
+  fingerprintGeneratedExercisePreviewRequest,
+  formatGeneratedPreviewDiagnostics,
+  matchingGeneratedPreviewData,
+} from '@/src/utils/generated/generatedExercisePreview';
+
+const mockReset = jest.fn();
+const mockPreview = jest.fn();
+const previewState: {
+  data: { words: Array<{ id: string }> } | undefined;
+  isLoading: boolean;
+  error: unknown;
+  originalArgs:
+    | {
+        type: 'generated-translation';
+        translationDirection?: 'latin-to-english' | 'english-to-latin';
+        data: Record<string, unknown>;
+      }
+    | undefined;
+  reset: typeof mockReset;
+} = {
+  data: undefined,
+  isLoading: false,
+  error: undefined,
+  originalArgs: undefined,
+  reset: mockReset,
+};
+
+jest.mock('@/src/store/hooks', () => ({
+  useAppDispatch: () => jest.fn(),
+}));
+jest.mock('@/src/hooks/usePoolPOSSummary', () => ({
+  usePoolPOSSummary: () => ({ uniquePOS: undefined, availablePOS: [], summary: undefined }),
+}));
+jest.mock('@/src/hooks/useFormSelection', () => ({
+  useFormSelectionControls: () => ({
+    handleToggleCell: jest.fn(),
+    handleTogglePaths: jest.fn(),
+    handleSelectAll: jest.fn(),
+    handleClearSelection: jest.fn(),
+  }),
+}));
+jest.mock('@/src/store/api/advancedVocabularyApi', () => ({
+  usePreviewGeneratedExerciseMutation: () => [mockPreview, previewState],
+}));
+
+import { useGeneratedExerciseEditor } from '@/src/hooks/useGeneratedExerciseEditor';
+
+const makeExercise = (count: number, direction: 'latin-to-english' | 'english-to-latin' = 'latin-to-english') =>
+  ({
+    id: 'ex-1',
+    type: 'generated-translation',
+    title: 'Preview',
+    instructions: '',
+    translationDirection: direction,
+    feedbackConfig: { escalationLevels: [] },
+    data: {
+      generatorConfig: { collection: 'vocabulary_words_v5', wordSource: 'filters', count },
+      posConfigs: { noun: { enabled: true, filters: {} } },
+    },
+  }) as GeneratedTranslationExercise;
+
+describe('generated exercise preview staleness', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previewState.data = undefined;
+    previewState.originalArgs = undefined;
+    previewState.isLoading = false;
+    previewState.error = undefined;
+  });
+
+  it('hides preview results whose request fingerprint no longer matches', () => {
+    const current = {
+      type: 'generated-translation',
+      translationDirection: 'latin-to-english' as const,
+      data: { generatorConfig: { count: 5 } },
+    };
+    const stale = {
+      type: 'generated-translation',
+      translationDirection: 'latin-to-english' as const,
+      data: { generatorConfig: { count: 10 } },
+    };
+    expect(
+      matchingGeneratedPreviewData(
+        fingerprintGeneratedExercisePreviewRequest(current),
+        stale,
+        { words: [{ id: 'old' }] }
+      )
+    ).toBeUndefined();
+    expect(
+      matchingGeneratedPreviewData(
+        fingerprintGeneratedExercisePreviewRequest(current),
+        current,
+        { words: [{ id: 'fresh' }] }
+      )
+    ).toEqual({ words: [{ id: 'fresh' }] });
+  });
+
+  it('formats per-spec diagnostics and the global scan-budget suffix', () => {
+    expect(
+      formatGeneratedPreviewDiagnostics({
+        diagnostics: [
+          { specId: 'noun', collected: 3, scanned: 12, exhausted: true, scanLimitReached: false },
+          { specId: 'verb', collected: 2, scanned: 40, exhausted: false, scanLimitReached: true },
+        ],
+        globalScanLimitReached: true,
+      })
+    ).toBe('noun: 3 usable (12 scanned, exhausted) · verb: 2 usable (40 scanned, scan limit) · Global scan budget reached');
+  });
+
+  it('closes and resets preview when count, filters, or direction change', () => {
+    const { result, rerender } = renderHook(
+      ({ exercise }: { exercise: GeneratedTranslationExercise }) =>
+        useGeneratedExerciseEditor(exercise, { exerciseType: 'generated-translation' }),
+      { initialProps: { exercise: makeExercise(10) } }
+    );
+
+    act(() => {
+      result.current.setIsPreviewOpen(true);
+    });
+    expect(result.current.isPreviewOpen).toBe(true);
+    expect(mockPreview).toHaveBeenCalled();
+
+    rerender({ exercise: makeExercise(5) });
+    expect(result.current.isPreviewOpen).toBe(false);
+    expect(mockReset).toHaveBeenCalled();
+
+    mockReset.mockClear();
+    act(() => {
+      result.current.setIsPreviewOpen(true);
+    });
+    rerender({ exercise: makeExercise(5, 'english-to-latin') });
+    expect(result.current.isPreviewOpen).toBe(false);
+    expect(mockReset).toHaveBeenCalled();
+  });
+});

--- a/tests/generatedExercisePlaybackRoute.test.ts
+++ b/tests/generatedExercisePlaybackRoute.test.ts
@@ -1,0 +1,76 @@
+jest.mock('next/server', () => jest.requireActual('./helpers/routeMocks'));
+jest.mock('firebase-admin/firestore', () => ({ FieldPath: { documentId: jest.fn(() => '__name__') } }));
+
+const dbState: { collection: (name: string) => unknown } = {
+  collection: () => {
+    throw new Error('database was not installed');
+  },
+};
+
+jest.mock('@/src/services/firebase-admin', () => ({
+  adminDb: { collection: (name: string) => dbState.collection(name) },
+}));
+
+const mockVerifyAuthenticatedAccess = jest.fn();
+jest.mock('@/src/lib/verifyAdminAccess', () => ({
+  ...jest.requireActual('@/src/lib/verifyAdminAccess'),
+  verifyAuthenticatedAccess: (...args: unknown[]) => mockVerifyAuthenticatedAccess(...args),
+}));
+
+import { POST } from '@/src/app/api/words/generated-exercise/route';
+import { createFakeGeneratedWordDb } from './helpers/fakeGeneratedWordFirestore';
+import { AdminAccessError } from '@/src/lib/admin-access-error';
+
+const translationBody = {
+  type: 'generated-translation',
+  data: {
+    generatorConfig: { collection: 'vocabulary_words_v5', wordSource: 'filters', count: 10 },
+    posConfigs: { noun: { enabled: true, filters: {} }, verb: { enabled: true, filters: {} } },
+  },
+};
+
+describe('student generated exercise playback route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const db = createFakeGeneratedWordDb({
+      words: [
+        ...Array.from({ length: 8 }, (_, index) => ({
+          id: `noun-${index}`,
+          data: {
+            word: `noun-${index}`,
+            part_of_speech: 'noun',
+            translation: 'girl',
+            random_index: 0.5,
+            sort_key: `noun-${index}`,
+          },
+        })),
+        ...Array.from({ length: 8 }, (_, index) => ({
+          id: `verb-${index}`,
+          data: {
+            word: `verb-${index}`,
+            part_of_speech: 'verb',
+            translation: 'love',
+            random_index: 0.5,
+            sort_key: `verb-${index}`,
+          },
+        })),
+      ],
+    });
+    dbState.collection = db.collection;
+    mockVerifyAuthenticatedAccess.mockResolvedValue({ uid: 'student-1' });
+  });
+
+  it('rejects unauthenticated playback requests', async () => {
+    mockVerifyAuthenticatedAccess.mockRejectedValue(new AdminAccessError('Unauthorized', 401));
+    const response = await POST({ json: async () => translationBody } as never);
+    expect(response.status).toBe(401);
+  });
+
+  it('returns exactly count usable words from the shared collector', async () => {
+    const response = await POST({ json: async () => translationBody } as never);
+    expect(response.status).toBe(200);
+    const payload = (response as unknown as { body: { words: unknown[]; collected: number } }).body;
+    expect(payload.words).toHaveLength(10);
+    expect(payload.collected).toBe(10);
+  });
+});

--- a/tests/generatedExercisePlaybackRoute.test.ts
+++ b/tests/generatedExercisePlaybackRoute.test.ts
@@ -11,22 +11,33 @@ jest.mock('@/src/services/firebase-admin', () => ({
   adminDb: { collection: (name: string) => dbState.collection(name) },
 }));
 
-const mockVerifyAuthenticatedAccess = jest.fn();
-jest.mock('@/src/lib/verifyAdminAccess', () => ({
-  ...jest.requireActual('@/src/lib/verifyAdminAccess'),
-  verifyAuthenticatedAccess: (...args: unknown[]) => mockVerifyAuthenticatedAccess(...args),
+const mockVerifyRequestAuth = jest.fn();
+jest.mock('@/src/lib/verifyRequestAuth', () => ({
+  verifyRequestAuth: (...args: unknown[]) => mockVerifyRequestAuth(...args),
+}));
+
+const mockGetLesson = jest.fn();
+jest.mock('@/src/lib/learning-units/student-dashboard-service', () => ({
+  studentDashboardService: { getLesson: (...args: unknown[]) => mockGetLesson(...args) },
 }));
 
 import { POST } from '@/src/app/api/words/generated-exercise/route';
 import { createFakeGeneratedWordDb } from './helpers/fakeGeneratedWordFirestore';
-import { AdminAccessError } from '@/src/lib/admin-access-error';
 
-const translationBody = {
+const translationExercise = {
+  id: 'exercise-1',
   type: 'generated-translation',
   data: {
     generatorConfig: { collection: 'vocabulary_words_v5', wordSource: 'filters', count: 10 },
     posConfigs: { noun: { enabled: true, filters: {} }, verb: { enabled: true, filters: {} } },
   },
+};
+
+const playbackBody = {
+  lessonId: 'lesson-1',
+  pageIndex: 0,
+  itemIndex: 0,
+  exerciseId: 'exercise-1',
 };
 
 describe('student generated exercise playback route', () => {
@@ -57,20 +68,45 @@ describe('student generated exercise playback route', () => {
       ],
     });
     dbState.collection = db.collection;
-    mockVerifyAuthenticatedAccess.mockResolvedValue({ uid: 'student-1' });
+    mockVerifyRequestAuth.mockResolvedValue({ uid: 'student-1' });
+    mockGetLesson.mockResolvedValue({ id: 'lesson-1', pages: [{ id: 'page-1', items: [translationExercise] }] });
   });
 
   it('rejects unauthenticated playback requests', async () => {
-    mockVerifyAuthenticatedAccess.mockRejectedValue(new AdminAccessError('Unauthorized', 401));
-    const response = await POST({ json: async () => translationBody } as never);
+    mockVerifyRequestAuth.mockResolvedValue(null);
+    const response = await POST({ json: async () => playbackBody } as never);
     expect(response.status).toBe(401);
   });
 
-  it('returns exactly count usable words from the shared collector', async () => {
-    const response = await POST({ json: async () => translationBody } as never);
+  it('loads the authorized persisted exercise and returns exactly count usable words', async () => {
+    const response = await POST({ json: async () => playbackBody } as never);
     expect(response.status).toBe(200);
+    expect(mockGetLesson).toHaveBeenCalledWith('student-1', 'lesson-1');
     const payload = (response as unknown as { body: { words: unknown[]; collected: number } }).body;
     expect(payload.words).toHaveLength(10);
     expect(payload.collected).toBe(10);
+  });
+
+  it('preserves lesson access failures from the ownership check', async () => {
+    mockGetLesson.mockRejectedValue(
+      Object.assign(new Error('Lesson is locked'), { status: 403, code: 'LESSON_LOCKED' })
+    );
+
+    const response = await POST({ json: async () => playbackBody } as never);
+
+    expect(response.status).toBe(403);
+  });
+
+  it('rejects a stale exercise location instead of trusting client-authored content', async () => {
+    const response = await POST({ json: async () => ({ ...playbackBody, exerciseId: 'other-exercise' }) } as never);
+
+    expect(response.status).toBe(404);
+  });
+
+  it('rejects the old caller-authored exercise body', async () => {
+    const response = await POST({ json: async () => translationExercise } as never);
+
+    expect(response.status).toBe(400);
+    expect(mockGetLesson).not.toHaveBeenCalled();
   });
 });

--- a/tests/generatedExercisePreviewMutation.test.ts
+++ b/tests/generatedExercisePreviewMutation.test.ts
@@ -73,14 +73,59 @@ describe('generated exercise preview mutation', () => {
       },
     };
 
-    const result = await store.dispatch(advancedVocabularyApi.endpoints.getGeneratedExerciseWords.initiate(body));
+    const source = {
+      kind: 'lesson' as const,
+      lessonId: 'lesson-1',
+      pageIndex: 2,
+      itemIndex: 3,
+      exerciseId: 'exercise-1',
+    };
+    const result = await store.dispatch(
+      advancedVocabularyApi.endpoints.getGeneratedExerciseWords.initiate({ exercise: body, source })
+    );
 
     expect('data' in result && result.data?.collected).toBe(1);
     expect(mockBaseQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         url: '/words/generated-exercise',
         method: 'POST',
-        body,
+        body: {
+          lessonId: 'lesson-1',
+          pageIndex: 2,
+          itemIndex: 3,
+          exerciseId: 'exercise-1',
+        },
+      }),
+      expect.anything(),
+      undefined
+    );
+  });
+
+  it('routes generated exercise rendering in admin previews through the admin endpoint', async () => {
+    mockBaseQuery.mockResolvedValue({
+      data: { words: [], diagnostics: [], requestedCount: 1, collected: 0, globalScanLimitReached: false },
+    });
+    const store = createStore();
+    const exercise = {
+      type: 'generated-translation' as const,
+      data: {
+        generatorConfig: { collection: 'vocabulary_words_v5', wordSource: 'filters' as const, count: 1 },
+        posConfigs: { noun: { enabled: true, filters: {} } },
+      },
+    };
+
+    await store.dispatch(
+      advancedVocabularyApi.endpoints.getGeneratedExerciseWords.initiate({
+        exercise,
+        source: { kind: 'admin-preview' },
+      })
+    );
+
+    expect(mockBaseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/admin/exercises/generated-preview',
+        method: 'POST',
+        body: exercise,
       }),
       expect.anything(),
       undefined

--- a/tests/generatedExercisePreviewMutation.test.ts
+++ b/tests/generatedExercisePreviewMutation.test.ts
@@ -1,0 +1,89 @@
+const mockBaseQuery = jest.fn();
+
+jest.mock('@/src/store/api/baseQuery', () => ({
+  createAuthenticatedBaseQuery:
+    () =>
+    (...args: unknown[]) =>
+      mockBaseQuery(...args),
+}));
+
+import { configureStore } from '@reduxjs/toolkit';
+import { advancedVocabularyApi } from '@/src/store/api/advancedVocabularyApi';
+
+const createStore = () =>
+  configureStore({
+    reducer: { [advancedVocabularyApi.reducerPath]: advancedVocabularyApi.reducer },
+    middleware: getDefaultMiddleware => getDefaultMiddleware().concat(advancedVocabularyApi.middleware),
+  });
+
+describe('generated exercise preview mutation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('posts the draft body to the dedicated preview endpoint', async () => {
+    mockBaseQuery.mockResolvedValue({
+      data: {
+        words: [{ id: 'noun-1' }],
+        diagnostics: [{ specId: 'noun', collected: 1, scanned: 1, exhausted: true, scanLimitReached: false }],
+        requestedCount: 10,
+        collected: 1,
+        globalScanLimitReached: false,
+      },
+    });
+    const store = createStore();
+    const body = {
+      type: 'generated-translation' as const,
+      data: {
+        generatorConfig: { collection: 'vocabulary_words_v5', wordSource: 'filters' as const, count: 10 },
+        posConfigs: { noun: { enabled: true, filters: {} } },
+      },
+    };
+
+    const result = await store.dispatch(advancedVocabularyApi.endpoints.previewGeneratedExercise.initiate(body));
+
+    expect('data' in result && result.data?.collected).toBe(1);
+    expect(mockBaseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/admin/exercises/generated-preview',
+        method: 'POST',
+        body,
+      }),
+      expect.anything(),
+      undefined
+    );
+  });
+
+  it('posts lesson playback collection through the student collector endpoint', async () => {
+    mockBaseQuery.mockResolvedValue({
+      data: {
+        words: [{ id: 'noun-1' }],
+        diagnostics: [{ specId: 'noun', collected: 1, scanned: 1, exhausted: true, scanLimitReached: false }],
+        requestedCount: 10,
+        collected: 1,
+        globalScanLimitReached: false,
+      },
+    });
+    const store = createStore();
+    const body = {
+      type: 'generated-translation' as const,
+      data: {
+        generatorConfig: { collection: 'vocabulary_words_v5', wordSource: 'filters' as const, count: 10 },
+        posConfigs: { noun: { enabled: true, filters: {} } },
+      },
+    };
+
+    const result = await store.dispatch(advancedVocabularyApi.endpoints.getGeneratedExerciseWords.initiate(body));
+
+    expect('data' in result && result.data?.collected).toBe(1);
+    expect(mockBaseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/words/generated-exercise',
+        method: 'POST',
+        body,
+      }),
+      expect.anything(),
+      undefined
+    );
+  });
+});

--- a/tests/generatedExercisePreviewRoute.test.ts
+++ b/tests/generatedExercisePreviewRoute.test.ts
@@ -1,0 +1,174 @@
+jest.mock('next/server', () => jest.requireActual('./helpers/routeMocks'));
+jest.mock('firebase-admin/firestore', () => ({ FieldPath: { documentId: jest.fn(() => '__name__') } }));
+
+const dbState: { collection: (name: string) => unknown } = {
+  collection: () => {
+    throw new Error('database was not installed');
+  },
+};
+
+jest.mock('@/src/services/firebase-admin', () => ({
+  adminDb: { collection: (name: string) => dbState.collection(name) },
+}));
+
+const mockVerifyAdminAccess = jest.fn();
+jest.mock('@/src/lib/verifyAdminAccess', () => ({
+  ...jest.requireActual('@/src/lib/verifyAdminAccess'),
+  verifyAdminAccess: (...args: unknown[]) => mockVerifyAdminAccess(...args),
+}));
+
+import { POST } from '@/src/app/api/admin/exercises/generated-preview/route';
+import { createFakeGeneratedWordDb } from './helpers/fakeGeneratedWordFirestore';
+import { AdminAccessError } from '@/src/lib/admin-access-error';
+import { MAX_GENERATED_WORD_COUNT } from '@/src/config/generatedExerciseLimits';
+
+const translationBody = {
+  type: 'generated-translation',
+  data: {
+    generatorConfig: { collection: 'vocabulary_words_v5', wordSource: 'filters', count: 10 },
+    posConfigs: { noun: { enabled: true, filters: {} }, verb: { enabled: true, filters: {} } },
+  },
+};
+
+describe('admin generated exercise preview route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const db = createFakeGeneratedWordDb({
+      words: [
+        ...Array.from({ length: 8 }, (_, index) => ({
+          id: `noun-${index}`,
+          data: {
+            word: `noun-${index}`,
+            part_of_speech: 'noun',
+            translation: 'girl',
+            random_index: 0.5,
+            sort_key: `noun-${index}`,
+          },
+        })),
+        ...Array.from({ length: 8 }, (_, index) => ({
+          id: `verb-${index}`,
+          data: {
+            word: `verb-${index}`,
+            part_of_speech: 'verb',
+            translation: 'love',
+            random_index: 0.5,
+            sort_key: `verb-${index}`,
+          },
+        })),
+      ],
+    });
+    dbState.collection = db.collection;
+    mockVerifyAdminAccess.mockResolvedValue({ uid: 'admin-1' });
+  });
+
+  it('rejects unauthenticated preview requests', async () => {
+    mockVerifyAdminAccess.mockRejectedValue(new AdminAccessError('Unauthorized', 401));
+    const response = await POST({ json: async () => translationBody } as never);
+    expect(response.status).toBe(401);
+  });
+
+  it('returns exactly count usable words and per-spec diagnostics', async () => {
+    const response = await POST({ json: async () => translationBody } as never);
+    expect(response.status).toBe(200);
+    const payload = (response as unknown as { body: { words: unknown[]; diagnostics: unknown[]; collected: number } })
+      .body;
+    expect(payload.words).toHaveLength(10);
+    expect(payload.collected).toBe(10);
+    expect(payload.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ specId: 'noun' }),
+        expect.objectContaining({ specId: 'verb' }),
+      ])
+    );
+  });
+
+  it('preserves count: all through the preview endpoint', async () => {
+    const response = await POST({
+      json: async () => ({
+        ...translationBody,
+        data: {
+          ...translationBody.data,
+          generatorConfig: { ...translationBody.data.generatorConfig, count: 'all' },
+        },
+      }),
+    } as never);
+    expect(response.status).toBe(200);
+    const payload = (response as unknown as { body: { words: unknown[]; requestedCount: unknown } }).body;
+    expect(payload.requestedCount).toBe('all');
+    expect(payload.words).toHaveLength(16);
+  });
+
+  it('rejects an invalid collection like delivery', async () => {
+    const response = await POST({
+      json: async () => ({
+        ...translationBody,
+        data: {
+          ...translationBody.data,
+          generatorConfig: { ...translationBody.data.generatorConfig, collection: 'users' },
+        },
+      }),
+    } as never);
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects a missing pool like delivery', async () => {
+    const response = await POST({
+      json: async () => ({
+        ...translationBody,
+        data: {
+          ...translationBody.data,
+          generatorConfig: {
+            ...translationBody.data.generatorConfig,
+            wordSource: 'pool',
+            poolId: 'missing-pool',
+          },
+        },
+      }),
+    } as never);
+    expect(response.status).toBe(404);
+  });
+
+  it('rejects counts above the authorable ceiling', async () => {
+    const response = await POST({
+      json: async () => ({
+        ...translationBody,
+        data: {
+          ...translationBody.data,
+          generatorConfig: {
+            ...translationBody.data.generatorConfig,
+            count: MAX_GENERATED_WORD_COUNT + 1,
+          },
+        },
+      }),
+    } as never);
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects a numeric verb conjugation filter instead of 500ing', async () => {
+    const response = await POST({
+      json: async () => ({
+        ...translationBody,
+        data: {
+          ...translationBody.data,
+          posConfigs: { verb: { enabled: true, filters: { verbConjugation: 3 } } },
+        },
+      }),
+    } as never);
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects filter lists that exceed the Firestore in-query operand bound', async () => {
+    const response = await POST({
+      json: async () => ({
+        ...translationBody,
+        data: {
+          ...translationBody.data,
+          posConfigs: {
+            verb: { enabled: true, filters: { verbConjugation: Array.from({ length: 31 }, () => '1').join(',') } },
+          },
+        },
+      }),
+    } as never);
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/generatedExercisePreviewRoute.test.ts
+++ b/tests/generatedExercisePreviewRoute.test.ts
@@ -16,6 +16,10 @@ jest.mock('@/src/lib/verifyAdminAccess', () => ({
   ...jest.requireActual('@/src/lib/verifyAdminAccess'),
   verifyAdminAccess: (...args: unknown[]) => mockVerifyAdminAccess(...args),
 }));
+jest.mock('@/src/lib/verifyRequestAuth', () => ({ verifyRequestAuth: jest.fn() }));
+jest.mock('@/src/lib/learning-units/student-dashboard-service', () => ({
+  studentDashboardService: { getLesson: jest.fn() },
+}));
 
 import { POST } from '@/src/app/api/admin/exercises/generated-preview/route';
 import { createFakeGeneratedWordDb } from './helpers/fakeGeneratedWordFirestore';
@@ -126,6 +130,25 @@ describe('admin generated exercise preview route', () => {
       }),
     } as never);
     expect(response.status).toBe(404);
+  });
+
+  it('rejects a pool source without a selected pool instead of querying the full collection', async () => {
+    const response = await POST({
+      json: async () => ({
+        ...translationBody,
+        data: {
+          ...translationBody.data,
+          generatorConfig: {
+            ...translationBody.data.generatorConfig,
+            wordSource: 'pool',
+            poolId: null,
+          },
+        },
+      }),
+    } as never);
+
+    expect(response.status).toBe(400);
+    expect((response as unknown as { body: { code?: string } }).body.code).toBe('POOL_ID_REQUIRED');
   });
 
   it('rejects counts above the authorable ceiling', async () => {

--- a/tests/helpers/fakeGeneratedWordFirestore.ts
+++ b/tests/helpers/fakeGeneratedWordFirestore.ts
@@ -1,0 +1,137 @@
+export type FakeDocument = {
+  id: string;
+  data: Record<string, unknown>;
+};
+
+type Filter = { field: string; op: string; value: unknown };
+
+const compareValues = (left: unknown, right: unknown): number => {
+  if (typeof left === 'number' && typeof right === 'number') return left - right;
+  return String(left ?? '').localeCompare(String(right ?? ''));
+};
+
+const fieldValue = (doc: FakeDocument, field: string): unknown =>
+  field === '__name__' ? doc.id : doc.data[field];
+
+const matchesFilter = (doc: FakeDocument, filter: Filter): boolean => {
+  const actual = fieldValue(doc, filter.field);
+  switch (filter.op) {
+    case '==':
+      return actual === filter.value;
+    case 'in':
+      return Array.isArray(filter.value) && filter.value.includes(actual);
+    case '>=':
+      return compareValues(actual, filter.value) >= 0;
+    case '<=':
+      return compareValues(actual, filter.value) <= 0;
+    case '<':
+      return compareValues(actual, filter.value) < 0;
+    case '>':
+      return compareValues(actual, filter.value) > 0;
+    default:
+      return true;
+  }
+};
+
+const toSnapshot = (doc: FakeDocument) => ({
+  id: doc.id,
+  data: () => doc.data,
+});
+
+class FakeQuery {
+  constructor(
+    private readonly docs: FakeDocument[],
+    private readonly state: {
+      filters: Filter[];
+      orderBy?: string;
+      limitCount?: number;
+      startAfterId?: string;
+    },
+    private readonly limitCalls?: number[]
+  ) {}
+
+  where(field: string, op: string, value: unknown) {
+    return new FakeQuery(
+      this.docs,
+      {
+        ...this.state,
+        filters: [...this.state.filters, { field, op, value }],
+      },
+      this.limitCalls
+    );
+  }
+
+  orderBy(field: string) {
+    return new FakeQuery(this.docs, { ...this.state, orderBy: field }, this.limitCalls);
+  }
+
+  limit(limitCount: number) {
+    this.limitCalls?.push(limitCount);
+    return new FakeQuery(this.docs, { ...this.state, limitCount }, this.limitCalls);
+  }
+
+  startAfter(snapshot: { id: string }) {
+    return new FakeQuery(this.docs, { ...this.state, startAfterId: snapshot.id }, this.limitCalls);
+  }
+
+  async get() {
+    let rows = this.docs.filter(doc => this.state.filters.every(filter => matchesFilter(doc, filter)));
+    const orderField = this.state.orderBy;
+    if (orderField) {
+      rows = [...rows].sort((left, right) => {
+        const ordered = compareValues(fieldValue(left, orderField), fieldValue(right, orderField));
+        return ordered !== 0 ? ordered : left.id.localeCompare(right.id);
+      });
+    }
+    if (this.state.startAfterId) {
+      const cursor = this.docs.find(doc => doc.id === this.state.startAfterId);
+      if (cursor && orderField) {
+        rows = rows.filter(row => {
+          const ordered = compareValues(fieldValue(row, orderField), fieldValue(cursor, orderField));
+          if (ordered > 0) return true;
+          if (ordered < 0) return false;
+          return row.id > cursor.id;
+        });
+      } else {
+        const index = rows.findIndex(row => row.id === this.state.startAfterId);
+        if (index >= 0) rows = rows.slice(index + 1);
+      }
+    }
+    if (this.state.limitCount !== undefined) rows = rows.slice(0, this.state.limitCount);
+    const snapshots = rows.map(toSnapshot);
+    return { docs: snapshots, size: snapshots.length };
+  }
+}
+
+export function createFakeGeneratedWordDb(options: {
+  words?: FakeDocument[];
+  pools?: Array<{ id: string; wordDocIds: string[] }>;
+  limitCalls?: number[];
+}) {
+  const collections: Record<string, FakeDocument[]> = {
+    vocabulary_words_v5: options.words ?? [],
+    vocabulary_pools: (options.pools ?? []).map(pool => ({
+      id: pool.id,
+      data: { wordDocIds: pool.wordDocIds },
+    })),
+  };
+
+  const collection = (name: string) => {
+    const docs = collections[name] ?? [];
+    const query = new FakeQuery(docs, { filters: [] }, options.limitCalls);
+    return Object.assign(query, {
+      doc: (id: string) => ({
+        get: async () => {
+          const found = docs.find(doc => doc.id === id);
+          return {
+            id,
+            exists: Boolean(found),
+            data: () => found?.data,
+          };
+        },
+      }),
+    });
+  };
+
+  return { collection };
+}

--- a/tests/morphologyWordReplenishment.test.ts
+++ b/tests/morphologyWordReplenishment.test.ts
@@ -602,6 +602,58 @@ describe('generated exercise word replenishment', () => {
     expect(new Set(result.words.map(word => word.id)).size).toBeLessThanOrEqual(5);
   });
 
+  it('keeps the unused portion of a pool chunk available for cross-spec borrowing', async () => {
+    const words = Array.from({ length: 10 }, (_, index) => nounDoc(`noun-${index}`));
+    const db = createFakeGeneratedWordDb({
+      words,
+      pools: [{ id: 'noun-pool', wordDocIds: words.map(word => word.id) }],
+    });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        { id: 'noun', partOfSpeech: 'noun', filters: {} },
+        { id: 'verb', partOfSpeech: 'verb', filters: {} },
+      ],
+      count: 10,
+      exercise: translationExercise(['noun', 'verb'], 10, {
+        wordSource: 'pool',
+        poolId: 'noun-pool',
+      }),
+      poolId: 'noun-pool',
+      rng: createGeneratedExerciseRng(18),
+    });
+
+    expect(result.words).toHaveLength(10);
+    expect(result.words.every(word => word.part_of_speech === 'noun')).toBe(true);
+    expect(result.diagnostics.find(entry => entry.specId === 'noun')?.collected).toBe(10);
+  });
+
+  it('charges non-matching pool documents against the global scan budget', async () => {
+    const words = Array.from({ length: 2100 }, (_, index) => verbDoc(`verb-${index}`));
+    const db = createFakeGeneratedWordDb({
+      words,
+      pools: [{ id: 'verb-pool', wordDocIds: words.map(word => word.id) }],
+    });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [{ id: 'noun', partOfSpeech: 'noun', filters: {} }],
+      count: 100,
+      exercise: translationExercise(['noun'], 100, {
+        wordSource: 'pool',
+        poolId: 'verb-pool',
+      }),
+      poolId: 'verb-pool',
+      rng: createGeneratedExerciseRng(19),
+    });
+
+    expect(result.words).toHaveLength(0);
+    expect(result.diagnostics[0]?.scanned).toBe(2000);
+    expect(result.diagnostics[0]?.scanLimitReached).toBe(false);
+    expect(result.globalScanLimitReached).toBe(true);
+  });
+
   it('stops a sparse pool POS scan at the per-spec ceiling instead of walking the whole ID list', async () => {
     const nouns = Array.from({ length: 600 }, (_, index) => nounDoc(`noun-${index}`));
     const verbs = Array.from({ length: 4 }, (_, index) => verbDoc(`verb-${index}`));

--- a/tests/morphologyWordReplenishment.test.ts
+++ b/tests/morphologyWordReplenishment.test.ts
@@ -1,0 +1,666 @@
+jest.mock('firebase-admin/firestore', () => ({ FieldPath: { documentId: jest.fn(() => '__name__') } }));
+
+import { createFakeGeneratedWordDb, type FakeDocument } from './helpers/fakeGeneratedWordFirestore';
+import {
+  allocateFairShares,
+  collectGeneratedExerciseWords,
+  createGeneratedExerciseRng,
+  PER_SPEC_SCAN_FLOOR,
+  perSpecScanCeiling,
+} from '@/src/lib/tests/generated-word-composition.server';
+import { createFirestoreGeneratedWordLoader } from '@/src/lib/tests/generated-word-loader.server';
+import {
+  isUsableGeneratedTranslationWord,
+  resolveGeneratedExerciseItems,
+} from '@/src/lib/tests/generated-exercises';
+import type { GeneratedFormIdentificationExercise, GeneratedTranslationExercise } from '@/src/types/exercises';
+import { isRejectedBySpecAwarePronounOverlap } from '@/src/utils/generated/pronounParadigmFiltering';
+
+const translationExercise = (
+  pos: string[],
+  count: number | 'all',
+  extras: Partial<GeneratedTranslationExercise['data']['generatorConfig']> = {}
+): GeneratedTranslationExercise =>
+  ({
+    type: 'generated-translation',
+    translationDirection: 'latin-to-english',
+    data: {
+      generatorConfig: { collection: 'vocabulary_words_v5', wordSource: 'filters', count, ...extras },
+      posConfigs: Object.fromEntries(pos.map(partOfSpeech => [partOfSpeech, { enabled: true, filters: {} }])),
+    },
+  }) as GeneratedTranslationExercise;
+
+const morphologyExercise = (
+  paradigms: GeneratedFormIdentificationExercise['data']['paradigmConfigs'],
+  count: number | 'all' = 10
+): GeneratedFormIdentificationExercise =>
+  ({
+    type: 'generated-form-identification',
+    data: {
+      mode: 'step-by-step',
+      generatorConfig: { collection: 'vocabulary_words_v5', wordSource: 'filters', count },
+      paradigmConfigs: paradigms,
+    },
+  }) as GeneratedFormIdentificationExercise;
+
+const nounDoc = (id: string, extras: Record<string, unknown> = {}): FakeDocument => ({
+  id,
+  data: {
+    word: id,
+    part_of_speech: 'noun',
+    translation: 'girl',
+    random_index: 0.5,
+    sort_key: id,
+    declension_table: { singular: { nominative: [id] } },
+    ...extras,
+  },
+});
+
+const verbDoc = (id: string, extras: Record<string, unknown> = {}): FakeDocument => ({
+  id,
+  data: {
+    word: id,
+    part_of_speech: 'verb',
+    translation: 'love',
+    random_index: 0.5,
+    sort_key: id,
+    conjugation_table: {
+      indicative: { active: { present: { singular: { first: [id] } } } },
+    },
+    ...extras,
+  },
+});
+
+describe('generated exercise word replenishment', () => {
+  it('returns exactly count usable words from a mixed fixture', async () => {
+    const words = [
+      ...Array.from({ length: 8 }, (_, index) => nounDoc(`noun-${index}`)),
+      ...Array.from({ length: 8 }, (_, index) => verbDoc(`verb-${index}`)),
+    ];
+    const db = createFakeGeneratedWordDb({ words });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        { id: 'noun', partOfSpeech: 'noun', filters: {} },
+        { id: 'verb', partOfSpeech: 'verb', filters: {} },
+      ],
+      count: 10,
+      exercise: translationExercise(['noun', 'verb'], 10),
+      rng: createGeneratedExerciseRng(1),
+    });
+
+    expect(result.words).toHaveLength(10);
+  });
+
+  it('continues scanning after ineligible candidates instead of stopping at fetch-N-then-filter', async () => {
+    const words = [
+      ...Array.from({ length: 5 }, (_, index) => nounDoc(`aaa-reject-${index}`, { declension_table: {} })),
+      ...Array.from({ length: 12 }, (_, index) => nounDoc(`noun-${index}`)),
+    ];
+    const db = createFakeGeneratedWordDb({ words });
+    const formSelection = { tableType: 'declension' as const, selectedCellPaths: ['singular.nominative'] };
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        {
+          id: 'noun-declension',
+          paradigm: 'noun-declension',
+          partOfSpeech: 'noun',
+          filters: {},
+          tableType: 'declension',
+          steps: ['case'],
+          formSelection,
+        },
+      ],
+      count: 10,
+      exercise: morphologyExercise(
+        {
+          'noun-declension': {
+            enabled: true,
+            filters: {},
+            steps: ['case'],
+            formSelection,
+          },
+        },
+        10
+      ),
+      rng: createGeneratedExerciseRng(1),
+    });
+
+    expect(result.words).toHaveLength(10);
+    expect(result.words.every(word => word.id.startsWith('noun-'))).toBe(true);
+    expect(result.diagnostics[0].scanned).toBeGreaterThan(10);
+  });
+
+  it('returns all eligible words when the source is smaller than count', async () => {
+    const db = createFakeGeneratedWordDb({
+      words: [nounDoc('n1'), nounDoc('n2'), verbDoc('v1')],
+    });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        { id: 'noun', partOfSpeech: 'noun', filters: {} },
+        { id: 'verb', partOfSpeech: 'verb', filters: {} },
+      ],
+      count: 10,
+      exercise: translationExercise(['noun', 'verb'], 10),
+      rng: createGeneratedExerciseRng(2),
+    });
+
+    expect(result.words).toHaveLength(3);
+    expect(result.diagnostics.every(entry => entry.exhausted)).toBe(true);
+  });
+
+  it('borrows from a rich spec when a sparse spec cannot fill its share', async () => {
+    const db = createFakeGeneratedWordDb({
+      words: [nounDoc('n1'), ...Array.from({ length: 12 }, (_, index) => verbDoc(`verb-${index}`))],
+    });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        { id: 'noun', partOfSpeech: 'noun', filters: {} },
+        { id: 'verb', partOfSpeech: 'verb', filters: {} },
+      ],
+      count: 10,
+      exercise: translationExercise(['noun', 'verb'], 10),
+      rng: createGeneratedExerciseRng(3),
+    });
+
+    expect(result.words).toHaveLength(10);
+    const byPos = result.words.reduce<Record<string, number>>((counts, word) => {
+      const pos = String(word.part_of_speech);
+      counts[pos] = (counts[pos] ?? 0) + 1;
+      return counts;
+    }, {});
+    expect(byPos.noun).toBe(1);
+    expect(byPos.verb).toBe(9);
+  });
+
+  it('honors fair shares for two healthy paradigms', async () => {
+    const db = createFakeGeneratedWordDb({
+      words: [
+        ...Array.from({ length: 12 }, (_, index) => nounDoc(`noun-${index}`)),
+        ...Array.from({ length: 12 }, (_, index) => verbDoc(`verb-${index}`)),
+      ],
+    });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        { id: 'noun', partOfSpeech: 'noun', filters: {} },
+        { id: 'verb', partOfSpeech: 'verb', filters: {} },
+      ],
+      count: 10,
+      exercise: translationExercise(['noun', 'verb'], 10),
+      rng: createGeneratedExerciseRng(4),
+    });
+
+    const byPos = result.words.reduce<Record<string, number>>((counts, word) => {
+      const pos = String(word.part_of_speech);
+      counts[pos] = (counts[pos] ?? 0) + 1;
+      return counts;
+    }, {});
+    expect(byPos.noun).toBe(5);
+    expect(byPos.verb).toBe(5);
+  });
+
+  it('assigns remainders deterministically from a seeded rng', () => {
+    const rng = createGeneratedExerciseRng(42);
+    expect(allocateFairShares(5, 2, rng)).toEqual(allocateFairShares(5, 2, createGeneratedExerciseRng(42)));
+    expect(allocateFairShares(5, 2, createGeneratedExerciseRng(42)).reduce((sum, value) => sum + value, 0)).toBe(2);
+    expect(allocateFairShares(5, 2, createGeneratedExerciseRng(42)).filter(value => value > 0)).toHaveLength(2);
+  });
+
+  it('keeps count: all matching semantics', async () => {
+    const db = createFakeGeneratedWordDb({
+      words: [nounDoc('n1'), nounDoc('n2'), verbDoc('v1')],
+    });
+    const words = await createFirestoreGeneratedWordLoader(db as never, { rng: createGeneratedExerciseRng(5) })(
+      translationExercise(['noun', 'verb'], 'all')
+    );
+    expect(words).toHaveLength(3);
+  });
+
+  it('stops at the per-spec scan ceiling and flags scanLimitReached', async () => {
+    const db = createFakeGeneratedWordDb({
+      words: Array.from({ length: 500 }, (_, index) => nounDoc(`noun-${index}`, { translation: '' })),
+    });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [{ id: 'noun', partOfSpeech: 'noun', filters: {} }],
+      count: 10,
+      exercise: translationExercise(['noun'], 10),
+      rng: createGeneratedExerciseRng(6),
+    });
+
+    expect(result.words).toHaveLength(0);
+    expect(result.diagnostics[0]?.scanLimitReached).toBe(true);
+    expect(result.diagnostics[0]?.scanned).toBeLessThanOrEqual(Math.max(PER_SPEC_SCAN_FLOOR, 400));
+  });
+
+  it('does not let many sparse paradigms exceed the global scan budget', async () => {
+    const parts = ['noun', 'verb', 'adjective', 'adverb', 'preposition', 'conjunction', 'interjection', 'pronoun'];
+    const words = parts.flatMap(partOfSpeech =>
+      Array.from({ length: 400 }, (_, index) => ({
+        id: `${partOfSpeech}-${index}`,
+        data: {
+          word: `${partOfSpeech}-${index}`,
+          part_of_speech: partOfSpeech,
+          random_index: 0.5,
+          sort_key: `${partOfSpeech}-${index}`,
+        },
+      }))
+    );
+    const db = createFakeGeneratedWordDb({ words });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: parts.map(partOfSpeech => ({ id: partOfSpeech, partOfSpeech, filters: {} })),
+      count: 10,
+      exercise: translationExercise(parts, 10),
+      rng: createGeneratedExerciseRng(7),
+    });
+
+    const scanned = result.diagnostics.reduce((sum, entry) => sum + entry.scanned, 0);
+    expect(scanned).toBeLessThanOrEqual(2000);
+    expect(result.globalScanLimitReached).toBe(true);
+  });
+
+  it('uses a first batch equal to the remaining share for a dense small-count query', async () => {
+    const limitCalls: number[] = [];
+    const db = createFakeGeneratedWordDb({
+      words: Array.from({ length: 20 }, (_, index) => nounDoc(`noun-${index}`)),
+      limitCalls,
+    });
+    await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [{ id: 'noun', partOfSpeech: 'noun', filters: {} }],
+      count: 10,
+      exercise: translationExercise(['noun'], 10),
+      rng: createGeneratedExerciseRng(8),
+    });
+
+    expect(limitCalls[0]).toBe(10);
+  });
+
+  it('does not skip documents that share a sort_key across a search page boundary', async () => {
+    const words = Array.from({ length: 6 }, (_, index) =>
+      nounDoc(`puella-${index}`, { sort_key: 'puella', random_index: index / 10 })
+    );
+    const db = createFakeGeneratedWordDb({ words });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [{ id: 'noun', partOfSpeech: 'noun', filters: { search: 'puella' } }],
+      count: 6,
+      exercise: translationExercise(['noun'], 6),
+      rng: createGeneratedExerciseRng(9),
+    });
+
+    expect(result.words).toHaveLength(6);
+  });
+
+  it('does not skip documents that share random_index across the wrap boundary', async () => {
+    const words = Array.from({ length: 8 }, (_, index) => nounDoc(`noun-${index}`, { random_index: 0.5 }));
+    const db = createFakeGeneratedWordDb({ words });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [{ id: 'noun', partOfSpeech: 'noun', filters: {} }],
+      count: 8,
+      exercise: translationExercise(['noun'], 8),
+      rng: createGeneratedExerciseRng(10),
+    });
+
+    expect(result.words).toHaveLength(8);
+  });
+
+  it('allows the same word id from two specs', async () => {
+    const shared = nounDoc('shared', { part_of_speech: 'noun', translation: 'girl' });
+    const db = createFakeGeneratedWordDb({ words: [shared] });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        { id: 'one', partOfSpeech: 'noun', filters: {} },
+        { id: 'two', partOfSpeech: 'noun', filters: {} },
+      ],
+      count: 2,
+      exercise: translationExercise(['noun'], 2),
+      rng: createGeneratedExerciseRng(11),
+    });
+
+    expect(result.words.map(word => word.id)).toEqual(['shared', 'shared']);
+  });
+
+  it('skips morphology words that map but cannot be prepared', async () => {
+    const db = createFakeGeneratedWordDb({
+      words: [
+        verbDoc('amo'),
+        nounDoc('puella'),
+        verbDoc('laudo'),
+      ],
+    });
+    const exercise = morphologyExercise(
+      {
+        'verb-conjugation': {
+          enabled: true,
+          filters: {},
+          steps: ['gender'],
+          formSelection: {
+            tableType: 'conjugation',
+            selectedCellPaths: ['indicative.active.present.singular.first'],
+          },
+        },
+      },
+      10
+    );
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        {
+          id: 'verb-conjugation',
+          paradigm: 'verb-conjugation',
+          partOfSpeech: 'verb',
+          filters: {},
+          tableType: 'conjugation',
+          formSelection: {
+            tableType: 'conjugation',
+            selectedCellPaths: ['indicative.active.present.singular.first'],
+          },
+        },
+      ],
+      count: 10,
+      exercise,
+      rng: createGeneratedExerciseRng(12),
+    });
+
+    expect(result.words).toHaveLength(0);
+  });
+
+  it('keeps personal-paradigm pronouns when a broad gendered spec is also enabled', async () => {
+    const ego: FakeDocument = {
+      id: 'ego',
+      data: {
+        word: 'ego',
+        part_of_speech: 'pronoun',
+        pronoun_type: 'personal',
+        person: '1st',
+        translation: 'I',
+        random_index: 0.2,
+        sort_key: 'ego',
+        declension_table: { singular: { nominative: ['ego'] } },
+      },
+    };
+    const is: FakeDocument = {
+      id: 'is',
+      data: {
+        word: 'is',
+        part_of_speech: 'pronoun',
+        pronoun_type: 'personal',
+        person: '3rd',
+        translation: 'he',
+        random_index: 0.3,
+        sort_key: 'is',
+        declension_table: { masculine: { singular: { nominative: ['is'] } } },
+      },
+    };
+    expect(
+      isRejectedBySpecAwarePronounOverlap(
+        ego.data,
+        'pronoun-gendered',
+        {
+          'pronoun-gendered': { enabled: true, steps: ['case'], filters: {} },
+          'pronoun-personal': { enabled: true, steps: ['case'], filters: {} },
+        }
+      )
+    ).toBe(true);
+    expect(
+      isRejectedBySpecAwarePronounOverlap(ego.data, 'pronoun-personal', {
+        'pronoun-gendered': { enabled: true, steps: ['case'], filters: {} },
+        'pronoun-personal': { enabled: true, steps: ['case'], filters: {} },
+      })
+    ).toBe(false);
+
+    const db = createFakeGeneratedWordDb({ words: [ego, is] });
+    const exercise = morphologyExercise(
+      {
+        'pronoun-personal': {
+          enabled: true,
+          filters: {},
+          steps: ['case', 'number'],
+          formSelection: { tableType: 'pronoun-declension', selectedCellPaths: ['singular.nominative'] },
+        },
+        'pronoun-gendered': {
+          enabled: true,
+          filters: {},
+          steps: ['case', 'number'],
+          formSelection: {
+            tableType: 'pronoun-adjective-declension',
+            selectedCellPaths: ['masculine.singular.nominative'],
+          },
+        },
+      },
+      2
+    );
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        {
+          id: 'pronoun-personal',
+          paradigm: 'pronoun-personal',
+          partOfSpeech: 'pronoun',
+          filters: { pronounType: 'personal', pronounPerson: '1st,2nd' },
+          tableType: 'pronoun-declension',
+          steps: ['case', 'number'],
+          formSelection: { tableType: 'pronoun-declension', selectedCellPaths: ['singular.nominative'] },
+        },
+        {
+          id: 'pronoun-gendered',
+          paradigm: 'pronoun-gendered',
+          partOfSpeech: 'pronoun',
+          filters: {},
+          tableType: 'pronoun-adjective-declension',
+          steps: ['case', 'number'],
+          formSelection: {
+            tableType: 'pronoun-adjective-declension',
+            selectedCellPaths: ['masculine.singular.nominative'],
+          },
+        },
+      ],
+      count: 2,
+      exercise,
+      rng: createGeneratedExerciseRng(13),
+    });
+
+    expect(result.words.some(word => word.id === 'ego')).toBe(true);
+  });
+
+  it('drops translation candidates missing a translation or root word', async () => {
+    const db = createFakeGeneratedWordDb({
+      words: [
+        nounDoc('missing-translation', { translation: '' }),
+        nounDoc('missing-root', { word: '', translation: 'girl' }),
+        nounDoc('ok'),
+      ],
+    });
+    const latin = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [{ id: 'noun', partOfSpeech: 'noun', filters: {} }],
+      count: 10,
+      exercise: translationExercise(['noun'], 10),
+      rng: createGeneratedExerciseRng(14),
+    });
+    expect(latin.words.map(word => word.id)).toEqual(['ok']);
+
+    const englishToLatin = {
+      ...translationExercise(['noun'], 10),
+      translationDirection: 'english-to-latin' as const,
+    };
+    const reverse = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [{ id: 'noun', partOfSpeech: 'noun', filters: {} }],
+      count: 10,
+      exercise: englishToLatin,
+      rng: createGeneratedExerciseRng(15),
+    });
+    expect(reverse.words.map(word => word.id)).toEqual(['ok']);
+  });
+
+  it('rejects latin-to-english words whose display form is blank', () => {
+    const exercise = translationExercise(['noun'], 1);
+    expect(
+      isUsableGeneratedTranslationWord(exercise, {
+        id: 'blank',
+        root_word: '',
+        dictionary_entry: null,
+        selected_form: '',
+        part_of_speech: 'noun',
+        form_path: null,
+        translation: 'girl',
+      })
+    ).toBe(false);
+    expect(
+      isUsableGeneratedTranslationWord(exercise, {
+        id: 'ok',
+        root_word: 'puella',
+        dictionary_entry: 'puella',
+        selected_form: 'puella',
+        part_of_speech: 'noun',
+        form_path: null,
+        translation: 'girl',
+      })
+    ).toBe(true);
+  });
+
+  it('resolves exactly N frozen words and more than N step-by-step items', async () => {
+    const db = createFakeGeneratedWordDb({
+      words: Array.from({ length: 12 }, (_, index) =>
+        nounDoc(`noun-${index}`, {
+          declension_table: { singular: { nominative: [`noun-${index}`] } },
+        })
+      ),
+    });
+    const exercise = morphologyExercise(
+      {
+        'noun-declension': {
+          enabled: true,
+          filters: {},
+          steps: ['case', 'number'],
+          formSelection: { tableType: 'declension', selectedCellPaths: ['singular.nominative'] },
+        },
+      },
+      4
+    );
+    const items = await resolveGeneratedExerciseItems(
+      exercise,
+      createFirestoreGeneratedWordLoader(db as never, { rng: createGeneratedExerciseRng(16) })
+    );
+    const wordIds = new Set(items.map(item => ('wordId' in item ? item.wordId : item.text)));
+    expect(wordIds.size).toBe(4);
+    expect(items.length).toBeGreaterThan(4);
+  });
+
+  it('caps pool sampling to a shared universe and consumes missing ids without extending it', async () => {
+    const ids = [...Array.from({ length: 8 }, (_, index) => `noun-${index}`), 'missing-id'];
+    const db = createFakeGeneratedWordDb({
+      words: Array.from({ length: 8 }, (_, index) => nounDoc(`noun-${index}`)),
+      pools: [{ id: 'pool-1', wordDocIds: ids }],
+    });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        { id: 'noun', partOfSpeech: 'noun', filters: {} },
+        { id: 'verb', partOfSpeech: 'verb', filters: {} },
+        { id: 'adjective', partOfSpeech: 'adjective', filters: {} },
+      ],
+      count: 20,
+      exercise: {
+        ...translationExercise(['noun', 'verb', 'adjective'], 20, {
+          wordSource: 'pool',
+          poolId: 'pool-1',
+          poolWordLimit: 5,
+        }),
+      },
+      poolId: 'pool-1',
+      poolWordLimit: 5,
+      rng: createGeneratedExerciseRng(17),
+    });
+
+    expect(result.words.length).toBeLessThanOrEqual(5);
+    expect(new Set(result.words.map(word => word.id)).size).toBeLessThanOrEqual(5);
+  });
+
+  it('stops a sparse pool POS scan at the per-spec ceiling instead of walking the whole ID list', async () => {
+    const nouns = Array.from({ length: 600 }, (_, index) => nounDoc(`noun-${index}`));
+    const verbs = Array.from({ length: 4 }, (_, index) => verbDoc(`verb-${index}`));
+    const words = [...nouns, ...verbs];
+    const ids = words.map(word => word.id);
+    const db = createFakeGeneratedWordDb({
+      words,
+      pools: [{ id: 'mixed-pool', wordDocIds: ids }],
+    });
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        { id: 'noun', partOfSpeech: 'noun', filters: {} },
+        { id: 'verb', partOfSpeech: 'verb', filters: {} },
+      ],
+      count: 10,
+      exercise: {
+        ...translationExercise(['noun', 'verb'], 10, {
+          wordSource: 'pool',
+          poolId: 'mixed-pool',
+        }),
+      },
+      poolId: 'mixed-pool',
+      rng: createGeneratedExerciseRng(18),
+    });
+
+    const verbShare = 5;
+    const verb = result.diagnostics.find(entry => entry.specId === 'verb');
+    expect(verb).toBeDefined();
+    expect(perSpecScanCeiling(verbShare)).toBe(PER_SPEC_SCAN_FLOOR);
+    expect(verb?.scanned).toBeLessThanOrEqual(perSpecScanCeiling(verbShare));
+    expect(verb?.scanned).toBeLessThan(ids.length);
+    expect(verb?.scanLimitReached).toBe(true);
+    expect(result.words.length).toBeLessThanOrEqual(10);
+  });
+
+  it('replays the same seeded rng to the same word set', async () => {
+    const db = createFakeGeneratedWordDb({
+      words: [
+        ...Array.from({ length: 8 }, (_, index) => nounDoc(`noun-${index}`, { random_index: index / 10 })),
+        ...Array.from({ length: 8 }, (_, index) => verbDoc(`verb-${index}`, { random_index: index / 10 })),
+      ],
+    });
+    const collect = () =>
+      collectGeneratedExerciseWords({
+        db: db as never,
+        collection: 'vocabulary_words_v5',
+        specs: [
+          { id: 'noun', partOfSpeech: 'noun', filters: {} },
+          { id: 'verb', partOfSpeech: 'verb', filters: {} },
+        ],
+        count: 10,
+        exercise: translationExercise(['noun', 'verb'], 10),
+        rng: createGeneratedExerciseRng(99),
+      });
+
+    const first = await collect();
+    const second = await collect();
+    expect(first.words.map(word => word.id)).toEqual(second.words.map(word => word.id));
+  });
+});

--- a/tests/runtimeModeScoring.test.tsx
+++ b/tests/runtimeModeScoring.test.tsx
@@ -15,6 +15,7 @@ jest.mock('@/src/components/ui/core/simple-rich-editor', () => ({ SimpleRichEdit
 jest.mock('@/src/hooks/useTranslationGrading', () => ({ useTranslationGrading: () => ({}) }));
 const mockUseGetMultiPosWordsQuery = jest.fn();
 jest.mock('@/src/store/api/advancedVocabularyApi', () => ({
+  useGetGeneratedExerciseWordsQuery: (...args: unknown[]) => mockUseGetMultiPosWordsQuery(...args),
   useGetMultiPosWordsQuery: (...args: unknown[]) => mockUseGetMultiPosWordsQuery(...args),
   useGetMultiParadigmWordsQuery: () => ({ data: undefined, isLoading: false, isError: false }),
 }));

--- a/tests/runtimeModeScoring.test.tsx
+++ b/tests/runtimeModeScoring.test.tsx
@@ -293,7 +293,50 @@ describe('exercise runtime-mode scoring', () => {
 
     render(<ContentRenderer content={exercise} runtimeMode="test" allowGeneratedExerciseQueries />);
 
-    expect(mockUseGetMultiPosWordsQuery).toHaveBeenCalled();
+    expect(mockUseGetMultiPosWordsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        exercise: expect.objectContaining({ type: 'generated-translation' }),
+        source: { kind: 'admin-preview' },
+      }),
+      expect.objectContaining({ skip: false })
+    );
     expect(screen.getByText('No vocabulary found')).toBeInTheDocument();
+  });
+
+  it('scopes generated lesson queries to the rendered lesson item', () => {
+    mockUseGetMultiPosWordsQuery.mockReturnValue({ data: { words: [] }, isLoading: false, isError: false });
+    const exercise: GeneratedTranslationExercise = {
+      id: 'generated-lesson-exercise',
+      type: 'generated-translation',
+      title: 'Generated translation',
+      instructions: '',
+      feedbackConfig: manualProgression,
+      data: {
+        generatorConfig: { collection: 'words', wordSource: 'filters', count: 1 },
+        posConfigs: {},
+      },
+    };
+
+    render(
+      <ContentRenderer
+        content={exercise}
+        pageIndex={2}
+        itemIndex={3}
+        generatedExerciseContext={{ kind: 'lesson', lessonId: 'lesson-1' }}
+      />
+    );
+
+    expect(mockUseGetMultiPosWordsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: {
+          kind: 'lesson',
+          lessonId: 'lesson-1',
+          pageIndex: 2,
+          itemIndex: 3,
+          exerciseId: 'generated-lesson-exercise',
+        },
+      }),
+      expect.objectContaining({ skip: false })
+    );
   });
 });

--- a/tests/testDeliveryRendering.test.tsx
+++ b/tests/testDeliveryRendering.test.tsx
@@ -18,6 +18,7 @@ import type {
 import { createAnnotationId, createEmptySentenceDiagramDocument } from '@/src/features/sentence-diagramming';
 
 jest.mock('@/src/store/api/advancedVocabularyApi', () => ({
+  useGetGeneratedExerciseWordsQuery: () => ({ data: undefined, isLoading: false, isError: false }),
   useGetMultiPosWordsQuery: () => ({ data: undefined, isLoading: false, isError: false }),
   useGetMultiParadigmWordsQuery: () => ({ data: undefined, isLoading: false, isError: false }),
 }));

--- a/tests/testGradingFoundation.test.ts
+++ b/tests/testGradingFoundation.test.ts
@@ -14,7 +14,7 @@ import {
 } from '@/src/lib/tests/grading';
 import { estimateFirestoreDocumentBytes } from '@/src/lib/tests/firestore-size';
 import { applyValueFilter } from '@/src/lib/tests/generated-word-loader.server';
-import { filterOverlappingPronounParadigms } from '@/src/utils/generated/pronounParadigmFiltering';
+import { filterOverlappingPronounParadigms, isRejectedBySpecAwarePronounOverlap } from '@/src/utils/generated/pronounParadigmFiltering';
 import type {
   FillExercise,
   Exercise,
@@ -124,6 +124,13 @@ describe('test grading foundation', () => {
     expect(query.where).not.toHaveBeenCalled();
   });
 
+  it('ignores non-string filter values instead of throwing', () => {
+    const query = { where: jest.fn() } as unknown as Parameters<typeof applyValueFilter>[0];
+
+    expect(applyValueFilter(query, 'conjugation', 3 as never)).toBe(query);
+    expect(query.where).not.toHaveBeenCalled();
+  });
+
   it('uses a conservative Firestore-aware document size estimate', () => {
     const document = { numericValues: Array.from({ length: 20 }, (_, index) => index) };
 
@@ -145,6 +152,12 @@ describe('test grading foundation', () => {
 
     expect(filterOverlappingPronounParadigms(words, broad).map(word => word.id)).toEqual(['third', 'relative']);
     expect(filterOverlappingPronounParadigms(words, personalOnly)).toEqual(words);
+    expect(
+      isRejectedBySpecAwarePronounOverlap(words[0], 'pronoun-personal', broad as Parameters<typeof isRejectedBySpecAwarePronounOverlap>[2])
+    ).toBe(false);
+    expect(
+      isRejectedBySpecAwarePronounOverlap(words[0], 'pronoun-gendered', broad as Parameters<typeof isRejectedBySpecAwarePronounOverlap>[2])
+    ).toBe(true);
   });
 
   it('normalizes single-field morphology credit to the authored max points', () => {

--- a/tests/testVersionExerciseValidation.test.ts
+++ b/tests/testVersionExerciseValidation.test.ts
@@ -263,6 +263,13 @@ describe('active test exercise validation', () => {
     expect(messagesFor(morphology)).toContain('Enabled morphology paradigms require at least one selected form');
   });
 
+  it('rejects generated word counts above the shared authoring ceiling', () => {
+    const translation = copyItem(validItems['generated-translation']);
+    (translation.data.generatorConfig as { count: number }).count = 201;
+
+    expect(activeVersionResult(translation).success).toBe(false);
+  });
+
   it('accepts legacy generated configurations when they still resolve scorable items', () => {
     const translation = copyItem(validItems['generated-translation']);
     delete translation.data.posConfigs;


### PR DESCRIPTION
## Summary
- Generated translation and morphology exercises now treat authored `count` as a word quota: eligible candidates are scanned and replenished (with fair multi-paradigm shares) instead of stopping after the first ineligible batch.
- Admin preview and student playback use the same bounded collector, so draft preview matches delivery semantics and surfaces per-spec diagnostics when a configuration is too sparse.
- Preview is a dedicated mutation with staleness fingerprinting, and generated counts above 200 are rejected at authoring time.

## Test plan
- [ ] Create a generated translation exercise with count 10 and mixed POS; preview should show 10 usable words and balanced diagnostics.
- [ ] Create a generated form-identification exercise with sparse cell selection; preview should either fill the count or show exhausted/scan-limit diagnostics rather than silently returning fewer items.
- [ ] Play the same exercises as a student and confirm item counts match preview for healthy configs.
- [ ] Confirm `count: all` still loads the full eligible set in preview and playback.
- [ ] Confirm unauthenticated preview is rejected and student playback still requires auth.
- [ ] `npm test -- --runInBand tests/morphologyWordReplenishment.test.ts tests/generatedExercisePreviewRoute.test.ts tests/generatedExercisePlaybackRoute.test.ts tests/generatedExerciseEditorPreview.test.ts tests/generatedExercisePreviewMutation.test.ts tests/testVersionExerciseValidation.test.ts`


Made with [Cursor](https://cursor.com)