### PR TITLE
Fix remaining search, carousel, and test-player bugs

### DIFF
--- a/src/app/admin/(shell)/vocabulary/page.tsx
+++ b/src/app/admin/(shell)/vocabulary/page.tsx
@@ -31,6 +31,7 @@ import { PartOfSpeechSchema, type PartOfSpeech } from '@/shared/types/vocabulary
 import { buildEmptyWord, isPlaceholderWord } from '@/src/utils/vocabulary-defaults';
 import { VOCABULARY_WORDS_COLLECTION } from '@/shared/constants/firestore';
 import { fetchVocabularyBackup } from '@/src/services/vocabularyBackupService';
+import { shouldFetchNextSearchPage } from '@/src/lib/paginated-search';
 
 const EMPTY_WORDS: VocabularyWordWithId[] = [];
 const PART_OF_SPEECH_OPTIONS = PartOfSpeechSchema.options;
@@ -50,11 +51,11 @@ function AdminVocabularyPage() {
     confirmationToken: string;
   } | null>(null);
   const TARGET_COLLECTION = VOCABULARY_WORDS_COLLECTION;
-
+  const searchPending = filters.search !== debouncedSearch;
   const queryArgs = {
     wordType: filters.wordType,
     search: debouncedSearch,
-    lastWordId,
+    lastWordId: searchPending ? null : lastWordId,
     collection: TARGET_COLLECTION,
   };
 
