### PR TITLE
Fix lesson page body lagging behind navigation

### DIFF
--- a/src/components/ui/lesson/lesson-player.tsx
+++ b/src/components/ui/lesson/lesson-player.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import * as Sentry from '@sentry/nextjs';
-import { AnimatePresence } from 'framer-motion';
 import { LessonWithProgress } from '@/src/types/lesson';
 import { BookOpen, Headphones, CheckCircle } from 'lucide-react';
 import { RomanPlayerShell } from '@/src/components/ui/core/roman-player-shell';
@@ -555,21 +554,19 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
         }>
         <div className="mb-6">
           <div className="lesson-content">
-            <AnimatePresence mode="wait">
-              <PageTemplate
-                key={currentPage.id}
-                page={currentPage}
-                pageIndex={currentPageIndex}
-                lessonId={lesson.id}
-                runtimeMode={effectiveRuntimeMode}
-                onAnswer={onAnswer}
-                resolvedExerciseState={resolvedExerciseState}
-                generatedExerciseContext={resolvedGeneratedExerciseContext}
-                onCompletionAccepted={handleCompletionAccepted}
-                onPageComplete={handlePageComplete}
-                onDiagrammingAttempt={handleDiagrammingAttempt}
-              />
-            </AnimatePresence>
+            <PageTemplate
+              key={currentPage.id}
+              page={currentPage}
+              pageIndex={currentPageIndex}
+              lessonId={lesson.id}
+              runtimeMode={effectiveRuntimeMode}
+              onAnswer={onAnswer}
+              resolvedExerciseState={resolvedExerciseState}
+              generatedExerciseContext={resolvedGeneratedExerciseContext}
+              onCompletionAccepted={handleCompletionAccepted}
+              onPageComplete={handlePageComplete}
+              onDiagrammingAttempt={handleDiagrammingAttempt}
+            />
           </div>
         </div>
 

--- a/src/components/ui/lesson/page-template.tsx
+++ b/src/components/ui/lesson/page-template.tsx
@@ -91,7 +91,6 @@ export const PageTemplate: React.FC<PageTemplateProps> = ({
       key={page.id}
       initial={{ opacity: 0, x: 20 }}
       animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: -20 }}
       transition={{ duration: 0.3 }}
       className="space-y-6">
       {page.title && (

--- a/tests/lessonPlayerCompletionTracking.test.tsx
+++ b/tests/lessonPlayerCompletionTracking.test.tsx
@@ -32,6 +32,19 @@ const mockMarkExerciseComplete = jest.fn();
 const mockUpdatePageProgress = jest.fn();
 const mockFinishLesson = jest.fn();
 
+jest.mock('framer-motion', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    AnimatePresence: ({ children, mode }: { children: React.ReactNode; mode?: string }) => {
+      // Model the exit window where wait mode retains the previous page body.
+      const renderedChild = React.useRef(children);
+      if (mode !== 'wait') renderedChild.current = children;
+      return renderedChild.current;
+    },
+  };
+});
+
 jest.mock('@/src/store/api/lessonApi', () => ({
   useMarkExerciseCompleteMutation: jest.fn(),
   useUpdatePageProgressMutation: jest.fn(),
@@ -184,6 +197,18 @@ afterEach(() => {
 });
 
 describe('LessonPlayer accepted completion tracking', () => {
+  it('replaces the page body immediately when navigation advances the counter', () => {
+    render(<LessonPlayer lesson={createLesson(2)} trackProgress={false} />);
+
+    expect(screen.getByText('Page content: page-1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+
+    expect(screen.getByText('Progress 100%')).toBeInTheDocument();
+    expect(screen.getByText('Page content: page-2')).toBeInTheDocument();
+    expect(screen.queryByText('Page content: page-1')).not.toBeInTheDocument();
+  });
+
   it('renders a noninteractive ring from server counts and applies successful updates', async () => {
     render(
       <LessonPlayer


### PR DESCRIPTION
## Summary

- replace the waiting exit transition so the next page body mounts immediately with the updated counter
- preserve the incoming page fade/slide animation
- add a regression test that models the wait-mode exit window and asserts the counter and body advance together

## Verification

- npm test -- --runInBand tests/lessonPlayerCompletionTracking.test.tsx tests/lessonPlayerPreview.test.tsx tests/lessonNavigation.test.tsx tests/lessonPageNavigation.test.tsx
- npx tsc --noEmit
- npx eslint src/components/ui/lesson/lesson-player.tsx src/components/ui/lesson/page-template.tsx tests/lessonPlayerCompletionTracking.test.tsx
- git diff --check