### PR TITLE
Fix remaining 375px, keyboard, and pool-list bugs

### DIFF
--- a/src/app/admin/(shell)/lessons/create/page.tsx
+++ b/src/app/admin/(shell)/lessons/create/page.tsx
@@ -351,7 +351,7 @@ function CreateLessonPage() {
         </div>
       </header>
 
-      <div className="flex-1 overflow-hidden">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         <ClipboardProvider>
           <LessonBuilder onSave={handleSaveLesson} saving={saving} />
         </ClipboardProvider>

--- a/src/app/admin/(shell)/lessons/edit/[id]/page.tsx
+++ b/src/app/admin/(shell)/lessons/edit/[id]/page.tsx
@@ -232,7 +232,7 @@ function EditLessonPage({ params }: EditLessonPageProps) {
           )}
         </header>
 
-        <div className="flex-1 overflow-hidden">
+        <div className="flex min-h-0 flex-1 overflow-hidden">
           <ClipboardProvider>
             <LessonBuilder initialLesson={initialLesson ?? undefined} onSave={handleSaveLesson} saving={saving} />
           </ClipboardProvider>

--- a/src/app/admin/(shell)/lessons/live/page.tsx
+++ b/src/app/admin/(shell)/lessons/live/page.tsx
@@ -579,7 +579,16 @@ function LiveLessonsPage() {
             setFilterStatus('live');
             setSearchQuery('');
           }}>
-          <LessonTypeTabs counts={counts} />
+          <LessonTypeTabs
+            value={lessonType}
+            onValueChange={value => {
+              if (value !== lessonType && pathDirty && !window.confirm(SWITCH_WITH_UNSAVED_PATH_MESSAGE)) return;
+              setLessonType(value);
+              setFilterStatus('live');
+              setSearchQuery('');
+            }}
+            counts={counts}
+          />
 
           <TabsContent value="normal" className="mt-5">
             <RomanCard className="mb-6">
