### PR TITLE
Fix Manage Lessons title wrapping

### DIFF
--- a/src/components/ui/admin/LessonManager.tsx
+++ b/src/components/ui/admin/LessonManager.tsx
@@ -55,7 +55,6 @@ import {
   AdminSearchInput,
   AdminStatusBadge,
 } from '@/src/components/admin/shell';
-import { cn } from '@/src/lib/utils';
 
 type LessonTab = LessonSummary['type'];
 type LessonType = LessonSummary['type'];
@@ -138,12 +137,8 @@ function LessonDescription({ content }: { content?: string }) {
 
 function LessonTitle({ content }: { content: string }) {
   return (
-    <h3 className="relative min-w-0 flex-1 pr-10 font-serif text-xl leading-5 tracking-tight text-foreground">
+    <h3 className="min-w-0 flex-1 font-serif text-xl leading-5 tracking-tight text-foreground">
       <SimpleRichDisplay content={content} className="!block break-words whitespace-normal" />
-      <div
-        className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-white via-white/95 to-transparent"
-        aria-hidden="true"
-      />
     </h3>
   );
 }
@@ -332,18 +327,18 @@ export const LessonManager: React.FC<LessonManagerProps> = ({ onEditLesson, onCo
             key={lesson.id}
             className="group flex h-full flex-col overflow-hidden border-border/80 bg-white/95 shadow-sm transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:border-primary/20 hover:shadow-lg motion-reduce:transition-none">
             <CardContent className="flex min-h-0 flex-1 flex-col !p-0">
-              <div className="relative flex flex-1 flex-col gap-5 p-5 sm:p-6">
-                {lesson.isLive && (
-                  <div className="absolute right-5 top-5 z-10 sm:right-6 sm:top-6">
-                    <AdminStatusBadge tone="success">Live</AdminStatusBadge>
-                  </div>
-                )}
-                <div className={cn('flex items-start gap-3', lesson.isLive && 'pr-20 sm:pr-24')}>
+              <div className="flex flex-1 flex-col gap-5 p-5 sm:p-6">
+                <div className="flex items-start gap-3">
                   <AdminIconChip
                     icon={lessonTypeConfig[lesson.type].icon}
                     className={lessonTypeConfig[lesson.type].iconChip}
                   />
                   <div className="min-w-0 flex-1">
+                    {lesson.isLive && (
+                      <div className="mb-2 flex">
+                        <AdminStatusBadge tone="success">Live</AdminStatusBadge>
+                      </div>
+                    )}
                     <LessonTitle content={lesson.title} />
                   </div>
                 </div>

--- a/src/components/ui/admin/LessonManager.tsx
+++ b/src/components/ui/admin/LessonManager.tsx
@@ -321,7 +321,7 @@ export const LessonManager: React.FC<LessonManagerProps> = ({ onEditLesson, onCo
     }
 
     return (
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
         {lessonsList.map(lesson => (
           <Card
             key={lesson.id}
@@ -471,7 +471,7 @@ export const LessonManager: React.FC<LessonManagerProps> = ({ onEditLesson, onCo
               These lessons failed to save previously. You can retry saving them or discard them if no longer needed.
             </p>
           </div>
-          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
             {filteredRecoveryItems.map(item => (
               <Card
                 key={item.id}
@@ -559,7 +559,7 @@ export const LessonManager: React.FC<LessonManagerProps> = ({ onEditLesson, onCo
             <div className="h-8 w-1 rounded-full bg-roman-gold" aria-hidden="true" />
             <h2 className="font-serif text-xl text-foreground">Drafts ({filteredDrafts.length})</h2>
           </div>
-          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
             {filteredDrafts
               .sort(([, a], [, b]) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime())
               .map(([draftKey, draft]) => {


### PR DESCRIPTION
## Summary
- move the live status badge into the lesson card content flow
- remove obsolete title fade/padding that squeezed the title column
- keep lesson grids at two columns through narrow desktop widths, switching to three columns at `xl`
- preserve natural wrapping for genuinely long lesson titles

## Verification
- visually verified `MCS_Lesson XII` at 768px, 1024px, and 1280px viewports
- `npx eslint src/components/ui/admin/LessonManager.tsx`
- `npx tsc --noEmit`
- `git diff --check`