### PR TITLE
Fix responsive lesson and admin UI regressions

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -471,7 +471,7 @@ export default function DashboardPage() {
                   </RomanCardContent>
                 </RomanCard>
               ) : (
-                <div className="relative ">
+                <div className="relative overflow-hidden">
                   <Swiper
                     spaceBetween={0}
                     slidesPerView={1}
@@ -483,7 +483,7 @@ export default function DashboardPage() {
                       1024: { slidesPerView: 2 },
                       1280: { slidesPerView: 3 },
                     }}
-                    className="lesson-cards-carousel overflow-visible px-0 py-8 sm:p-8"
+                    className="lesson-cards-carousel overflow-hidden px-0 py-8 sm:p-8"
                     centeredSlides={true}
                     effect="slide">
                     <div slot="container-end">

--- a/src/app/lesson/[lessonId]/page.tsx
+++ b/src/app/lesson/[lessonId]/page.tsx
@@ -80,7 +80,9 @@ export default function DynamicLessonPage() {
     });
   }, [error, isLockedError, lessonId]);
 
-  if (authLoading || !user || lessonsLoading) {
+  const isRequestedLessonLoading = lessonsLoading || Boolean(currentLesson && currentLesson.id !== lessonId);
+
+  if (authLoading || !user || isRequestedLessonLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-roman-marble">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-roman-red"></div>
@@ -194,7 +196,7 @@ export default function DynamicLessonPage() {
           isCollapsed={collapsed.left}
           onToggleCollapse={toggleLeft}
         />
-        <main className="flex-1 overflow-y-auto px-6 pt-6 pb-28">
+        <main className="min-w-0 flex-1 overflow-y-auto px-3 pb-6 pt-4 sm:px-6 sm:pt-6">
           <div className="max-w-3xl mx-auto">
             <LessonPlayer key={currentLesson.id} lesson={currentLesson} />
           </div>

--- a/src/components/admin/shell/AdminSidebar.tsx
+++ b/src/components/admin/shell/AdminSidebar.tsx
@@ -6,7 +6,6 @@ import { usePathname } from 'next/navigation';
 import {
   BookOpen,
   ChevronLeft,
-  ChevronRight,
   ClipboardCheck,
   ClipboardList,
   FileCheck2,
@@ -182,7 +181,6 @@ export function AdminSidebar({ onNavigate, collapsed = false, onToggleCollapse, 
                           )}>
                           {item.label}
                         </span>
-                        {isActive && !collapsed && <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />}
                       </Link>
                     )}
                   </li>

--- a/src/components/ui/admin/LessonManager.tsx
+++ b/src/components/ui/admin/LessonManager.tsx
@@ -326,7 +326,7 @@ export const LessonManager: React.FC<LessonManagerProps> = ({ onEditLesson, onCo
     }
 
     return (
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,22rem),1fr))] gap-5">
         {lessonsList.map(lesson => (
           <Card
             key={lesson.id}

--- a/src/components/ui/admin/lesson-builder/ContentItem.tsx
+++ b/src/components/ui/admin/lesson-builder/ContentItem.tsx
@@ -8,6 +8,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useClipboard } from '../../core/clipboard';
 import { toast } from 'sonner';
 import { getContentTypeLabel } from '@/src/lib/content/registry';
+import { stripHtmlTags } from '@/src/utils/exercises';
 
 interface ContentItemProps {
   item: RenderableContentItem;
@@ -37,6 +38,7 @@ const getContentIcon = (type: string) => {
 export const ContentItem: React.FC<ContentItemProps> = ({ item, onEdit, onRemove, isDraggable = false, meta }) => {
   const Icon = getContentIcon(item.type);
   const typeLabel = getContentTypeLabel(item.type);
+  const accessibleTitle = stripHtmlTags(item.title || typeLabel);
   const { copyItem } = useClipboard();
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -66,6 +68,7 @@ export const ContentItem: React.FC<ContentItemProps> = ({ item, onEdit, onRemove
             variant="ghost"
             size="sm"
             className="cursor-grab active:cursor-grabbing p-0.5 h-5 w-5 text-gray-400 hover:text-gray-600"
+            aria-label={`Reorder ${accessibleTitle}`}
             {...attributes}
             {...listeners}>
             <GripVertical className="h-3 w-3" />
@@ -79,13 +82,29 @@ export const ContentItem: React.FC<ContentItemProps> = ({ item, onEdit, onRemove
       </div>
       <div className="flex items-center gap-0.5">
         {meta}
-        <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={handleCopy} title="Copy content">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          onClick={handleCopy}
+          aria-label={`Copy ${accessibleTitle}`}
+          title="Copy content">
           <Copy className="h-3 w-3" />
         </Button>
-        <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={onEdit}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          onClick={onEdit}
+          aria-label={`Edit ${accessibleTitle}`}>
           <Edit className="h-3 w-3" />
         </Button>
-        <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={onRemove}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          onClick={onRemove}
+          aria-label={`Remove ${accessibleTitle}`}>
           <Trash2 className="h-3 w-3" />
         </Button>
       </div>

--- a/src/components/ui/admin/lesson-builder/PageSection.tsx
+++ b/src/components/ui/admin/lesson-builder/PageSection.tsx
@@ -100,6 +100,7 @@ const SortablePage: React.FC<SortablePageProps> = ({
             variant="ghost"
             size="sm"
             className="cursor-grab active:cursor-grabbing p-0.5 h-6 w-6 text-gray-400 hover:text-gray-600"
+            aria-label={`Reorder page ${pageIndex + 1}`}
             {...attributes}
             {...listeners}>
             <GripVertical className="h-3.5 w-3.5" />
@@ -116,10 +117,20 @@ const SortablePage: React.FC<SortablePageProps> = ({
           />
         </div>
         <div className="flex items-center gap-1">
-          <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => onDuplicatePage(pageIndex)}>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0"
+            onClick={() => onDuplicatePage(pageIndex)}
+            aria-label={`Duplicate page ${pageIndex + 1}`}>
             <Copy className="h-3.5 w-3.5" />
           </Button>
-          <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => onRemovePage(pageIndex)}>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0"
+            onClick={() => onRemovePage(pageIndex)}
+            aria-label={`Remove page ${pageIndex + 1}`}>
             <Trash2 className="h-3.5 w-3.5" />
           </Button>
         </div>

--- a/src/components/ui/admin/vocabulary/VocabularyFilters.tsx
+++ b/src/components/ui/admin/vocabulary/VocabularyFilters.tsx
@@ -47,7 +47,7 @@ export const VocabularyFiltersComponent: React.FC<VocabularyFiltersProps> = ({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
           <div className="space-y-2">
             <Label htmlFor="wordType" className="text-sm font-medium text-gray-700">
               Word Type
@@ -83,7 +83,7 @@ export const VocabularyFiltersComponent: React.FC<VocabularyFiltersProps> = ({
                 placeholder="Search words..."
                 value={filters.search}
                 onChange={e => onFiltersChange({ search: e.target.value })}
-                className="h-9 flex-1 bg-white"
+                className="h-9 min-w-0 flex-1 bg-white"
               />
               <Button type="submit" size="sm" variant="outline" className="px-3" title="Search">
                 <Search className="h-4 w-4" />
@@ -91,7 +91,7 @@ export const VocabularyFiltersComponent: React.FC<VocabularyFiltersProps> = ({
             </form>
           </div>
 
-          <div className="space-y-2">
+          <div className="space-y-2 xl:col-span-2">
             <Label className="text-sm font-medium text-gray-700 opacity-0">Actions</Label>
             <Button
               variant="ghost"

--- a/src/components/ui/admin/vocabulary/WordCard.tsx
+++ b/src/components/ui/admin/vocabulary/WordCard.tsx
@@ -54,9 +54,11 @@ const ExpandableDefinitions: React.FC<{ definitions: string[] }> = ({ definition
           </Button>
         )}
       </div>
-      <ul className="space-y-1">
+      <ul className="divide-y divide-gray-100">
         {visibleDefinitions.map((def, idx) => (
-          <li key={idx} className="text-sm text-gray-600 leading-relaxed flex items-start gap-2">
+          <li
+            key={idx}
+            className="flex items-start gap-2 py-1.5 text-sm leading-relaxed text-gray-600 first:pt-0 last:pb-0">
             <span className="text-gray-400 mt-1 text-xs">{idx + 1}.</span>
             <span className="flex-1">{def}</span>
           </li>

--- a/src/components/ui/core/roman-player-shell.tsx
+++ b/src/components/ui/core/roman-player-shell.tsx
@@ -58,8 +58,8 @@ export function RomanPlayerShell({
                 Page {currentPage} of {totalPages}
               </span>
             </div>
-            <Heading className="truncate font-serif text-2xl leading-tight tracking-wide text-roman-red">
-              {title}
+            <Heading className="min-w-0 overflow-hidden font-serif text-2xl leading-tight tracking-wide text-roman-red">
+              <span className="block truncate [&_*]:inline [&_*]:whitespace-nowrap">{title}</span>
             </Heading>
             {description && (
               <div className="mt-1 line-clamp-2 text-sm leading-relaxed text-roman-stone">{description}</div>

--- a/src/components/ui/lesson/lesson-player.tsx
+++ b/src/components/ui/lesson/lesson-player.tsx
@@ -537,6 +537,7 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
         totalPages={totalPages}
         title={<SimpleRichDisplay content={lesson.title} />}
         description={lesson.description ? <SimpleRichDisplay content={lesson.description} /> : undefined}
+        contentClassName={navigationPlacement === 'fixed' ? 'pb-28 sm:pb-24' : undefined}
         headerAside={
           shouldShowExerciseRing ? (
             <ExerciseCompletionRing

--- a/src/components/ui/lesson/lesson-sidebar.tsx
+++ b/src/components/ui/lesson/lesson-sidebar.tsx
@@ -84,13 +84,12 @@ export default function LessonSidebar({ currentLessonId, isCollapsed = false, on
     [router]
   );
 
-  const EXPANDED_WIDTH = '20rem';
-  const COLLAPSED_WIDTH = '3rem';
-
   return (
     <div
-      className="relative h-full flex-shrink-0 transition-[width] duration-300 ease-in-out"
-      style={{ width: isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH }}>
+      className={cn(
+        'relative h-full flex-shrink-0 transition-[width] duration-300 ease-in-out max-[640px]:w-0',
+        isCollapsed ? 'w-12' : 'w-12 min-[901px]:w-80'
+      )}>
       <div className="absolute inset-0 overflow-hidden bg-gradient-to-br from-roman-marble via-white to-roman-parchment border-r border-roman-red/20">
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute top-0 left-0 w-48 h-48 bg-gradient-to-r from-roman-gold/20 to-amber-300/15 rounded-full mix-blend-multiply filter blur-2xl opacity-60" />
@@ -100,7 +99,8 @@ export default function LessonSidebar({ currentLessonId, isCollapsed = false, on
         <div
           className={cn(
             'absolute top-0 bottom-0 left-0 w-80 flex flex-col transition-opacity duration-200',
-            isCollapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'
+            isCollapsed ? 'opacity-0 pointer-events-none' : 'opacity-100',
+            'max-[900px]:pointer-events-none max-[900px]:opacity-0'
           )}>
           <div className="relative px-6 py-8 border-b border-roman-red/10 bg-white/40 backdrop-blur-sm flex-shrink-0">
             <div className="flex items-center gap-3 mb-2">
@@ -250,7 +250,8 @@ export default function LessonSidebar({ currentLessonId, isCollapsed = false, on
         <div
           className={cn(
             'absolute inset-0 flex flex-col items-center pt-5 transition-opacity duration-200',
-            isCollapsed ? 'opacity-100' : 'opacity-0 pointer-events-none'
+            isCollapsed ? 'opacity-100' : 'opacity-0 pointer-events-none',
+            'max-[640px]:pointer-events-none max-[640px]:opacity-0 max-[900px]:opacity-100'
           )}>
           <div className="relative h-10 w-10 bg-gradient-to-br from-roman-red/20 to-roman-terracotta/10 rounded-xl flex items-center justify-center shadow-lg border border-roman-red/20">
             <BookOpen className="h-5 w-5 text-roman-red" />
@@ -267,7 +268,7 @@ export default function LessonSidebar({ currentLessonId, isCollapsed = false, on
         type="button"
         onClick={onToggleCollapse}
         aria-label={isCollapsed ? 'Expand lessons sidebar' : 'Collapse lessons sidebar'}
-        className="absolute top-1/2 -translate-y-1/2 left-full z-20 inline-flex h-10 w-6 items-center justify-center rounded-r-lg border border-roman-red/20 border-l-0 bg-white text-roman-red shadow-md transition-colors hover:bg-roman-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red">
+        className="absolute left-full top-1/2 z-20 inline-flex h-10 w-6 -translate-y-1/2 items-center justify-center rounded-r-lg border border-l-0 border-roman-red/20 bg-white text-roman-red shadow-md transition-colors hover:bg-roman-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red max-[900px]:hidden">
         <ChevronLeft
           className="h-4 w-4 transition-transform duration-300"
           style={{ transform: isCollapsed ? 'rotate(180deg)' : 'none' }}

--- a/src/components/ui/lesson/practice-sidebar.tsx
+++ b/src/components/ui/lesson/practice-sidebar.tsx
@@ -129,13 +129,12 @@ export default function PracticeSidebar({
     return studentDashboard.practiceLessons.filter(lesson => lesson.type === lessonType);
   };
 
-  const EXPANDED_WIDTH = '20rem';
-  const COLLAPSED_WIDTH = '3rem';
-
   return (
     <div
-      className="relative h-full flex-shrink-0 transition-[width] duration-300 ease-in-out"
-      style={{ width: isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH }}>
+      className={cn(
+        'relative h-full flex-shrink-0 transition-[width] duration-300 ease-in-out max-[640px]:w-0',
+        isCollapsed ? 'w-12' : 'w-12 min-[901px]:w-80'
+      )}>
       <div className="absolute inset-0 overflow-hidden bg-gradient-to-br from-roman-marble via-white to-roman-parchment border-l border-roman-red/20">
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute top-0 right-0 w-48 h-48 bg-gradient-to-l from-roman-gold/20 to-amber-300/15 rounded-full mix-blend-multiply filter blur-2xl opacity-60" />
@@ -145,7 +144,8 @@ export default function PracticeSidebar({
         <div
           className={cn(
             'absolute top-0 bottom-0 right-0 w-80 flex flex-col transition-opacity duration-200',
-            isCollapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'
+            isCollapsed ? 'opacity-0 pointer-events-none' : 'opacity-100',
+            'max-[900px]:pointer-events-none max-[900px]:opacity-0'
           )}>
           <div className="relative px-6 py-8 border-b border-roman-red/10 bg-white/40 backdrop-blur-sm flex-shrink-0">
             <h3 className="text-2xl font-serif text-gray-800">Practice</h3>
@@ -266,7 +266,8 @@ export default function PracticeSidebar({
         <div
           className={cn(
             'absolute inset-0 flex flex-col items-center pt-5 transition-opacity duration-200',
-            isCollapsed ? 'opacity-100' : 'opacity-0 pointer-events-none'
+            isCollapsed ? 'opacity-100' : 'opacity-0 pointer-events-none',
+            'max-[640px]:pointer-events-none max-[640px]:opacity-0 max-[900px]:opacity-100'
           )}>
           <div className="relative h-10 w-10 bg-gradient-to-br from-roman-red/20 to-roman-terracotta/10 rounded-xl flex items-center justify-center shadow-lg border border-roman-red/20">
             <Pencil className="h-5 w-5 text-roman-red" />
@@ -283,7 +284,7 @@ export default function PracticeSidebar({
         type="button"
         onClick={onToggleCollapse}
         aria-label={isCollapsed ? 'Expand practice sidebar' : 'Collapse practice sidebar'}
-        className="absolute top-1/2 -translate-y-1/2 right-full z-20 inline-flex h-10 w-6 items-center justify-center rounded-l-lg border border-roman-red/20 border-r-0 bg-white text-roman-red shadow-md transition-colors hover:bg-roman-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red">
+        className="absolute right-full top-1/2 z-20 inline-flex h-10 w-6 -translate-y-1/2 items-center justify-center rounded-l-lg border border-r-0 border-roman-red/20 bg-white text-roman-red shadow-md transition-colors hover:bg-roman-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red max-[900px]:hidden">
         <ChevronRight
           className="h-4 w-4 transition-transform duration-300"
           style={{ transform: isCollapsed ? 'rotate(180deg)' : 'none' }}

--- a/tests/lessonBuilderAccessibility.test.tsx
+++ b/tests/lessonBuilderAccessibility.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { ContentItem } from '@/src/components/ui/admin/lesson-builder/ContentItem';
+import type { RenderableContentItem } from '@/src/types/page';
+
+jest.mock('@/src/components/ui/core/clipboard', () => ({
+  useClipboard: () => ({ copyItem: jest.fn() }),
+}));
+
+describe('lesson builder icon controls', () => {
+  it('gives every repeated content action an accessible name', () => {
+    const item = {
+      id: 'content-1',
+      type: 'text',
+      title: '<p>Opening note</p>',
+      content: '<p>Salve</p>',
+    } as RenderableContentItem;
+
+    render(<ContentItem item={item} onEdit={jest.fn()} onRemove={jest.fn()} isDraggable />);
+
+    expect(screen.getByRole('button', { name: 'Reorder Opening note' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy Opening note' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit Opening note' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove Opening note' })).toBeInTheDocument();
+  });
+});

--- a/tests/lessonPageNavigation.test.tsx
+++ b/tests/lessonPageNavigation.test.tsx
@@ -69,6 +69,20 @@ describe('lesson route navigation', () => {
     expect(screen.queryByText('Player lesson-2')).not.toBeInTheDocument();
   });
 
+  it('does not flash stale currentData while the route argument changes', () => {
+    mockUseGetStudentLessonQuery.mockReturnValue({
+      data: lesson('lesson-1'),
+      currentData: lesson('lesson-1'),
+      isLoading: false,
+      error: undefined,
+    });
+
+    render(<DynamicLessonPage />);
+
+    expect(screen.queryByText('Player lesson-1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Player lesson-2')).not.toBeInTheDocument();
+  });
+
   it('renders the data belonging to the current route argument', () => {
     mockUseGetStudentLessonQuery.mockReturnValue({
       data: lesson('lesson-1'),


### PR DESCRIPTION
## Summary
- collapse the lesson and practice sidebars below 900px (and remove them at phone widths) so the lesson player keeps a usable center column
- reserve footer clearance, prevent stale lesson-title renders during route transitions, and apply a true ellipsis to rich player titles
- contain the dashboard carousel and make Manage Lessons cards size from their container
- widen the All Words filters/search layout, separate definition rows, and preserve the full Diagramming Attempts nav label
- add accessible names to repeated lesson-editor page/content icon actions

The previously reported stale Next state and detached vocabulary-pool Edit action were left unchanged because live verification showed them already fixed.

## Verification
- responsive browser checks at 600px, 880px, and 1200px
- all 651 buttons in a 23-page lesson editor expose accessible names
- `npx tsc --noEmit`
- `npm test -- --runInBand` (136 suites, 986 tests)
- changed-file ESLint pass
- `git diff --check`

## Known baseline lint issue
`npm run lint` still reports the pre-existing `@typescript-eslint/no-require-imports` errors in `next.config.js` and the existing anonymous-default-export warning in `tests/helpers/sentryMock.ts`; no changed file reports lint issues.