@@ -812,10 +821,10 @@ function LiveLessonsPage() {
                   <p className="py-4 text-center text-sm text-gray-500">Every normal lesson is placed.</p>
                 ) : (
                   unplacedNormalLessons.map(lesson => (
-                    <div key={lesson.id} className="flex items-center gap-4 rounded-lg border bg-white p-4">
+                    <div key={lesson.id} className="flex min-w-0 flex-col gap-3 rounded-lg border bg-white p-4 sm:flex-row sm:items-center sm:gap-4">
                       <div className="min-w-0 flex-1">
                         <div className="font-medium">
-                          <SimpleRichDisplay content={lesson.title} />
+                          <SimpleRichDisplay content={lesson.title} className="break-words [&_p]:break-words" />
                         </div>
                         <p className="text-xs text-gray-500">{lesson.totalPages} pages</p>
                       </div>
@@ -841,7 +850,7 @@ function LiveLessonsPage() {
 
           {practiceTypes.map(type => (
             <TabsContent key={type} value={type} className="mt-5">
-              <div className="mb-8 grid grid-cols-3 gap-4">
+              <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
                 {[
                   {
                     label: 'Total Lessons',
@@ -865,7 +874,7 @@ function LiveLessonsPage() {
 
               <RomanCard className="mb-6">
                 <RomanCardContent className="flex flex-wrap items-center gap-4 p-4">
-                  <div className="relative min-w-52 flex-1">
+                  <div className="relative min-w-0 flex-1">
                     <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
                     <Input
                       placeholder="Search lessons by title or description..."

--- a/src/app/admin/(shell)/practice-categories/page.tsx
+++ b/src/app/admin/(shell)/practice-categories/page.tsx
@@ -513,7 +513,12 @@ function PracticeCategoriesPage() {
           }
         />
         <Tabs value={lessonType} onValueChange={value => guardContextChange(value as PracticeLessonType, status)}>
-          <LessonTypeTabs lessonTypes={PRACTICE_LESSON_TYPE_TABS} disabled={orderPending} />
+          <LessonTypeTabs
+            value={lessonType}
+            onValueChange={value => guardContextChange(value as PracticeLessonType, status)}
+            lessonTypes={PRACTICE_LESSON_TYPE_TABS}
+            disabled={orderPending}
+          />
         </Tabs>
 
         <section className="rounded-xl border bg-white/70 p-4 shadow-sm sm:p-6" aria-labelledby="category-list-heading">

--- a/src/app/admin/(shell)/vocabulary-pools/page.tsx
+++ b/src/app/admin/(shell)/vocabulary-pools/page.tsx
@@ -113,6 +113,7 @@ function VocabularyPoolsPage() {
   };
 
   const handleUpdateFilters = (newFilters: Partial<typeof filters>) => {
+    setLastPoolId(null);
     dispatch(updateFilters(newFilters));
   };
 
@@ -151,6 +152,7 @@ function VocabularyPoolsPage() {
           pools={pools}
           loading={isLoading}
           loadingMore={loadingMore}
+          fetching={isFetching && lastPoolId === null}
           hasMore={hasMore}
           onLoadMore={() => {
             if (data?.lastPoolId) setLastPoolId(data.lastPoolId);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -401,35 +401,37 @@ export default function DashboardPage() {
       </div>
 
       <div className="relative">
-        <header className="bg-white/80 backdrop-blur-sm border-b border-roman-red/20 px-8 py-6 flex items-center justify-between shadow-xl">
-          <div className="flex items-center gap-4">
+        <header className="relative flex flex-col gap-4 bg-white/80 px-4 py-4 shadow-xl backdrop-blur-sm sm:flex-row sm:items-center sm:justify-between sm:px-8 sm:py-6">
+          <div className="flex min-w-0 items-center gap-3 sm:gap-4">
             <Image
               src="/assets/logos/wakeforest_shield.png"
               alt="Wake Forest University"
               width={1000}
               height={736}
-              className="h-14 w-auto"
+              className="h-10 w-auto shrink-0 sm:h-14"
               priority
             />
-            <div>
-              <h1 className="text-3xl font-serif tracking-wide text-gray-900 mb-1">Wake Forest University Latin</h1>
-              <p className="text-lg text-roman-stone leading-relaxed">
+            <div className="min-w-0">
+              <h1 className="mb-1 font-serif text-xl tracking-wide text-gray-900 sm:text-3xl">
+                Wake Forest University Latin
+              </h1>
+              <p className="text-sm leading-relaxed text-roman-stone sm:text-lg">
                 {displayName ? `Welcome back, ${displayName}` : 'Welcome back'}
               </p>
             </div>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex shrink-0 items-center gap-2 sm:gap-4">
             <Button
               variant="ghost"
-              className="text-roman-stone hover:text-roman-red px-6 py-3 rounded-xl text-lg font-medium flex items-center hover:bg-roman-red/5 transition-all"
+              className="flex items-center rounded-xl px-4 py-2 text-base font-medium text-roman-stone transition-all hover:bg-roman-red/5 hover:text-roman-red sm:px-6 sm:py-3 sm:text-lg"
               onClick={() => router.push('/profile')}>
-              <User className="h-5 w-5 mr-2" />
+              <User className="mr-2 h-5 w-5" />
               Profile
             </Button>
             <Button
               onClick={handleSignOut}
               size="lg"
-              className="bg-gradient-to-r from-gray-900 to-gray-800 hover:from-gray-800 hover:to-gray-700 text-white px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all transform hover:-translate-y-0.5 hover:scale-105">
+              className="rounded-xl bg-gradient-to-r from-gray-900 to-gray-800 px-4 py-2 text-white shadow-lg transition-all hover:-translate-y-0.5 hover:from-gray-800 hover:to-gray-700 hover:shadow-xl sm:px-8 sm:py-3">
               Sign Out
             </Button>
           </div>

--- a/src/app/lesson/[lessonId]/page.tsx
+++ b/src/app/lesson/[lessonId]/page.tsx
@@ -10,11 +10,13 @@ import LessonSidebar from '@/src/components/ui/lesson/lesson-sidebar';
 import PracticeSidebar from '@/src/components/ui/lesson/practice-sidebar';
 import { FeedbackBanner } from '@/src/components/ui/core/feedback-banner';
 import { useAuth } from '@/src/hooks/useAuth';
+import { BookOpen, Pencil } from 'lucide-react';
 import { shouldReportClientHardFail, reportUnexpectedError } from '@/src/lib/report-unexpected-error';
 
 const SIDEBAR_COLLAPSE_KEY = 'lesson-sidebar-collapse';
 
-const defaultCollapseState = { left: false, right: false };
+const defaultCollapseState = { left: true, right: true };
+const desktopCollapseState = { left: false, right: false };
 
 export default function DynamicLessonPage() {
   const params = useParams();
@@ -35,13 +37,16 @@ export default function DynamicLessonPage() {
 
   const [collapsed, setCollapsed] = useState<{ left: boolean; right: boolean }>(() => {
     if (typeof window === 'undefined') return defaultCollapseState;
+    if (typeof window.matchMedia === 'function' && window.matchMedia('(max-width: 900px)').matches) {
+      return defaultCollapseState;
+    }
     try {
       const stored = sessionStorage.getItem(SIDEBAR_COLLAPSE_KEY);
-      if (stored) return { ...defaultCollapseState, ...JSON.parse(stored) };
+      if (stored) return { ...desktopCollapseState, ...JSON.parse(stored) };
     } catch {
       /* ignore */
     }
-    return defaultCollapseState;
+    return desktopCollapseState;
   });
 
   useEffect(() => {
@@ -171,21 +176,37 @@ export default function DynamicLessonPage() {
 
   return (
     <div className="h-screen flex flex-col bg-roman-marble">
-      <header className="bg-white border-b border-border px-4 py-3 flex items-center justify-between flex-shrink-0">
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-white px-4 py-3">
         <Link
           href="/dashboard"
           aria-label="Back to dashboard"
-          className="flex items-center gap-3 rounded hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red">
+          className="flex min-w-0 items-center gap-3 rounded hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red">
           <Image
             src="/assets/logos/wakeforest_shield.png"
             alt="Wake Forest University"
             width={1000}
             height={736}
-            className="h-10 w-auto"
+            className="h-10 w-auto shrink-0"
             priority
           />
-          <h1 className="text-xl font-serif tracking-wide">Wake Forest University Latin</h1>
+          <h1 className="truncate font-serif text-lg tracking-wide sm:text-xl">Wake Forest University Latin</h1>
         </Link>
+        <div className="flex shrink-0 items-center gap-2 min-[901px]:hidden">
+          <button
+            type="button"
+            onClick={toggleLeft}
+            aria-label="Open lessons sidebar"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-roman-red/20 bg-white text-roman-red">
+            <BookOpen className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={toggleRight}
+            aria-label="Open practice sidebar"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-roman-red/20 bg-white text-roman-red">
+            <Pencil className="h-5 w-5" />
+          </button>
+        </div>
       </header>
 
       <FeedbackBanner />

--- a/src/components/admin/SortableLearningPathLesson.tsx
+++ b/src/components/admin/SortableLearningPathLesson.tsx
@@ -43,7 +43,7 @@ export function SortableLearningPathLesson({
         opacity: isDragging ? 0.7 : 1,
         zIndex: isDragging ? 10 : 'auto',
       }}
-      className={`flex items-center gap-4 rounded-lg border p-4 transition-shadow hover:shadow-sm ${
+      className={`flex min-w-0 flex-col gap-3 rounded-lg border p-4 transition-shadow hover:shadow-sm sm:flex-row sm:items-center sm:gap-4 ${
         isTest ? 'border-roman-gold/35 bg-roman-gold/[0.08]' : 'bg-white'
       }`}>
       <button
@@ -66,16 +66,16 @@ export function SortableLearningPathLesson({
       </div>
 
       <div className="min-w-0 flex-1">
-        <div className="mb-1 flex items-center gap-2">
-          <div className="min-w-0 flex-1 truncate font-medium text-gray-900" role="heading" aria-level={3}>
-            <SimpleRichDisplay content={unit.title} />
+        <div className="mb-1 flex min-w-0 items-start gap-2">
+          <div className="min-w-0 flex-1 font-medium text-gray-900" role="heading" aria-level={3}>
+            <SimpleRichDisplay content={unit.title} className="break-words [&_p]:break-words" />
           </div>
           <Badge
             variant="outline"
             className={
               isTest
-                ? 'border-roman-gold/35 bg-roman-gold/15 text-foreground'
-                : 'border-primary/15 bg-primary/[0.08] text-primary'
+                ? 'shrink-0 border-roman-gold/35 bg-roman-gold/15 text-foreground'
+                : 'shrink-0 border-primary/15 bg-primary/[0.08] text-primary'
             }>
             {isTest ? (
               <span className="inline-flex items-center gap-1">
@@ -87,7 +87,7 @@ export function SortableLearningPathLesson({
             )}
           </Badge>
           {hasIssues && (
-            <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-900">
+            <Badge variant="outline" className="shrink-0 border-amber-300 bg-amber-50 text-amber-900">
               <span className="inline-flex items-center gap-1">
                 <ShieldAlert className="h-3 w-3" aria-hidden="true" />
                 Needs attention
@@ -131,6 +131,7 @@ export function SortableLearningPathLesson({
         )}
       </div>
 
+      <div className="flex shrink-0 items-center gap-2">
       <Button size="sm" variant="outline" asChild>
         <Link
           href={editHref}
@@ -159,6 +160,7 @@ export function SortableLearningPathLesson({
           Gate
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/src/components/admin/SortableLessonItem.tsx
+++ b/src/components/admin/SortableLessonItem.tsx
@@ -31,22 +31,22 @@ export function SortableLessonItem({ lesson, id, onNavigate }: SortableLessonIte
     <div
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-4 p-4 bg-white rounded-lg border hover:shadow-sm transition-shadow">
+      className="flex min-w-0 flex-col gap-3 rounded-lg border bg-white p-4 transition-shadow hover:shadow-sm sm:flex-row sm:items-center sm:gap-4">
       <button
-        className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 p-1"
+        className="cursor-grab p-1 text-gray-400 hover:text-gray-600 active:cursor-grabbing"
         {...attributes}
         {...listeners}>
-        <GripVertical className="w-5 h-5" />
+        <GripVertical className="h-5 w-5" />
       </button>
 
-      <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-primary/15 bg-primary/[0.08] text-sm font-semibold text-primary shadow-[0_1px_2px_rgb(15_23_42/0.06)]">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-primary/15 bg-primary/[0.08] text-sm font-semibold text-primary shadow-[0_1px_2px_rgb(15_23_42/0.06)]">
         {(lesson.liveOrder || 0) + 1}
       </div>
 
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 mb-1">
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex min-w-0 items-start gap-2">
           <div className="min-w-0 flex-1 font-medium text-gray-900" role="heading" aria-level={3}>
-            <SimpleRichDisplay content={lesson.title} className="truncate" />
+            <SimpleRichDisplay content={lesson.title} className="break-words [&_p]:break-words" />
           </div>
           <Badge variant="default" className="shrink-0">
             Live
@@ -71,7 +71,7 @@ export function SortableLessonItem({ lesson, id, onNavigate }: SortableLessonIte
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         <Button size="sm" variant="outline" asChild>
           <Link
             href={`/admin/lessons/edit/${lesson.id}`}

--- a/src/components/ui/admin/LessonBuilder.tsx
+++ b/src/components/ui/admin/LessonBuilder.tsx
@@ -126,9 +126,9 @@ export const LessonBuilder: React.FC<LessonBuilderProps> = ({ initialLesson, onS
 
   return (
     <>
-      <div className="flex h-full bg-gray-50">
+      <div className="flex h-full min-h-0 bg-gray-50">
         {/* Left Panel - Editor */}
-        <div className="w-1/2 overflow-y-auto p-4 space-y-4">
+        <div className="flex min-h-0 w-1/2 flex-col overflow-y-auto p-4 space-y-4">
           {/* Header */}
           <div className="flex items-center justify-between bg-white border rounded-md p-3">
             <div>

--- a/src/components/ui/admin/LessonManager.tsx
+++ b/src/components/ui/admin/LessonManager.tsx
@@ -684,6 +684,13 @@ export const LessonManager: React.FC<LessonManagerProps> = ({ onEditLesson, onCo
             }}
             className="w-full">
             <LessonTypeTabs
+              value={activeTab}
+              onValueChange={value => {
+                setActiveTab(value);
+                if (categoryFilter !== 'all' && categoryFilter !== 'uncategorized') {
+                  setCategoryFilter('all');
+                }
+              }}
               counts={{
                 normal: normalLessons.length,
                 vocab: vocabLessons.length,

--- a/src/components/ui/admin/LessonTypeTabs.tsx
+++ b/src/components/ui/admin/LessonTypeTabs.tsx
@@ -1,6 +1,5 @@
 import type { LessonSummary } from '@/src/types/lesson';
 import { cn } from '@/src/lib/utils';
-import { TabsList, TabsTrigger } from '@/src/components/ui/tabs';
 
 type LessonType = LessonSummary['type'];
 
@@ -10,6 +9,8 @@ export interface LessonTypeTab {
 }
 
 interface LessonTypeTabsProps {
+  value: LessonType;
+  onValueChange: (value: LessonType) => void;
   counts?: Partial<Record<LessonType, number>>;
   lessonTypes?: LessonTypeTab[];
   disabled?: boolean;
@@ -24,39 +25,54 @@ const defaultLessonTypes: LessonTypeTab[] = [
 ];
 
 export function LessonTypeTabs({
+  value,
+  onValueChange,
   counts,
   lessonTypes = defaultLessonTypes,
   disabled = false,
   className,
 }: LessonTypeTabsProps) {
   return (
-    <TabsList
+    <div
+      role="tablist"
       aria-label="Lesson types"
       className={cn(
-        'flex h-auto w-full items-center justify-start gap-1.5 overflow-x-auto rounded-xl border border-border/80 bg-white/80 p-1.5 shadow-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+        'flex h-auto w-full flex-wrap items-center justify-start gap-1.5 rounded-xl border border-border/80 bg-white/80 p-1.5 shadow-sm',
         className
       )}>
-      {lessonTypes.map(({ value, label }) => (
-        <TabsTrigger
-          key={value}
-          value={value}
-          disabled={disabled}
-          className={cn(
-            'group relative h-9 shrink-0 rounded-lg border border-transparent bg-transparent px-3.5 py-2 text-xs font-medium text-roman-stone shadow-none transition-[background-color,color,box-shadow]',
-            'hover:bg-roman-parchment hover:text-foreground',
-            'data-[state=active]:border-primary/20 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-[0_2px_6px_hsl(var(--primary)/0.22)]',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-roman-red focus-visible:ring-offset-2'
-          )}>
-          <span className="flex items-center gap-2">
-            <span>{label}</span>
-            {counts && (
-              <span className="text-[11px] tabular-nums text-roman-stone/70 group-data-[state=active]:text-primary-foreground/75">
-                {counts[value] ?? 0}
-              </span>
-            )}
-          </span>
-        </TabsTrigger>
-      ))}
-    </TabsList>
+      {lessonTypes.map(({ value: tabValue, label }) => {
+        const selected = value === tabValue;
+        return (
+          <button
+            key={tabValue}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            disabled={disabled}
+            tabIndex={0}
+            onClick={() => onValueChange(tabValue)}
+            className={cn(
+              'group relative h-9 shrink-0 rounded-lg border border-transparent bg-transparent px-3.5 py-2 text-xs font-medium text-roman-stone shadow-none transition-[background-color,color,box-shadow]',
+              'hover:bg-roman-parchment hover:text-foreground',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-roman-red focus-visible:ring-offset-2',
+              selected &&
+                'border-primary/20 bg-primary text-primary-foreground shadow-[0_2px_6px_hsl(var(--primary)/0.22)]'
+            )}>
+            <span className="flex items-center gap-2">
+              <span>{label}</span>
+              {counts && (
+                <span
+                  className={cn(
+                    'text-[11px] tabular-nums text-roman-stone/70',
+                    selected && 'text-primary-foreground/75'
+                  )}>
+                  {counts[tabValue] ?? 0}
+                </span>
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/src/components/ui/admin/lesson-builder/LessonPreview.tsx
+++ b/src/components/ui/admin/lesson-builder/LessonPreview.tsx
@@ -11,7 +11,7 @@ export const LessonPreview: React.FC<LessonPreviewProps> = ({ lesson }) => {
   const hasContent = lesson.pages.length > 0;
 
   return (
-    <div className="w-1/2 border-l border-border bg-white overflow-y-auto">
+    <div className="flex min-h-0 w-1/2 flex-col overflow-y-auto border-l border-border bg-white">
       <div className="sticky top-0 bg-white border-b border-border p-4 z-10">
         <h2 className="text-xl font-serif text-gray-800 flex items-center gap-2">
           <BookOpen className="h-5 w-5" />

--- a/src/components/ui/admin/lesson-builder/PageSection.tsx
+++ b/src/components/ui/admin/lesson-builder/PageSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import { Button } from '@/src/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/src/components/ui/card';
 import { Plus, Trash2, GripVertical, Copy } from 'lucide-react';
@@ -60,6 +60,8 @@ interface SortablePageProps {
   onUpdatePageAutoAdvance: (pageIndex: number, autoAdvance: { enabled: boolean; delay: number }) => void;
   isAutoAdvanceExpanded: boolean;
   onToggleAutoAdvance: () => void;
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
   editorKind: PageDocumentEditorKind;
 }
 
@@ -77,6 +79,8 @@ const SortablePage: React.FC<SortablePageProps> = ({
   onUpdatePageAutoAdvance,
   isAutoAdvanceExpanded,
   onToggleAutoAdvance,
+  isExpanded,
+  onToggleExpanded,
   editorKind,
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: page.id });
@@ -120,6 +124,15 @@ const SortablePage: React.FC<SortablePageProps> = ({
           <Button
             variant="ghost"
             size="sm"
+            className="h-6 px-2 text-xs"
+            onClick={onToggleExpanded}
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? `Collapse page ${pageIndex + 1}` : `Expand page ${pageIndex + 1}`}>
+            {isExpanded ? 'Collapse' : 'Expand'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
             className="h-6 w-6 p-0"
             onClick={() => onDuplicatePage(pageIndex)}
             aria-label={`Duplicate page ${pageIndex + 1}`}>
@@ -136,6 +149,8 @@ const SortablePage: React.FC<SortablePageProps> = ({
         </div>
       </div>
 
+      {isExpanded && (
+        <>
       <DraggableContentList
         items={page.items}
         pageIndex={pageIndex}
@@ -167,6 +182,8 @@ const SortablePage: React.FC<SortablePageProps> = ({
           ))}
         </div>
       </div>
+        </>
+      )}
     </div>
   );
 };
@@ -188,6 +205,17 @@ export const PageSection: React.FC<PageSectionProps> = ({
 }) => {
   const dispatch = useDispatch();
   const [expandedAutoAdvancePageId, setExpandedAutoAdvancePageId] = useState<string | null>(null);
+  const [expandedPageId, setExpandedPageId] = useState<string | null>(pages[0]?.id ?? null);
+  const previousPageCount = useRef(pages.length);
+
+  useEffect(() => {
+    if (pages.length > previousPageCount.current) {
+      setExpandedPageId(pages[pages.length - 1]?.id ?? null);
+    } else if (!expandedPageId || !pages.some(page => page.id === expandedPageId)) {
+      setExpandedPageId(pages[0]?.id ?? null);
+    }
+    previousPageCount.current = pages.length;
+  }, [pages, expandedPageId]);
 
   const handleUpdatePageAutoAdvance = (pageIndex: number, autoAdvance: { enabled: boolean; delay: number }) => {
     dispatch(updatePageAutoAdvance({ pageIndex, autoAdvance }));
@@ -261,6 +289,10 @@ export const PageSection: React.FC<PageSectionProps> = ({
                 onUpdatePageAutoAdvance={handleUpdatePageAutoAdvance}
                 isAutoAdvanceExpanded={expandedAutoAdvancePageId === page.id}
                 onToggleAutoAdvance={() => handleToggleAutoAdvance(page.id)}
+                isExpanded={expandedPageId === page.id}
+                onToggleExpanded={() =>
+                  setExpandedPageId(current => (current === page.id ? null : page.id))
+                }
                 editorKind={editorKind}
               />
             ))}

--- a/src/components/ui/admin/vocabulary-pools/PoolList.tsx
+++ b/src/components/ui/admin/vocabulary-pools/PoolList.tsx
@@ -21,6 +21,7 @@ interface PoolListProps {
   loading: boolean;
   loadingMore: boolean;
   hasMore: boolean;
+  fetching?: boolean;
   onLoadMore: () => void;
   onEdit: (pool: VocabularyPoolSummary) => void;
   onDuplicate?: (pool: VocabularyPoolSummary) => void;
@@ -96,6 +97,7 @@ export const PoolList: React.FC<PoolListProps> = ({
   loading,
   loadingMore,
   hasMore,
+  fetching = false,
   onLoadMore,
   onEdit,
   onDuplicate,
@@ -107,13 +109,14 @@ export const PoolList: React.FC<PoolListProps> = ({
   const reduceMotion = useReducedMotion();
   const revealTransition = assignmentTransition(reduceMotion);
   const [expandedPoolIds, setExpandedPoolIds] = useState<Set<string>>(() => new Set());
+  const uniquePools = pools.filter((pool, index, list) => list.findIndex(candidate => candidate.id === pool.id) === index);
   const sentinelRef = useInfiniteScroll({
     onLoadMore,
     hasMore,
     loading: loadingMore,
     rootMargin: '300px',
   });
-  if (loading && pools.length === 0) {
+  if ((loading || fetching) && pools.length === 0) {
     return (
       <div className="text-center py-12">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-roman-red mx-auto mb-4"></div>
@@ -122,7 +125,7 @@ export const PoolList: React.FC<PoolListProps> = ({
     );
   }
 
-  if (pools.length === 0) {
+  if (uniquePools.length === 0) {
     return (
       <RomanCard>
         <RomanCardContent className="p-12 text-center">
@@ -137,7 +140,7 @@ export const PoolList: React.FC<PoolListProps> = ({
 
   return (
     <div className="space-y-4">
-      {pools.map(pool => {
+      {uniquePools.map(pool => {
         const usages = usagesByPoolId[pool.id] ?? [];
         const assigned = usages.length > 0;
         const expanded = expandedPoolIds.has(pool.id);

--- a/src/components/ui/lesson/lesson-sidebar.tsx
+++ b/src/components/ui/lesson/lesson-sidebar.tsx
@@ -85,22 +85,37 @@ export default function LessonSidebar({ currentLessonId, isCollapsed = false, on
   );
 
   return (
-    <div
-      className={cn(
-        'relative h-full flex-shrink-0 transition-[width] duration-300 ease-in-out max-[640px]:w-0',
-        isCollapsed ? 'w-12' : 'w-12 min-[901px]:w-80'
-      )}>
-      <div className="absolute inset-0 overflow-hidden bg-gradient-to-br from-roman-marble via-white to-roman-parchment border-r border-roman-red/20">
+    <>
+      {!isCollapsed && (
+        <button
+          type="button"
+          className="fixed inset-0 z-30 bg-black/40 min-[901px]:hidden"
+          aria-label="Close lessons sidebar"
+          onClick={onToggleCollapse}
+        />
+      )}
+      <div
+        className={cn(
+          'relative h-full shrink-0 transition-[width] duration-300 ease-in-out',
+          isCollapsed ? 'w-0 min-[901px]:w-12' : 'w-0 min-[901px]:w-80'
+        )}>
+      <div
+        className={cn(
+          'overflow-hidden border-r border-roman-red/20 bg-gradient-to-br from-roman-marble via-white to-roman-parchment',
+          isCollapsed
+            ? 'hidden min-[901px]:absolute min-[901px]:inset-0 min-[901px]:block'
+            : 'fixed inset-y-0 left-0 z-40 w-80 min-[901px]:absolute min-[901px]:inset-0 min-[901px]:w-auto'
+        )}>
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute top-0 left-0 w-48 h-48 bg-gradient-to-r from-roman-gold/20 to-amber-300/15 rounded-full mix-blend-multiply filter blur-2xl opacity-60" />
           <div className="absolute bottom-0 right-0 w-48 h-48 bg-gradient-to-l from-roman-red/15 to-roman-terracotta/10 rounded-full mix-blend-multiply filter blur-2xl opacity-60" />
         </div>
 
         <div
+          hidden={isCollapsed}
           className={cn(
-            'absolute top-0 bottom-0 left-0 w-80 flex flex-col transition-opacity duration-200',
-            isCollapsed ? 'opacity-0 pointer-events-none' : 'opacity-100',
-            'max-[900px]:pointer-events-none max-[900px]:opacity-0'
+            'absolute inset-0 flex flex-col',
+            isCollapsed && 'pointer-events-none'
           )}>
           <div className="relative px-6 py-8 border-b border-roman-red/10 bg-white/40 backdrop-blur-sm flex-shrink-0">
             <div className="flex items-center gap-3 mb-2">
@@ -248,11 +263,8 @@ export default function LessonSidebar({ currentLessonId, isCollapsed = false, on
         </div>
 
         <div
-          className={cn(
-            'absolute inset-0 flex flex-col items-center pt-5 transition-opacity duration-200',
-            isCollapsed ? 'opacity-100' : 'opacity-0 pointer-events-none',
-            'max-[640px]:pointer-events-none max-[640px]:opacity-0 max-[900px]:opacity-100'
-          )}>
+          hidden={!isCollapsed}
+          className="absolute inset-0 hidden flex-col items-center pt-5 min-[901px]:flex">
           <div className="relative h-10 w-10 bg-gradient-to-br from-roman-red/20 to-roman-terracotta/10 rounded-xl flex items-center justify-center shadow-lg border border-roman-red/20">
             <BookOpen className="h-5 w-5 text-roman-red" />
           </div>
@@ -268,12 +280,13 @@ export default function LessonSidebar({ currentLessonId, isCollapsed = false, on
         type="button"
         onClick={onToggleCollapse}
         aria-label={isCollapsed ? 'Expand lessons sidebar' : 'Collapse lessons sidebar'}
-        className="absolute left-full top-1/2 z-20 inline-flex h-10 w-6 -translate-y-1/2 items-center justify-center rounded-r-lg border border-l-0 border-roman-red/20 bg-white text-roman-red shadow-md transition-colors hover:bg-roman-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red max-[900px]:hidden">
+        className="absolute left-full top-1/2 z-20 hidden h-10 w-6 -translate-y-1/2 items-center justify-center rounded-r-lg border border-l-0 border-roman-red/20 bg-white text-roman-red shadow-md transition-colors hover:bg-roman-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red min-[901px]:inline-flex">
         <ChevronLeft
           className="h-4 w-4 transition-transform duration-300"
           style={{ transform: isCollapsed ? 'rotate(180deg)' : 'none' }}
         />
       </button>
     </div>
+    </>
   );
 }

--- a/src/components/ui/lesson/practice-sidebar.tsx
+++ b/src/components/ui/lesson/practice-sidebar.tsx
@@ -130,22 +130,37 @@ export default function PracticeSidebar({
   };
 
   return (
-    <div
-      className={cn(
-        'relative h-full flex-shrink-0 transition-[width] duration-300 ease-in-out max-[640px]:w-0',
-        isCollapsed ? 'w-12' : 'w-12 min-[901px]:w-80'
-      )}>
-      <div className="absolute inset-0 overflow-hidden bg-gradient-to-br from-roman-marble via-white to-roman-parchment border-l border-roman-red/20">
+    <>
+      {!isCollapsed && (
+        <button
+          type="button"
+          className="fixed inset-0 z-30 bg-black/40 min-[901px]:hidden"
+          aria-label="Close practice sidebar"
+          onClick={onToggleCollapse}
+        />
+      )}
+      <div
+        className={cn(
+          'relative h-full shrink-0 transition-[width] duration-300 ease-in-out',
+          isCollapsed ? 'w-0 min-[901px]:w-12' : 'w-0 min-[901px]:w-80'
+        )}>
+      <div
+        className={cn(
+          'overflow-hidden border-l border-roman-red/20 bg-gradient-to-br from-roman-marble via-white to-roman-parchment',
+          isCollapsed
+            ? 'hidden min-[901px]:absolute min-[901px]:inset-0 min-[901px]:block'
+            : 'fixed inset-y-0 right-0 z-40 w-80 min-[901px]:absolute min-[901px]:inset-0 min-[901px]:w-auto'
+        )}>
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute top-0 right-0 w-48 h-48 bg-gradient-to-l from-roman-gold/20 to-amber-300/15 rounded-full mix-blend-multiply filter blur-2xl opacity-60" />
           <div className="absolute bottom-0 left-0 w-48 h-48 bg-gradient-to-r from-roman-red/15 to-roman-terracotta/10 rounded-full mix-blend-multiply filter blur-2xl opacity-60" />
         </div>
 
         <div
+          hidden={isCollapsed}
           className={cn(
-            'absolute top-0 bottom-0 right-0 w-80 flex flex-col transition-opacity duration-200',
-            isCollapsed ? 'opacity-0 pointer-events-none' : 'opacity-100',
-            'max-[900px]:pointer-events-none max-[900px]:opacity-0'
+            'absolute inset-0 flex flex-col',
+            isCollapsed && 'pointer-events-none'
           )}>
           <div className="relative px-6 py-8 border-b border-roman-red/10 bg-white/40 backdrop-blur-sm flex-shrink-0">
             <h3 className="text-2xl font-serif text-gray-800">Practice</h3>
@@ -264,11 +279,8 @@ export default function PracticeSidebar({
         </div>
 
         <div
-          className={cn(
-            'absolute inset-0 flex flex-col items-center pt-5 transition-opacity duration-200',
-            isCollapsed ? 'opacity-100' : 'opacity-0 pointer-events-none',
-            'max-[640px]:pointer-events-none max-[640px]:opacity-0 max-[900px]:opacity-100'
-          )}>
+          hidden={!isCollapsed}
+          className="absolute inset-0 hidden flex-col items-center pt-5 min-[901px]:flex">
           <div className="relative h-10 w-10 bg-gradient-to-br from-roman-red/20 to-roman-terracotta/10 rounded-xl flex items-center justify-center shadow-lg border border-roman-red/20">
             <Pencil className="h-5 w-5 text-roman-red" />
           </div>
@@ -284,12 +296,13 @@ export default function PracticeSidebar({
         type="button"
         onClick={onToggleCollapse}
         aria-label={isCollapsed ? 'Expand practice sidebar' : 'Collapse practice sidebar'}
-        className="absolute right-full top-1/2 z-20 inline-flex h-10 w-6 -translate-y-1/2 items-center justify-center rounded-l-lg border border-r-0 border-roman-red/20 bg-white text-roman-red shadow-md transition-colors hover:bg-roman-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red max-[900px]:hidden">
+        className="absolute right-full top-1/2 z-20 hidden h-10 w-6 -translate-y-1/2 items-center justify-center rounded-l-lg border border-r-0 border-roman-red/20 bg-white text-roman-red shadow-md transition-colors hover:bg-roman-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-roman-red min-[901px]:inline-flex">
         <ChevronRight
           className="h-4 w-4 transition-transform duration-300"
           style={{ transform: isCollapsed ? 'rotate(180deg)' : 'none' }}
         />
       </button>
     </div>
+    </>
   );
 }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -13,6 +13,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps['theme']}
       className="toaster group"
+      position="top-center"
       toastOptions={{
         classNames: {
           toast:

--- a/src/store/api/vocabularyPoolApi.ts
+++ b/src/store/api/vocabularyPoolApi.ts
@@ -83,14 +83,22 @@ export const vocabularyPoolApi = createApi({
       },
       merge: (currentCache, newData, { arg }) => {
         if (!arg.lastPoolId) return newData;
-        const existingIds = new Set(currentCache.pools.map(p => p.id));
-        const newPools = newData.pools.filter(p => !existingIds.has(p.id));
+        const pools: VocabularyPoolSummary[] = [];
+        const seen = new Set<string>();
+        for (const pool of [...currentCache.pools, ...newData.pools]) {
+          if (seen.has(pool.id)) continue;
+          seen.add(pool.id);
+          pools.push(pool);
+        }
         return {
           ...newData,
-          pools: [...currentCache.pools, ...newPools],
+          pools,
         };
       },
       forceRefetch: ({ currentArg, previousArg }) => {
+        if (!previousArg) return true;
+        const filtersChanged = JSON.stringify(currentArg?.filters) !== JSON.stringify(previousArg?.filters);
+        if (filtersChanged) return true;
         return currentArg?.lastPoolId !== previousArg?.lastPoolId;
       },
       providesTags: result =>

--- a/tests/lessonBuilderPageSection.test.tsx
+++ b/tests/lessonBuilderPageSection.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { PageSection } from '@/src/components/ui/admin/lesson-builder/PageSection';
+import lessonEditorReducer from '@/src/store/slices/lessonEditorSlice';
+import { ALL_CONTENT_TYPES } from '@/src/utils/contentTypeConstants';
+import type { Page } from '@/src/types/page';
+import { BookOpen } from 'lucide-react';
+
+jest.mock('@/src/components/ui/core/clipboard', () => ({
+  PasteZone: () => null,
+}));
+
+jest.mock('@/src/components/ui/admin/lesson-builder/DraggableContentList', () => ({
+  DraggableContentList: () => <div>items</div>,
+}));
+
+jest.mock('@/src/components/ui/core/simple-rich-editor', () => ({
+  SimpleRichEditor: () => <span>Title editor</span>,
+}));
+
+jest.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => children,
+  closestCenter: jest.fn(),
+  KeyboardSensor: class {},
+  PointerSensor: class {},
+  useSensor: jest.fn(),
+  useSensors: () => [],
+}));
+
+jest.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => children,
+  sortableKeyboardCoordinates: jest.fn(),
+  verticalListSortingStrategy: jest.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+jest.mock('@dnd-kit/modifiers', () => ({
+  restrictToVerticalAxis: jest.fn(),
+  restrictToParentElement: jest.fn(),
+}));
+
+jest.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
+const page = (index: number): Page =>
+  ({
+    id: `page-${index}`,
+    title: `Page ${index}`,
+    items: [{ id: `item-${index}`, type: 'text', title: 'Note', content: 'Salve' }],
+  }) as Page;
+
+describe('lesson builder page section', () => {
+  it('mounts add-content controls for the expanded page only', () => {
+    const store = configureStore({ reducer: { lessonEditor: lessonEditorReducer } });
+    const pages = Array.from({ length: 23 }, (_, index) => page(index + 1));
+
+    render(
+      <Provider store={store}>
+        <PageSection
+          title="Pages"
+          icon={BookOpen}
+          pages={pages}
+          contentTypes={ALL_CONTENT_TYPES}
+          onAddPage={jest.fn()}
+          onRemovePage={jest.fn()}
+          onDuplicatePage={jest.fn()}
+          onUpdatePageTitle={jest.fn()}
+          onAddContent={jest.fn()}
+          onEditContent={jest.fn()}
+          onRemoveContent={jest.fn()}
+        />
+      </Provider>
+    );
+
+    expect(screen.getAllByRole('button', { name: /^Expand page / })).toHaveLength(22);
+    expect(screen.getByRole('button', { name: 'Collapse page 1' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Text Block' })).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand page 12' }));
+    expect(screen.getByRole('button', { name: 'Collapse page 12' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Collapse page 1' })).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Text Block' })).toHaveLength(1);
+  });
+});

--- a/tests/lessonPageNavigation.test.tsx
+++ b/tests/lessonPageNavigation.test.tsx
@@ -96,4 +96,18 @@ describe('lesson route navigation', () => {
     expect(screen.getByText('Player lesson-2')).toBeInTheDocument();
     expect(screen.queryByText('Player lesson-1')).not.toBeInTheDocument();
   });
+
+  it('keeps sidebar open controls available in the lesson header', () => {
+    mockUseGetStudentLessonQuery.mockReturnValue({
+      data: lesson('lesson-2'),
+      currentData: lesson('lesson-2'),
+      isLoading: false,
+      error: undefined,
+    });
+
+    render(<DynamicLessonPage />);
+
+    expect(screen.getByRole('button', { name: 'Open lessons sidebar' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open practice sidebar' })).toBeInTheDocument();
+  });
 });

--- a/tests/lessonSidebarMixedPath.test.tsx
+++ b/tests/lessonSidebarMixedPath.test.tsx
@@ -128,4 +128,12 @@ describe('lesson sidebar mixed Learning Path', () => {
     expect(refetch).toHaveBeenCalledTimes(1);
     expect(screen.queryByText('No learning units available')).not.toBeInTheDocument();
   });
+
+  it('hides lesson actions from assistive tech while the sidebar is collapsed', () => {
+    render(<LessonSidebar currentLessonId="lesson-1" isCollapsed />);
+
+    expect(screen.queryByRole('button', { name: /^Chapter test TEST Pass/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Close lessons sidebar' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Expand lessons sidebar' })).toBeInTheDocument();
+  });
 });

--- a/tests/lessonTypeTabs.test.tsx
+++ b/tests/lessonTypeTabs.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { LessonTypeTabs } from '@/src/components/ui/admin/LessonTypeTabs';
+
+describe('LessonTypeTabs keyboard access', () => {
+  it('keeps Normal, Vocab, and Diagramming in the tab order', () => {
+    const onValueChange = jest.fn();
+    render(<LessonTypeTabs value="normal" onValueChange={onValueChange} />);
+
+    for (const name of ['Normal', 'Vocab', 'Diagramming', 'Listening']) {
+      expect(screen.getByRole('tab', { name: new RegExp(`^${name}`) })).toHaveAttribute('tabindex', '0');
+    }
+
+    fireEvent.click(screen.getByRole('tab', { name: /^Vocab/ }));
+    expect(onValueChange).toHaveBeenCalledWith('vocab');
+  });
+});

--- a/tests/vocabularyPoolDuplicateCache.test.ts
+++ b/tests/vocabularyPoolDuplicateCache.test.ts
@@ -183,4 +183,41 @@ describe('vocabulary pool duplication cache refresh', () => {
       ]);
     });
   });
+
+  it('replaces an accumulated list when search starts after the last page', async () => {
+    const store = createStore();
+    const unfilteredArgs = { filters: { sortBy: 'createdAt' as const, sortOrder: 'desc' as const }, lastPoolId: null };
+    const searchArgs = { filters: { search: 'lesson', sortBy: 'createdAt' as const, sortOrder: 'desc' as const }, lastPoolId: null };
+    const lessonPool = summary('lesson-pool', 'Lesson words', 12);
+
+    mockBaseQuery.mockImplementation(async (request: unknown) => {
+      const url = new URL(String(request), 'https://latin.test');
+      if (url.pathname !== '/admin/vocabulary-pools') throw new Error(`Unexpected request: ${String(request)}`);
+      const cursor = url.searchParams.get('lastPoolId');
+      const search = url.searchParams.get('search');
+      if (search === 'lesson') {
+        if (cursor) return poolsResponse([]);
+        return poolsResponse([lessonPool]);
+      }
+      return cursor ? poolsResponse([middlePool]) : poolsResponse([oldestPool], 'oldest-pool');
+    });
+
+    await store.dispatch(vocabularyPoolApi.endpoints.getPools.initiate(unfilteredArgs, { subscribe: false }));
+    await store.dispatch(
+      vocabularyPoolApi.endpoints.getPools.initiate(
+        { ...unfilteredArgs, lastPoolId: 'oldest-pool' },
+        { subscribe: false }
+      )
+    );
+
+    await store.dispatch(
+      vocabularyPoolApi.endpoints.getPools.initiate(
+        { ...searchArgs, lastPoolId: 'oldest-pool' },
+        { subscribe: false }
+      )
+    );
+    await store.dispatch(vocabularyPoolApi.endpoints.getPools.initiate(searchArgs, { subscribe: false }));
+
+    expect(vocabularyPoolApi.endpoints.getPools.select(searchArgs)(store.getState()).data?.pools).toEqual([lessonPool]);
+  });
 });

--- a/tests/vocabularyPoolList.test.tsx
+++ b/tests/vocabularyPoolList.test.tsx
@@ -276,4 +276,27 @@ describe('vocabulary pool list usage status', () => {
     expect(screen.queryByText('Assigned to')).not.toBeInTheDocument();
     expect(screen.queryByText(/Assigned \(/)).not.toBeInTheDocument();
   });
+
+  it('renders one row when pagination returns the same pool twice', () => {
+    render(
+      <PoolList
+        pools={[pool, { ...pool, metadata: { ...pool.metadata, isActive: false } }]}
+        loading={false}
+        loadingMore={false}
+        hasMore={false}
+        onLoadMore={jest.fn()}
+        onEdit={jest.fn()}
+        onDelete={jest.fn()}
+        usagesByPoolId={{
+          'pool-1': [
+            { id: '1', poolId: 'pool-1', kind: 'lesson', label: 'Lesson: One', editorUrl: '/admin/lessons/edit/one' },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getAllByText('Chapter 1 words')).toHaveLength(1);
+    expect(screen.getByText('Assigned (1)')).toBeInTheDocument();
+    expect(screen.queryByText('Inactive')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Live Lessons rows wrap on small screens so titles no longer collapse to width 0; dashboard Sign Out stays on-screen at 375px.
- Lesson-type filters (Normal/Vocab/Diagramming) are real tabbable buttons instead of Radix triggers with `tabIndex=-1`.
- Toasts move to top-center so preview mode no longer covers Finish; the lesson player gets visible 40×40 sidebar toggles and collapsed sidebars are removed from the tab order.
- The lesson builder only mounts add-content controls for the expanded page, and pool search resets the pagination cursor so a full infinite-scroll no longer returns an empty unique list or duplicate assignment badges.

## Test plan
- [ ] Admin → Live Lessons at 375px: lesson titles remain readable; Normal/Vocab/Diagramming are reachable with Tab and switch the list.
- [ ] Open a 23-page lesson in the editor: only one page’s add-content buttons are mounted; the builder pane has a single scroll.
- [ ] Preview a lesson and click Finish: the preview toast does not cover Finish.
- [ ] Vocabulary pools: scroll to the end, type `lesson` in search, matching pools appear without clearing the box; no duplicate rows or conflicting Assigned badges.
- [ ] Student lesson at 375px: Lessons and Practice header buttons open overlays; Sign Out on the dashboard is fully visible.


Made with [Cursor](https://cursor.com)