### PR TITLE
Release 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "latin-app",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "latin-app",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latin-app",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -49,6 +49,23 @@ export const LessonCard = memo(
   ({ lesson, onLessonClick }: { lesson: StudentLessonSummary; onLessonClick: (id: string) => void }) => {
     const config = statusConfig[lesson.status || 'available'] || statusConfig.available;
     const progress = typeof lesson.progress === 'number' ? lesson.progress : 0;
+    const statusLabel =
+      lesson.status === 'completed'
+        ? 'Completed'
+        : lesson.status === 'in-progress'
+          ? `${Math.round(progress)}% complete`
+          : lesson.status === 'locked'
+            ? lesson.lockedReason || 'Complete the previous learning unit to unlock'
+            : 'Ready to begin';
+    const description = lesson.description?.trim()
+      ? lesson.description
+      : lesson.status === 'completed'
+        ? 'Review the material from this lesson.'
+        : lesson.status === 'in-progress'
+          ? 'Continue from where you left off.'
+          : lesson.status === 'locked'
+            ? 'Finish the previous learning unit to unlock this lesson.'
+            : 'Start this lesson when you are ready.';
 
     const handleClick = () => {
       if (lesson.status === 'locked') {
@@ -60,20 +77,45 @@ export const LessonCard = memo(
 
     return (
       <RomanCard
-        className={`group h-36 cursor-pointer rounded-3xl shadow-xl transition-all duration-300 transform hover:-translate-y-2 hover:scale-[1.02] hover:shadow-2xl ${config.card}`}
+        className={`group h-40 cursor-pointer overflow-hidden rounded-3xl shadow-xl transition-all duration-300 transform hover:-translate-y-2 hover:scale-[1.02] hover:shadow-2xl ${config.card}`}
         onClick={handleClick}>
-        <RomanCardContent className="relative p-6">
-          <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-white/20 to-transparent" />
-          <div className="relative flex items-center justify-between">
-            <div className="min-w-0 flex-1 pr-4">
-              <h3 className="mb-2 min-w-0 truncate font-serif text-xl text-gray-900">
+        <RomanCardContent className="relative h-full p-5 sm:p-6">
+          <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-white/25 to-transparent" />
+          <div className="relative flex h-full items-center gap-4">
+            <div className="flex h-full min-w-0 flex-1 flex-col">
+              <div className="text-[0.68rem] font-bold uppercase tracking-[0.18em] text-roman-stone/80">Lesson</div>
+              <h3 className="mt-2 min-w-0 truncate font-serif text-xl text-gray-950">
                 <SimpleRichDisplay content={lesson.title} className="truncate [&_p]:truncate" />
               </h3>
-              <div className="line-clamp-2 text-sm text-roman-stone">
-                <SimpleRichDisplay content={lesson.description || ''} />
+              <div className="mt-1 min-h-5 text-sm text-roman-stone">
+                <SimpleRichDisplay content={description} className="line-clamp-1 [&_p]:line-clamp-1" />
+              </div>
+              <div
+                className={`mt-auto min-w-0 truncate text-xs font-semibold ${
+                  lesson.status === 'completed'
+                    ? 'text-emerald-700'
+                    : lesson.status === 'in-progress'
+                      ? 'text-roman-red'
+                      : lesson.status === 'locked'
+                        ? 'text-gray-500'
+                        : 'text-roman-stone'
+                }`}>
+                {statusLabel}
+              </div>
+              <div aria-hidden="true" className="mt-2 h-1 overflow-hidden rounded-full bg-gray-900/10">
+                <div
+                  className={`h-full rounded-full transition-[width] duration-500 ${
+                    lesson.status === 'completed'
+                      ? 'bg-roman-green'
+                      : lesson.status === 'locked'
+                        ? 'bg-gray-300'
+                        : 'bg-roman-red'
+                  }`}
+                  style={{ width: `${Math.max(0, Math.min(100, progress))}%` }}
+                />
               </div>
             </div>
-            <div className="shrink-0">
+            <div className="shrink-0 self-center">
               <CircularProgressButton
                 progress={progress}
                 status={lesson.status}
@@ -475,7 +517,7 @@ export default function DashboardPage() {
                   </RomanCardContent>
                 </RomanCard>
               ) : (
-                <div className="relative overflow-hidden">
+                <div className="relative">
                   <Swiper
                     spaceBetween={0}
                     slidesPerView={1}
@@ -488,7 +530,7 @@ export default function DashboardPage() {
                       1024: { slidesPerView: 2 },
                       1280: { slidesPerView: 3 },
                     }}
-                    className="lesson-cards-carousel overflow-hidden px-0 py-8 sm:p-8"
+                    className="lesson-cards-carousel !overflow-clip [overflow-clip-margin:4rem] px-0 py-8 sm:p-8"
                     centeredSlides={true}
                     effect="slide">
                     <div slot="container-end">
@@ -496,14 +538,21 @@ export default function DashboardPage() {
                     </div>
 
                     {learningUnits.map(unit => (
-                      <SwiperSlide key={unit.id} className="min-w-0 overflow-hidden px-2 py-8 sm:p-6 lg:p-10">
+                      <SwiperSlide
+                        key={unit.id}
+                        className="min-w-0 overflow-visible px-2 py-8 transition-transform duration-300 sm:p-6 lg:p-10">
                         {({ isActive, isVisible, isPrev, isNext }) => (
                           <OffscreenSlide isVisible={isActive || isVisible || isPrev || isNext}>
-                            {unit.kind === 'test' ? (
-                              <TestCard test={unit} onTestClick={handleLessonClick} />
-                            ) : (
-                              <LessonCard lesson={unit} onLessonClick={handleLessonClick} />
-                            )}
+                            <div
+                              className={`transform-gpu transition-transform duration-300 ${
+                                isActive ? 'scale-100 sm:scale-105 xl:scale-110' : 'scale-[0.98]'
+                              }`}>
+                              {unit.kind === 'test' ? (
+                                <TestCard test={unit} onTestClick={handleLessonClick} />
+                              ) : (
+                                <LessonCard lesson={unit} onLessonClick={handleLessonClick} />
+                              )}
+                            </div>
                           </OffscreenSlide>
                         )}
                       </SwiperSlide>

--- a/src/components/ui/core/offscreen-slide.tsx
+++ b/src/components/ui/core/offscreen-slide.tsx
@@ -26,7 +26,7 @@ export function OffscreenSlide({ isVisible, children }: { isVisible: boolean; ch
   const shown = intersecting ?? isVisible;
 
   return (
-    <div ref={ref} className="h-full min-w-0 overflow-hidden" inert={!shown || undefined} aria-hidden={!shown}>
+    <div ref={ref} className="h-full min-w-0 overflow-visible" inert={!shown || undefined} aria-hidden={!shown}>
       {children}
     </div>
   );

--- a/tests/dashboardCarouselOverflow.test.ts
+++ b/tests/dashboardCarouselOverflow.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('dashboard learning-path carousel overflow', () => {
+  it('keeps slides clipped while reserving enough paint space for the hover shadow', () => {
+    const source = readFileSync(join(process.cwd(), 'src/app/dashboard/page.tsx'), 'utf8');
+
+    expect(source).toContain('!overflow-clip [overflow-clip-margin:4rem]');
+    expect(source).toContain('className="min-w-0 overflow-visible');
+  });
+});

--- a/tests/dashboardTestCard.test.tsx
+++ b/tests/dashboardTestCard.test.tsx
@@ -64,10 +64,11 @@ describe('student dashboard test card', () => {
   it('uses the production lesson-card presentation while retaining the accessible action', () => {
     const { container } = render(<LessonCard lesson={lessonSummary()} onLessonClick={jest.fn()} />);
 
-    expect(container.firstChild).toHaveClass('h-36');
-    expect(screen.queryByText('Lesson')).not.toBeInTheDocument();
-    expect(screen.queryByText('Continue from where you left off.')).not.toBeInTheDocument();
-    expect(screen.queryByText('35% complete')).not.toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('h-40');
+    expect(screen.getByText('Lesson')).toBeInTheDocument();
+    expect(screen.getByText('Continue from where you left off.')).toBeInTheDocument();
+    expect(screen.getByText('35% complete')).toBeInTheDocument();
+    expect(container.querySelector('.h-1 > div')).toHaveStyle({ width: '35%' });
     expect(screen.getByRole('button', { name: 'Continue lesson' })).toBeInTheDocument();
   });
 

--- a/tests/offscreenSlide.test.tsx
+++ b/tests/offscreenSlide.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { OffscreenSlide } from '@/src/components/ui/core/offscreen-slide';
+
+describe('OffscreenSlide', () => {
+  it('lets visible card transforms and shadows paint outside the wrapper', () => {
+    render(
+      <OffscreenSlide isVisible>
+        <div data-testid="card">Lesson</div>
+      </OffscreenSlide>
+    );
+
+    const wrapper = screen.getByTestId('card').parentElement;
+
+    expect(wrapper).toHaveClass('overflow-visible');
+    expect(wrapper).not.toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('keeps an offscreen card out of the accessibility tree', () => {
+    render(
+      <OffscreenSlide isVisible={false}>
+        <div data-testid="card">Lesson</div>
+      </OffscreenSlide>
+    );
+
+    const wrapper = screen.getByTestId('card').parentElement;
+
+    expect(wrapper).toHaveAttribute('aria-hidden', 'true');
+    expect(wrapper).toHaveAttribute('inert');
+  });
+});


### PR DESCRIPTION
## Summary
- restore the standardized student dashboard lesson-card design
- keep lesson and review-test cards on the shared 160px footprint
- restore lesson status labels, fallback descriptions, and progress bars
- prevent hover shadows from being clipped by the learning-path carousel
- preserve offscreen-slide accessibility behavior
- bump the application version to 1.0.3

## Verification
- 143 Jest suites passed (1,008 tests)
- TypeScript passed with no errors
- targeted ESLint passed
- git diff checks passed

## Known baseline
- full-project ESLint still reports the existing CommonJS require-style errors in next.config.js