@@ -184,16 +185,26 @@ function AdminVocabularyPage() {
   };
 
   const handleLoadMore = () => {
-    if (data?.lastWordId) {
-      setLastWordId(data.lastWordId);
+    const nextCursor = data?.lastWordId ?? null;
+    if (
+      !shouldFetchNextSearchPage({
+        hasCursor: Boolean(nextCursor),
+        isFetching,
+        searchPending,
+      })
+    ) {
+      return;
     }
+    setLastWordId(nextCursor);
   };
 
   const handleUpdateFilters = (newFilters: Partial<typeof filters>) => {
+    setLastWordId(null);
     dispatch(updateFiltersAction(newFilters));
   };
 
   const handleResetFilters = () => {
+    setLastWordId(null);
     dispatch(resetFiltersAction());
   };
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -22,6 +22,7 @@ import { CircularProgressButton } from '@/src/components/ui/CircularProgressButt
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import { SwiperNavigation } from '@/src/components/ui/core/swiper-nav';
+import { OffscreenSlide } from '@/src/components/ui/core/offscreen-slide';
 import { PracticeSection } from '@/src/components/ui/core/PracticeSection';
 import { SimpleRichDisplay } from '@/src/components/ui/core/simple-rich-display';
 import { FeedbackBanner } from '@/src/components/ui/core/feedback-banner';
@@ -481,6 +482,7 @@ export default function DashboardPage() {
                     speed={250}
                     threshold={5}
                     grabCursor
+                    watchSlidesProgress
                     breakpoints={{
                       1024: { slidesPerView: 2 },
                       1280: { slidesPerView: 3 },
@@ -493,20 +495,15 @@ export default function DashboardPage() {
                     </div>
 
                     {learningUnits.map(unit => (
-                      <SwiperSlide
-                        key={unit.id}
-                        className="overflow-visible px-2 py-8 transition-transform duration-300 sm:p-6 lg:p-10">
-                        {({ isActive }) => (
-                          <div
-                            className={`transform-gpu transition-transform duration-300 ${
-                              isActive ? 'scale-100 sm:scale-105 xl:scale-110' : 'scale-[0.98]'
-                            }`}>
+                      <SwiperSlide key={unit.id} className="min-w-0 overflow-hidden px-2 py-8 sm:p-6 lg:p-10">
+                        {({ isActive, isVisible, isPrev, isNext }) => (
+                          <OffscreenSlide isVisible={isActive || isVisible || isPrev || isNext}>
                             {unit.kind === 'test' ? (
                               <TestCard test={unit} onTestClick={handleLessonClick} />
                             ) : (
                               <LessonCard lesson={unit} onLessonClick={handleLessonClick} />
                             )}
-                          </div>
+                          </OffscreenSlide>
                         )}
                       </SwiperSlide>
                     ))}

--- a/src/app/test/[testId]/page.tsx
+++ b/src/app/test/[testId]/page.tsx
@@ -239,13 +239,8 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
     };
   }, [flushPendingAnswers, hasUnsavedAnswers, originKey]);
 
-  const begin = async () => {
+  const startFreshAttempt = async () => {
     if (!user || !test || (isMockTest && !mockTest) || normalTest?.status === 'locked') return;
-    if (isMockTest && attempt) {
-      setScreen('taking');
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-      return;
-    }
     const requestedOriginKey = originKey;
     try {
       const response = await startAttempt({ uid: user.uid, origin }).unwrap();
@@ -258,7 +253,8 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
       });
       setAttempt(response.attempt);
       setPageIndex(0);
-      if (!isMockTest) setScreen('taking');
+      setScreen('taking');
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     } catch (error) {
       const code = getApiErrorCode(error);
       if (code === 'TEST_CONFIGURATION_ERROR' || code === 'TEST_NOT_AVAILABLE') {
@@ -266,6 +262,33 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
         return;
       }
       toast.error(getApiErrorMessage(error, 'Unable to start this test'));
+    }
+  };
+
+  const begin = async () => {
+    if (!user || !test || (isMockTest && !mockTest) || normalTest?.status === 'locked') return;
+    if (attempt) {
+      setScreen('taking');
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
+    await startFreshAttempt();
+  };
+
+  const retake = () => {
+    setAttempt(null);
+    setResult(null);
+    resetAnswerBuffer();
+    setPageIndex(0);
+    void startFreshAttempt();
+  };
+
+  const exitTest = async () => {
+    try {
+      await flushPendingAnswers();
+      router.push('/dashboard');
+    } catch {
+      toast.error('Save the pending answer before leaving this test.');
     }
   };
 
@@ -649,15 +672,7 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
                 </p>
               )
             ) : (
-              <Button
-                className="bg-roman-red hover:bg-roman-red/90"
-                onClick={() => {
-                  setAttempt(null);
-                  setResult(null);
-                  resetAnswerBuffer();
-                  setPageIndex(0);
-                  setScreen('expectations');
-                }}>
+              <Button className="bg-roman-red hover:bg-roman-red/90" onClick={() => void retake()}>
                 <RotateCcw className="mr-2 h-4 w-4" aria-hidden="true" />
                 {isMockTest ? 'Retake Mock Test' : 'Retake Test'}
               </Button>
@@ -822,6 +837,7 @@ export default function StudentTestPage({ params }: { params: Promise<{ testId: 
         onPrevious={() => void moveToPage(pageIndex - 1)}
         onNext={() => void moveToPage(pageIndex + 1)}
         onReview={() => void openReview()}
+        onExit={() => void exitTest()}
         navigationPending={translationGrading}
       />
     </TestTranslationGradingProvider>

--- a/src/components/ui/admin/vocabulary/VocabularyFilters.tsx
+++ b/src/components/ui/admin/vocabulary/VocabularyFilters.tsx
@@ -47,13 +47,13 @@ export const VocabularyFiltersComponent: React.FC<VocabularyFiltersProps> = ({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4">
           <div className="space-y-2">
             <Label htmlFor="wordType" className="text-sm font-medium text-gray-700">
               Word Type
             </Label>
             <Select value={filters.wordType} onValueChange={value => onFiltersChange({ wordType: value })}>
-              <SelectTrigger id="wordType" className="h-9 bg-white">
+              <SelectTrigger id="wordType" className="h-11 w-full bg-white">
                 <SelectValue placeholder="Select word type" />
               </SelectTrigger>
               <SelectContent className="bg-white max-h-60">
@@ -73,25 +73,25 @@ export const VocabularyFiltersComponent: React.FC<VocabularyFiltersProps> = ({
             </Select>
           </div>
 
-          <div className="space-y-2">
+          <div className="min-w-0 space-y-2">
             <Label htmlFor="search" className="text-sm font-medium text-gray-700">
               Search Words
             </Label>
-            <form onSubmit={onSearch} className="flex gap-2">
+            <form onSubmit={onSearch} className="flex w-full min-w-0 gap-2">
               <Input
                 id="search"
                 placeholder="Search words..."
                 value={filters.search}
                 onChange={e => onFiltersChange({ search: e.target.value })}
-                className="h-9 min-w-0 flex-1 bg-white"
+                className="h-11 min-w-0 flex-1 bg-white"
               />
-              <Button type="submit" size="sm" variant="outline" className="px-3" title="Search">
+              <Button type="submit" variant="outline" className="h-11 shrink-0 px-3" aria-label="Search words">
                 <Search className="h-4 w-4" />
               </Button>
             </form>
           </div>
 
-          <div className="space-y-2 xl:col-span-2">
+          <div className="space-y-2">
             <Label className="text-sm font-medium text-gray-700 opacity-0">Actions</Label>
             <Button
               variant="ghost"

--- a/src/components/ui/core/offscreen-slide.tsx
+++ b/src/components/ui/core/offscreen-slide.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+
+export function OffscreenSlide({ isVisible, children }: { isVisible: boolean; children: ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [intersecting, setIntersecting] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+    const root = el.closest('.swiper');
+    if (!root) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.rootBounds || entry.rootBounds.width <= 0) return;
+        setIntersecting(entry.intersectionRatio >= 0.2);
+      },
+      { root, threshold: [0, 0.2, 0.5, 1] }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const shown = intersecting ?? isVisible;
+
+  return (
+    <div ref={ref} className="h-full min-w-0 overflow-hidden" inert={!shown || undefined} aria-hidden={!shown}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/test/test-taking-view.tsx
+++ b/src/components/ui/test/test-taking-view.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { type ReactNode } from 'react';
-import { ArrowLeft, ArrowRight, Eye, FileCheck2, Save } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Eye, FileCheck2, LogOut, Save } from 'lucide-react';
 import { Button } from '@/src/components/ui/button';
 import { Progress } from '@/src/components/ui/progress';
 import { RomanPlayerShell } from '@/src/components/ui/core/roman-player-shell';
@@ -31,6 +31,7 @@ export interface TestTakingViewProps {
   onPrevious: () => void;
   onNext: () => void;
   onReview: () => void;
+  onExit?: () => void;
   navigationPending?: boolean;
   embedded?: boolean;
 }
@@ -54,6 +55,7 @@ export function TestTakingView({
   onPrevious,
   onNext,
   onReview,
+  onExit,
   navigationPending = false,
   embedded = false,
 }: TestTakingViewProps) {
@@ -123,31 +125,44 @@ export function TestTakingView({
         <div
           className="mt-4 flex flex-col gap-3 rounded-2xl border border-roman-red/15 bg-white/95 p-3 shadow-sm sm:flex-row sm:items-center sm:justify-between"
           aria-label="Test page navigation">
-          <Button
-            variant="outline"
-            className="rounded-xl border-roman-red/20 hover:bg-roman-parchment"
-            disabled={navigationPending || currentPageIndex === 0}
-            onClick={onPrevious}>
-            <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
-            Previous page
-          </Button>
-          {!isLastPage ? (
+          {onExit ? (
             <Button
-              className="rounded-xl bg-roman-red hover:bg-roman-red/90"
+              type="button"
+              variant="outline"
+              className="rounded-xl border-roman-red/20 hover:bg-roman-parchment"
               disabled={navigationPending}
-              onClick={onNext}>
-              Next page
-              <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+              onClick={onExit}>
+              <LogOut className="mr-2 h-4 w-4" aria-hidden="true" />
+              Exit test
             </Button>
-          ) : (
+          ) : null}
+          <div className="flex flex-col gap-3 sm:ml-auto sm:flex-row sm:items-center">
             <Button
-              className="rounded-xl bg-roman-red hover:bg-roman-red/90"
-              disabled={navigationPending}
-              onClick={onReview}>
-              Review answers
-              <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+              variant="outline"
+              className="rounded-xl border-roman-red/20 hover:bg-roman-parchment"
+              disabled={navigationPending || currentPageIndex === 0}
+              onClick={onPrevious}>
+              <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
+              Previous page
             </Button>
-          )}
+            {!isLastPage ? (
+              <Button
+                className="rounded-xl bg-roman-red hover:bg-roman-red/90"
+                disabled={navigationPending}
+                onClick={onNext}>
+                Next page
+                <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+              </Button>
+            ) : (
+              <Button
+                className="rounded-xl bg-roman-red hover:bg-roman-red/90"
+                disabled={navigationPending}
+                onClick={onReview}>
+                Review answers
+                <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+              </Button>
+            )}
+          </div>
         </div>
       </main>
     </div>

--- a/src/hooks/useWordSelection.ts
+++ b/src/hooks/useWordSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { useDebounce } from './useDebounce';
 import { useGetWordsForPoolSelectionQuery } from '@/src/store/api/vocabularyPoolApi';
@@ -21,6 +21,7 @@ import {
   selectFiltersExpanded,
 } from '@/src/store/selectors/vocabularyPoolSelectors';
 import { cascadeFilterUpdates } from '@/src/utils/wordFilters';
+import { shouldFetchNextSearchPage } from '@/src/lib/paginated-search';
 import type { Word } from '@/src/types/admin-vocabulary';
 import type { PoolFilters } from '@/src/types/pool-filters';
 
@@ -34,6 +35,9 @@ export const useWordSelection = () => {
   const filtersExpanded = useAppSelector(selectFiltersExpanded);
 
   const debouncedSearch = useDebounce(filters.search || '', 300);
+  const searchPending = (filters.search || '') !== debouncedSearch;
+  const committedSearchRef = useRef(debouncedSearch);
+  const searchCommitted = committedSearchRef.current === debouncedSearch;
   const debouncedFilters = useMemo(
     () => ({
       ...filters,
@@ -52,10 +56,16 @@ export const useWordSelection = () => {
     ]
   );
 
+  useEffect(() => {
+    if (committedSearchRef.current === debouncedSearch) return;
+    committedSearchRef.current = debouncedSearch;
+    dispatch(setPaginationCursor(null));
+  }, [debouncedSearch, dispatch]);
+
   const { data, isLoading, isFetching } = useGetWordsForPoolSelectionQuery({
     filters: debouncedFilters,
     limit: 50,
-    lastWordId: paginationCursor,
+    lastWordId: searchPending || !searchCommitted ? null : paginationCursor,
   });
 
   const availableWords = useMemo(() => {
@@ -85,10 +95,18 @@ export const useWordSelection = () => {
   );
 
   const handleLoadMore = useCallback(() => {
-    if (data?.lastWordId && !isFetching) {
-      dispatch(setPaginationCursor(data.lastWordId));
+    const nextCursor = data?.lastWordId ?? null;
+    if (
+      !shouldFetchNextSearchPage({
+        hasCursor: Boolean(nextCursor),
+        isFetching,
+        searchPending,
+      })
+    ) {
+      return;
     }
-  }, [dispatch, data?.lastWordId, isFetching]);
+    dispatch(setPaginationCursor(nextCursor));
+  }, [dispatch, data?.lastWordId, isFetching, searchPending]);
 
   const handleUpdateFilters = useCallback(
     (updates: Partial<PoolFilters>) => {

--- a/src/lib/paginated-search.ts
+++ b/src/lib/paginated-search.ts
@@ -1,0 +1,11 @@
+export function shouldFetchNextSearchPage({
+  hasCursor,
+  isFetching,
+  searchPending,
+}: {
+  hasCursor: boolean;
+  isFetching: boolean;
+  searchPending: boolean;
+}) {
+  return hasCursor && !isFetching && !searchPending;
+}

--- a/src/store/api/vocabularyApi.ts
+++ b/src/store/api/vocabularyApi.ts
@@ -101,7 +101,16 @@ export const vocabularyApi = createApi({
         };
       },
       forceRefetch: ({ currentArg, previousArg }) => {
-        return currentArg?.lastWordId !== previousArg?.lastWordId;
+        if (!previousArg) return true;
+        if (currentArg?.search !== previousArg.search) return true;
+        if (currentArg?.wordType !== previousArg.wordType) return true;
+        if (
+          (currentArg?.collection || VOCABULARY_WORDS_COLLECTION) !==
+          (previousArg.collection || VOCABULARY_WORDS_COLLECTION)
+        ) {
+          return true;
+        }
+        return currentArg?.lastWordId !== previousArg.lastWordId;
       },
       providesTags: result =>
         result

--- a/tests/paginatedSearch.test.ts
+++ b/tests/paginatedSearch.test.ts
@@ -1,0 +1,19 @@
+import { shouldFetchNextSearchPage } from '@/src/lib/paginated-search';
+
+describe('shouldFetchNextSearchPage', () => {
+  it('loads the next page only when a cursor is ready and search is not pending', () => {
+    expect(shouldFetchNextSearchPage({ hasCursor: true, isFetching: false, searchPending: false })).toBe(true);
+  });
+
+  it('does not page while a new search has not been committed', () => {
+    expect(shouldFetchNextSearchPage({ hasCursor: true, isFetching: false, searchPending: true })).toBe(false);
+  });
+
+  it('does not page while a request is already in flight', () => {
+    expect(shouldFetchNextSearchPage({ hasCursor: true, isFetching: true, searchPending: false })).toBe(false);
+  });
+
+  it('does not page without a cursor', () => {
+    expect(shouldFetchNextSearchPage({ hasCursor: false, isFetching: false, searchPending: false })).toBe(false);
+  });
+});

--- a/tests/remainingUiA11yFixes.test.tsx
+++ b/tests/remainingUiA11yFixes.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { OffscreenSlide } from '@/src/components/ui/core/offscreen-slide';
+import { VocabularyFiltersComponent } from '@/src/components/ui/admin/vocabulary/VocabularyFilters';
+
+describe('All Words search layout', () => {
+  it('keeps the search field full width instead of collapsing beside filters', () => {
+    render(
+      <VocabularyFiltersComponent
+        filters={{ wordType: 'all', search: '' }}
+        wordTypeCounts={{}}
+        countsLoading={false}
+        onFiltersChange={jest.fn()}
+        onSearch={jest.fn()}
+        onReset={jest.fn()}
+      />
+    );
+
+    const search = screen.getByLabelText('Search Words');
+    expect(search).toHaveClass('min-w-0', 'flex-1', 'h-11');
+    expect(search.parentElement).toHaveClass('w-full', 'min-w-0');
+  });
+});
+
+describe('off-screen carousel slides', () => {
+  it('removes hidden slide actions from the tab and accessibility trees', () => {
+    render(
+      <>
+        <OffscreenSlide isVisible>
+          <button type="button">Visible lesson</button>
+        </OffscreenSlide>
+        <OffscreenSlide isVisible={false}>
+          <button type="button">Hidden lesson</button>
+        </OffscreenSlide>
+      </>
+    );
+
+    expect(screen.getByRole('button', { name: 'Visible lesson' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Hidden lesson' })).not.toBeInTheDocument();
+    expect(screen.getByText('Hidden lesson').closest('[inert]')).toHaveAttribute('inert');
+  });
+});

--- a/tests/studentTestPage.test.tsx
+++ b/tests/studentTestPage.test.tsx
@@ -238,6 +238,50 @@ describe('student normal test flow', () => {
     expect(screen.getByText('Results breakdown')).toBeInTheDocument();
   });
 
+  it('exits the in-progress player to the dashboard after saving', async () => {
+    const params = Promise.resolve({ testId: 'test-1' }) as Promise<{ testId: string }> & {
+      status: 'fulfilled';
+      value: { testId: string };
+    };
+    params.status = 'fulfilled';
+    params.value = { testId: 'test-1' };
+    render(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start Test' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Exit test' }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/dashboard'));
+  });
+
+  it('starts a retake from results in one click', async () => {
+    const params = Promise.resolve({ testId: 'test-1' }) as Promise<{ testId: string }> & {
+      status: 'fulfilled';
+      value: { testId: string };
+    };
+    params.status = 'fulfilled';
+    params.value = { testId: 'test-1' };
+    render(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start Test' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Review answers' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit Test' }));
+    expect(await screen.findByRole('button', { name: 'Retake Test' })).toBeInTheDocument();
+    expect(screen.queryByText('Test in progress')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retake Test' }));
+    expect(await screen.findByText('Test in progress')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Start Retake' })).not.toBeInTheDocument();
+    expect(mockStartAttempt).toHaveBeenCalledTimes(2);
+  });
+
   it('reopens a recorded answer from review and clears its server-side value before editing', async () => {
     const params = Promise.resolve({ testId: 'test-1' }) as Promise<{ testId: string }> & {
       status: 'fulfilled';
@@ -692,7 +736,6 @@ describe('student normal test flow', () => {
       </Suspense>
     );
     fireEvent.click(await screen.findByRole('button', { name: 'Start Mock Test' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Begin Mock Test' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Record two answers' }));
     fireEvent.click(screen.getByRole('button', { name: 'Review answers' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Submit Test' }));
@@ -718,6 +761,80 @@ describe('student normal test flow', () => {
       expect(screen.getByText('This mock test is no longer available for another attempt.')).toBeInTheDocument()
     );
     expect(screen.queryByRole('button', { name: 'Retake Mock Test' })).not.toBeInTheDocument();
+  });
+
+  it('starts a mock retake from results in one click', async () => {
+    mockSearchParams.mockReturnValue(new URLSearchParams('origin=mock'));
+    const liveMock = {
+      id: 'mock-1',
+      title: 'Practice mock',
+      description: '',
+      passingPercentage: 70,
+      totalPoints: 2,
+      attemptSummary: {
+        origin: { kind: 'mock-test' as const, mockTestId: 'mock-1' },
+        inProgressAttemptId: null,
+        attemptCount: 0,
+        best: null,
+        latest: null,
+      },
+      scoreTrend: [],
+    };
+    const liveDetail = {
+      mock: {
+        id: 'mock-1',
+        title: 'Practice mock',
+        description: '',
+        passingPercentage: 70,
+        status: 'active' as const,
+        isLive: true,
+      },
+      attempt: null,
+    };
+    mockUseGetStudentDashboardQuery.mockReturnValue({
+      data: { ...dashboard, mockTests: [liveMock] },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetchDashboard,
+    });
+    mockUseGetStudentMockDetailQuery.mockReturnValue({
+      data: liveDetail,
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetchMockDetail,
+    });
+    mockStartAttempt.mockReturnValue({
+      unwrap: jest.fn().mockResolvedValue({
+        attempt: { ...startedAttempt, origin: { kind: 'mock-test', mockTestId: 'mock-1' } },
+        resumed: false,
+      }),
+    });
+    mockRefetchDashboard.mockResolvedValue({ data: { ...dashboard, mockTests: [liveMock] } });
+    mockRefetchMockDetail.mockResolvedValue({ data: liveDetail });
+    const params = Promise.resolve({ testId: 'mock-1' }) as Promise<{ testId: string }> & {
+      status: 'fulfilled';
+      value: { testId: string };
+    };
+    params.status = 'fulfilled';
+    params.value = { testId: 'mock-1' };
+
+    render(
+      <Suspense fallback={<div>Loading route</div>}>
+        <StudentTestPage params={params} />
+      </Suspense>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start Mock Test' }));
+    expect(await screen.findByText('Test in progress')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Begin Mock Test' })).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: 'Review answers' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit Test' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Retake Mock Test' }));
+
+    expect(await screen.findByText('Test in progress')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Start Mock Test' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Begin Mock Test' })).not.toBeInTheDocument();
+    expect(mockStartAttempt).toHaveBeenCalledTimes(2);
   });
 
   it('retries the failing mock-detail source', async () => {

--- a/tests/testTakingView.test.tsx
+++ b/tests/testTakingView.test.tsx
@@ -83,6 +83,28 @@ describe('shared Roman test-taking view', () => {
     expect(screen.getByText('page-one:test')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
     expect(onNext).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('button', { name: 'Exit test' })).not.toBeInTheDocument();
+  });
+
+  it('exposes an Exit control when the student player provides one', () => {
+    const onExit = jest.fn();
+    render(
+      <TestTakingView
+        title="Roman assessment"
+        pages={pages}
+        currentPageIndex={0}
+        answeredCount={0}
+        totalExercises={2}
+        status="Answer saved."
+        onPrevious={jest.fn()}
+        onNext={jest.fn()}
+        onReview={jest.fn()}
+        onExit={onExit}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Exit test' }));
+    expect(onExit).toHaveBeenCalledTimes(1);
   });
 
   it('keeps local preview answers across pages and resets them when authored pages change', async () => {


### PR DESCRIPTION
## Summary
- All Words search stays full width in the split pane, and both that list and the pool editor drop a stale `lastWordId` when the query changes so infinite-scroll no longer returns an empty unique result set.
- Dashboard carousel slides no longer overflow the page; off-screen cards are `inert`, so Tab does not walk ~60 hidden lesson buttons.
- The student test player gets an Exit control, and Start / Retake Mock Test enter the player in one click instead of parking on the expectations screen.

## Test plan
- [ ] Admin → All Words: search field is a usable width in the left pane (not ~48px).
- [ ] Admin → All Words: scroll the list, then search; results match the query instead of going empty until you clear the box.
- [ ] Admin → Vocabulary Pools → Edit: scroll the word picker, then search; matching words appear.
- [ ] Dashboard at 375px: learning-path carousel does not widen the page; Tab skips off-screen lesson/test buttons.
- [ ] Start a test or mock: Exit test returns to the dashboard after saving.
- [ ] From mock results, Retake Mock Test lands on the player in one click (no extra Begin Mock Test).
- [ ] Archived-mock resume still waits on Continue Mock Test after the frozen attempt is restored.


Made with [Cursor](https://cursor.com)