### PR TITLE
Keep student feedback form reachable after banner dismiss

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -25,6 +25,7 @@ import { SwiperNavigation } from '@/src/components/ui/core/swiper-nav';
 import { PracticeSection } from '@/src/components/ui/core/PracticeSection';
 import { SimpleRichDisplay } from '@/src/components/ui/core/simple-rich-display';
 import { FeedbackBanner } from '@/src/components/ui/core/feedback-banner';
+import { StudentFeedbackFooter } from '@/src/components/ui/core/student-feedback-footer';
 import { shouldReportClientHardFail, reportUnexpectedError } from '@/src/lib/report-unexpected-error';
 export { MockTestCard } from '@/src/components/ui/core/mock-test-card';
 
@@ -524,6 +525,8 @@ export default function DashboardPage() {
             </section>
           </div>
         </main>
+
+        <StudentFeedbackFooter />
       </div>
     </div>
   );

--- a/src/components/ui/core/feedback-banner.tsx
+++ b/src/components/ui/core/feedback-banner.tsx
@@ -2,9 +2,8 @@
 
 import React, { useState, useEffect } from 'react';
 import { X, MessageSquare } from 'lucide-react';
+import { FEEDBACK_FORM_URL } from '@/src/constants/student-feedback';
 
-const FEEDBACK_FORM_URL =
-  'https://docs.google.com/forms/d/e/1FAIpQLScuJEcipD4D1htH1m-VL0zyZj4H-NAydOM-Syn6e-DZ75M7zQ/viewform';
 const DISMISSED_KEY = 'feedback_banner_dismissed';
 
 interface FeedbackBannerProps {

--- a/src/components/ui/core/student-feedback-footer.tsx
+++ b/src/components/ui/core/student-feedback-footer.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { FEEDBACK_FORM_URL } from '@/src/constants/student-feedback';
+
+export const StudentFeedbackFooter: React.FC = () => (
+  <footer className="px-6 py-8 text-center border-t border-roman-terracotta/20 bg-white/70 backdrop-blur-sm">
+    <a
+      href={FEEDBACK_FORM_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-2 text-sm font-medium text-roman-red hover:underline">
+      Share your feedback
+    </a>
+    <p className="mt-1 text-xs text-roman-stone">Help us improve Wake Forest Latin — it only takes a minute.</p>
+  </footer>
+);

--- a/src/constants/student-feedback.ts
+++ b/src/constants/student-feedback.ts
@@ -1,0 +1,2 @@
+export const FEEDBACK_FORM_URL =
+  'https://docs.google.com/forms/d/e/1FAIpQLScuJEcipD4D1htH1m-VL0zyZj4H-NAydOM-Syn6e-DZ75M7zQ/viewform';

--- a/tests/studentFeedbackAccess.test.tsx
+++ b/tests/studentFeedbackAccess.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { FeedbackBanner } from '@/src/components/ui/core/feedback-banner';
+import { StudentFeedbackFooter } from '@/src/components/ui/core/student-feedback-footer';
+import { FEEDBACK_FORM_URL } from '@/src/constants/student-feedback';
+
+describe('student feedback access', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('hides the dismissible banner after close and keeps it hidden on remount', async () => {
+    const { unmount } = render(<FeedbackBanner />);
+
+    expect(await screen.findByRole('link', { name: 'Share your feedback' })).toHaveAttribute(
+      'href',
+      FEEDBACK_FORM_URL
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss feedback banner' }));
+    expect(screen.queryByRole('link', { name: 'Share your feedback' })).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('feedback_banner_dismissed')).toBe('true');
+
+    unmount();
+    render(<FeedbackBanner />);
+    await expect(
+      screen.findByRole('link', { name: 'Share your feedback' }, { timeout: 200 })
+    ).rejects.toThrow();
+  });
+
+  it('keeps a homepage footer link after the banner is dismissed', async () => {
+    render(
+      <>
+        <FeedbackBanner />
+        <StudentFeedbackFooter />
+      </>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Dismiss feedback banner' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss feedback banner' }));
+
+    expect(screen.getByRole('link', { name: 'Share your feedback' })).toHaveAttribute(
+      'href',
+      FEEDBACK_FORM_URL
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Dismissing the top-of-page feedback banner persisted `feedback_banner_dismissed` in `localStorage`, which hid the only Google Form link for that student.
- The dashboard (student homepage) now has a permanent footer link to the same form so closing the banner no longer removes access.

## Test plan
- [ ] Open the student dashboard with a clean browser (or cleared `localStorage`) and confirm the parchment banner still appears with **Share your feedback**.
- [ ] Dismiss the banner and confirm it stays gone after reload.
- [ ] Confirm the bottom homepage **Share your feedback** link remains and opens the Google Form in a new tab.
- [ ] Confirm the same footer is still present on a dashboard that already had the banner dismissed.


Made with [Cursor](https://cursor.com)