### PR TITLE
Release 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "latin-app",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "latin-app",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
         "@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "latin-app",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "latin-app",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latin-app",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latin-app",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/shared/constants/firestore.ts
+++ b/shared/constants/firestore.ts
@@ -16,6 +16,7 @@ export const TEST_RESULT_REVIEWS_COLLECTION = 'testResultReviews';
 export const STUDENT_MOCK_RESULTS_COLLECTION = 'studentMockResults';
 export const STUDENT_MOCK_RESULT_MIGRATIONS_COLLECTION = 'studentMockResultMigrations';
 export const USER_PROGRESS_COLLECTION = 'userProgress';
+export const USER_PROGRESS_V4_BACKUPS_COLLECTION = 'userProgressMigrationV4Backups';
 export const AI_EVALUATION_CASES_COLLECTION = 'aiEvaluationCases';
 export const AI_EVALUATION_RESULT_CACHE_COLLECTION = 'aiEvaluationResultCache';
 export const AI_EVALUATION_RUN_THROTTLES_COLLECTION = 'aiEvaluationRunThrottles';

--- a/src/app/api/admin/progress/migrate-exercise-progress-v4/route.ts
+++ b/src/app/api/admin/progress/migrate-exercise-progress-v4/route.ts
@@ -1,0 +1,345 @@
+import { FieldPath, type DocumentData, type Query } from 'firebase-admin/firestore';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  LEARNING_UNITS_COLLECTION,
+  USER_PROGRESS_COLLECTION,
+  USER_PROGRESS_V4_BACKUPS_COLLECTION,
+} from '@/shared/constants/firestore';
+import { AdminAccessError, verifyAdminAccess } from '@/src/lib/verifyAdminAccess';
+import { normalizeLearningUnit } from '@/src/lib/learning-units/domain';
+import { adminDb } from '@/src/services/firebase-admin';
+import type { Lesson, UserProgress } from '@/src/types/lesson';
+import { PROGRESS_SCHEMA_VERSION } from '@/src/utils/lessonProgress';
+import { migrateUserProgressToExerciseBasis } from '@/src/utils/progressMigration';
+
+export const dynamic = 'force-dynamic';
+
+const MIGRATION_ID = 'exercise-progress-v4';
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 100;
+
+const migrationRequestSchema = z
+  .object({
+    action: z.enum(['dry-run', 'apply', 'rollback']).default('dry-run'),
+    confirmWrite: z.boolean().optional(),
+    cursor: z.string().min(1).optional(),
+    limit: z.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+  })
+  .strict();
+
+type MigrationOutcome =
+  | { kind: 'invalid-progress' }
+  | { kind: 'missing-lesson' }
+  | { kind: 'invalid-lesson' }
+  | { kind: 'deletion-pending-lesson' }
+  | { kind: 'backup-conflict' }
+  | { kind: 'already-current' }
+  | {
+      kind: 'migrated';
+      mappedExerciseRecords: number;
+      unmappedExerciseRecords: number;
+      deduplicatedExerciseRecords: number;
+      derivedCompletion: boolean;
+      completedLessonPreserved: boolean;
+      resetIncompleteProgressToZero: boolean;
+    };
+
+type RollbackOutcome = { kind: 'rolled-back' | 'missing-backup' | 'missing-progress' | 'conflict' };
+
+function readProgressLessonId(documentId: string, data: DocumentData): string | null {
+  const userId = typeof data.userId === 'string' && data.userId.length > 0 ? data.userId : null;
+  if (!userId || !documentId.startsWith(`${userId}_`)) return null;
+  const documentLessonId = documentId.slice(userId.length + 1);
+  if (!documentLessonId) return null;
+
+  if (data.lessonId === undefined) return documentLessonId;
+  if (typeof data.lessonId !== 'string' || !data.lessonId || data.lessonId !== documentLessonId) return null;
+  return data.lessonId;
+}
+
+function isDeletionPending(data: DocumentData | undefined): boolean {
+  return data?._deletionPending === true;
+}
+
+function canonicalProgressFields(progress: Partial<UserProgress>) {
+  return {
+    status: progress.status,
+    completedAt: progress.completedAt,
+    furthestPageIndex: progress.furthestPageIndex,
+    currentPageIndex: progress.currentPageIndex,
+    exerciseProgress: progress.exerciseProgress,
+    completedExerciseCount: progress.completedExerciseCount,
+    requiredExerciseCount: progress.requiredExerciseCount,
+    progress: progress.progress,
+    progressSchemaVersion: progress.progressSchemaVersion,
+    progressLessonVersion: progress.progressLessonVersion,
+  };
+}
+
+function hasCanonicalV4Progress(existing: Partial<UserProgress>, canonical: Partial<UserProgress>): boolean {
+  return (
+    existing.progressSchemaVersion === PROGRESS_SCHEMA_VERSION &&
+    JSON.stringify(canonicalProgressFields(existing)) === JSON.stringify(canonicalProgressFields(canonical))
+  );
+}
+
+function migrationStats(action: 'dry-run' | 'apply') {
+  return {
+    action,
+    migrationId: MIGRATION_ID,
+    documentsScanned: 0,
+    documentsWouldMigrate: 0,
+    documentsMigrated: 0,
+    documentsAlreadyCurrent: 0,
+    documentsSkippedInvalidProgress: 0,
+    documentsSkippedMissingLesson: 0,
+    documentsSkippedInvalidLesson: 0,
+    documentsSkippedDeletionPendingLesson: 0,
+    documentsSkippedBackupConflict: 0,
+    mappedExerciseRecords: 0,
+    unmappedExerciseRecords: 0,
+    deduplicatedExerciseRecords: 0,
+    derivedCompletions: 0,
+    completedLessonsPreserved: 0,
+    resetIncompleteProgressToZero: 0,
+  };
+}
+
+function addMigrationOutcome(
+  summary: ReturnType<typeof migrationStats>,
+  outcome: MigrationOutcome,
+  isDryRun: boolean
+) {
+  if (outcome.kind === 'invalid-progress') summary.documentsSkippedInvalidProgress++;
+  else if (outcome.kind === 'missing-lesson') summary.documentsSkippedMissingLesson++;
+  else if (outcome.kind === 'invalid-lesson') summary.documentsSkippedInvalidLesson++;
+  else if (outcome.kind === 'deletion-pending-lesson') summary.documentsSkippedDeletionPendingLesson++;
+  else if (outcome.kind === 'backup-conflict') summary.documentsSkippedBackupConflict++;
+  else if (outcome.kind === 'already-current') summary.documentsAlreadyCurrent++;
+  else {
+    if (isDryRun) summary.documentsWouldMigrate++;
+    else summary.documentsMigrated++;
+    summary.mappedExerciseRecords += outcome.mappedExerciseRecords;
+    summary.unmappedExerciseRecords += outcome.unmappedExerciseRecords;
+    summary.deduplicatedExerciseRecords += outcome.deduplicatedExerciseRecords;
+    if (outcome.derivedCompletion) summary.derivedCompletions++;
+    if (outcome.completedLessonPreserved) summary.completedLessonsPreserved++;
+    if (outcome.resetIncompleteProgressToZero) summary.resetIncompleteProgressToZero++;
+  }
+}
+
+function evaluateMigration(
+  existing: DocumentData,
+  lessonData: DocumentData | undefined,
+  lessonDocumentId: string,
+  now: string
+): MigrationOutcome & { canonical?: Partial<UserProgress> } {
+  if (!lessonData) return { kind: 'missing-lesson' };
+  if (isDeletionPending(lessonData)) return { kind: 'deletion-pending-lesson' };
+  if (typeof existing.userId !== 'string' || !existing.userId) {
+    return { kind: 'invalid-progress' };
+  }
+
+  let lesson: Lesson;
+  try {
+    const unit = normalizeLearningUnit(lessonData, lessonDocumentId);
+    if (unit.kind !== 'lesson') return { kind: 'invalid-lesson' };
+    lesson = { ...unit, vocabulary_pool: unit.vocabulary_pool ?? undefined };
+  } catch {
+    return { kind: 'invalid-lesson' };
+  }
+  const result = migrateUserProgressToExerciseBasis(lesson, existing as Partial<UserProgress>, now);
+  if (hasCanonicalV4Progress(existing as Partial<UserProgress>, result.progress)) {
+    return { kind: 'already-current' };
+  }
+  return {
+    kind: 'migrated',
+    canonical: result.progress,
+    mappedExerciseRecords: result.mappedExerciseRecords,
+    unmappedExerciseRecords: result.unmappedExerciseRecords,
+    deduplicatedExerciseRecords: result.deduplicatedExerciseRecords,
+    derivedCompletion: result.derivedCompletion,
+    completedLessonPreserved: existing.status === 'completed',
+    resetIncompleteProgressToZero: result.resetIncompleteProgressToZero,
+  };
+}
+
+async function readPage(collectionName: string, cursor: string | undefined, limit: number) {
+  let query: Query = adminDb
+    .collection(collectionName)
+    .orderBy(FieldPath.documentId())
+    .limit(limit + 1);
+  if (cursor) query = query.startAfter(cursor);
+  const snapshot = await query.get();
+  return {
+    documents: snapshot.docs.slice(0, limit),
+    hasMore: snapshot.docs.length > limit,
+  };
+}
+
+async function dryRunDocument(progressDocument: FirebaseFirestore.QueryDocumentSnapshot, now: string) {
+  const existing = progressDocument.data();
+  const lessonId = readProgressLessonId(progressDocument.id, existing);
+  if (!lessonId) return { kind: 'invalid-progress' } as MigrationOutcome;
+  const lessonSnapshot = await adminDb.collection(LEARNING_UNITS_COLLECTION).doc(lessonId).get();
+  return evaluateMigration(existing, lessonSnapshot.data(), lessonSnapshot.id, now);
+}
+
+async function applyDocument(
+  progressDocument: FirebaseFirestore.QueryDocumentSnapshot,
+  adminId: string,
+  now: string
+): Promise<MigrationOutcome> {
+  return adminDb.runTransaction(async transaction => {
+    const progressSnapshot = await transaction.get(progressDocument.ref);
+    if (!progressSnapshot.exists) return { kind: 'invalid-progress' } as const;
+    const existing = progressSnapshot.data() ?? {};
+    const lessonId = readProgressLessonId(progressSnapshot.id, existing);
+    if (!lessonId) return { kind: 'invalid-progress' } as const;
+
+    const lessonRef = adminDb.collection(LEARNING_UNITS_COLLECTION).doc(lessonId);
+    const backupRef = adminDb.collection(USER_PROGRESS_V4_BACKUPS_COLLECTION).doc(progressSnapshot.id);
+    const [lessonSnapshot, backupSnapshot] = await Promise.all([
+      transaction.get(lessonRef),
+      transaction.get(backupRef),
+    ]);
+    const outcome = evaluateMigration(existing, lessonSnapshot.data(), lessonSnapshot.id, now);
+    if (outcome.kind !== 'migrated' || !outcome.canonical) return outcome;
+
+    if (backupSnapshot.exists) {
+      const backup = backupSnapshot.data();
+      if (
+        backup?.migrationId !== MIGRATION_ID ||
+        backup.progressDocumentId !== progressSnapshot.id ||
+        !backup.data ||
+        typeof backup.data !== 'object' ||
+        Array.isArray(backup.data)
+      ) {
+        return { kind: 'backup-conflict' } as const;
+      }
+    } else {
+      transaction.create(backupRef, {
+        migrationId: MIGRATION_ID,
+        progressDocumentId: progressSnapshot.id,
+        migratedAt: now,
+        migratedBy: adminId,
+        data: existing,
+      });
+    }
+    transaction.set(
+      progressSnapshot.ref,
+      {
+        ...outcome.canonical,
+        progressMigrationId: MIGRATION_ID,
+        progressMigratedAt: now,
+        progressMigratedBy: adminId,
+      },
+      { merge: true }
+    );
+    return outcome;
+  });
+}
+
+async function rollbackDocument(
+  backupDocument: FirebaseFirestore.QueryDocumentSnapshot,
+  adminId: string,
+  now: string
+): Promise<RollbackOutcome> {
+  return adminDb.runTransaction(async transaction => {
+    const backupRef = backupDocument.ref;
+    const backupSnapshot = await transaction.get(backupRef);
+    if (!backupSnapshot.exists) return { kind: 'missing-backup' } as const;
+    const backup = backupSnapshot.data();
+    const progressDocumentId = typeof backup?.progressDocumentId === 'string' ? backup.progressDocumentId : null;
+    const original = backup?.data;
+    if (
+      backup?.migrationId !== MIGRATION_ID ||
+      !progressDocumentId ||
+      backupRef.id !== progressDocumentId ||
+      !original ||
+      typeof original !== 'object' ||
+      Array.isArray(original)
+    ) {
+      return { kind: 'missing-backup' } as const;
+    }
+
+    const progressRef = adminDb.collection(USER_PROGRESS_COLLECTION).doc(progressDocumentId);
+    const progressSnapshot = await transaction.get(progressRef);
+    if (!progressSnapshot.exists) return { kind: 'missing-progress' } as const;
+    const current = progressSnapshot.data() ?? {};
+    const unchangedSinceMigration =
+      current.progressMigrationId === MIGRATION_ID &&
+      JSON.stringify(current.updatedAt) === JSON.stringify(original.updatedAt) &&
+      JSON.stringify(current.lastAccessedAt) === JSON.stringify(original.lastAccessedAt);
+    if (!unchangedSinceMigration) return { kind: 'conflict' } as const;
+
+    transaction.set(progressRef, original);
+    transaction.set(backupRef, { rolledBackAt: now, rolledBackBy: adminId }, { merge: true });
+    return { kind: 'rolled-back' } as const;
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const admin = await verifyAdminAccess(request);
+    const parsed = migrationRequestSchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid migration request' }, { status: 400 });
+    }
+    const input = parsed.data;
+    if (input.action !== 'dry-run' && input.confirmWrite !== true) {
+      return NextResponse.json({ error: 'confirmWrite: true is required for apply and rollback' }, { status: 400 });
+    }
+
+    const collectionName =
+      input.action === 'rollback' ? USER_PROGRESS_V4_BACKUPS_COLLECTION : USER_PROGRESS_COLLECTION;
+    const page = await readPage(collectionName, input.cursor, input.limit);
+    const now = new Date().toISOString();
+
+    if (input.action === 'rollback') {
+      const summary = {
+        action: input.action,
+        migrationId: MIGRATION_ID,
+        documentsScanned: page.documents.length,
+        documentsRolledBack: 0,
+        documentsSkippedMissingBackup: 0,
+        documentsSkippedMissingProgress: 0,
+        documentsSkippedConflict: 0,
+      };
+      for (const document of page.documents) {
+        const outcome = await rollbackDocument(document, admin.uid, now);
+        if (outcome.kind === 'rolled-back') summary.documentsRolledBack++;
+        else if (outcome.kind === 'missing-backup') summary.documentsSkippedMissingBackup++;
+        else if (outcome.kind === 'missing-progress') summary.documentsSkippedMissingProgress++;
+        else summary.documentsSkippedConflict++;
+      }
+      return NextResponse.json({
+        ...summary,
+        hasMore: page.hasMore,
+        nextCursor: page.hasMore ? page.documents.at(-1)?.id ?? null : null,
+      });
+    }
+
+    const summary = migrationStats(input.action);
+    summary.documentsScanned = page.documents.length;
+    for (const document of page.documents) {
+      const outcome =
+        input.action === 'dry-run'
+          ? await dryRunDocument(document, now)
+          : await applyDocument(document, admin.uid, now);
+      addMigrationOutcome(summary, outcome, input.action === 'dry-run');
+    }
+    return NextResponse.json({
+      ...summary,
+      hasMore: page.hasMore,
+      nextCursor: page.hasMore ? page.documents.at(-1)?.id ?? null : null,
+    });
+  } catch (error) {
+    if (error instanceof AdminAccessError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    console.error('Error migrating exercise-based lesson progress:', error);
+    return NextResponse.json({ error: 'Failed to migrate exercise-based lesson progress' }, { status: 500 });
+  }
+}

--- a/src/app/api/progress/[userId]/[lessonId]/complete/route.ts
+++ b/src/app/api/progress/[userId]/[lessonId]/complete/route.ts
@@ -73,7 +73,8 @@ export async function POST(
       const persisted = toPersistedProgressSummary(
         { ...summary, isCompleted: true, progress: 100 },
         existing,
-        now
+        now,
+        lesson.version
       );
 
       transaction.set(

--- a/src/app/api/progress/[userId]/[lessonId]/route.ts
+++ b/src/app/api/progress/[userId]/[lessonId]/route.ts
@@ -120,7 +120,7 @@ export async function POST(
             { exerciseId, completedAt: now, score: progressData.score },
           ],
         });
-        const persisted = toPersistedProgressSummary(summary, existing, now);
+        const persisted = toPersistedProgressSummary(summary, existing, now, lesson.version);
         const furthestPageIndex = getFurthestPageIndex(existing, lesson.pages.length);
 
         transaction.set(
@@ -186,7 +186,7 @@ export async function POST(
           furthestPageIndex,
           currentPageIndex: furthestPageIndex,
         });
-        const persisted = toPersistedProgressSummary(summary, existing, now);
+        const persisted = toPersistedProgressSummary(summary, existing, now, lesson.version);
 
         transaction.set(
           progressRef,
@@ -248,7 +248,12 @@ export async function POST(
           return { missingExercises: summary.missingExercises };
         }
 
-        const persisted = toPersistedProgressSummary({ ...summary, isCompleted: true, progress: 100 }, existing, now);
+        const persisted = toPersistedProgressSummary(
+          { ...summary, isCompleted: true, progress: 100 },
+          existing,
+          now,
+          lesson.version
+        );
 
         transaction.set(
           progressRef,

--- a/src/components/ui/lesson/lesson-sidebar.tsx
+++ b/src/components/ui/lesson/lesson-sidebar.tsx
@@ -113,6 +113,7 @@ export default function LessonSidebar({ currentLessonId, isCollapsed = false, on
 
         <div
           hidden={isCollapsed}
+          style={{ display: isCollapsed ? 'none' : undefined }}
           className={cn(
             'absolute inset-0 flex flex-col',
             isCollapsed && 'pointer-events-none'
@@ -264,6 +265,7 @@ export default function LessonSidebar({ currentLessonId, isCollapsed = false, on
 
         <div
           hidden={!isCollapsed}
+          style={{ display: isCollapsed ? undefined : 'none' }}
           className="absolute inset-0 hidden flex-col items-center pt-5 min-[901px]:flex">
           <div className="relative h-10 w-10 bg-gradient-to-br from-roman-red/20 to-roman-terracotta/10 rounded-xl flex items-center justify-center shadow-lg border border-roman-red/20">
             <BookOpen className="h-5 w-5 text-roman-red" />

--- a/src/components/ui/lesson/practice-sidebar.tsx
+++ b/src/components/ui/lesson/practice-sidebar.tsx
@@ -158,6 +158,7 @@ export default function PracticeSidebar({
 
         <div
           hidden={isCollapsed}
+          style={{ display: isCollapsed ? 'none' : undefined }}
           className={cn(
             'absolute inset-0 flex flex-col',
             isCollapsed && 'pointer-events-none'
@@ -280,6 +281,7 @@ export default function PracticeSidebar({
 
         <div
           hidden={!isCollapsed}
+          style={{ display: isCollapsed ? undefined : 'none' }}
           className="absolute inset-0 hidden flex-col items-center pt-5 min-[901px]:flex">
           <div className="relative h-10 w-10 bg-gradient-to-br from-roman-red/20 to-roman-terracotta/10 rounded-xl flex items-center justify-center shadow-lg border border-roman-red/20">
             <Pencil className="h-5 w-5 text-roman-red" />

--- a/src/lib/learning-units/progression-access.ts
+++ b/src/lib/learning-units/progression-access.ts
@@ -8,6 +8,7 @@ import {
 } from '@/shared/constants/firestore';
 import type { LearningPathDocument, LessonUnit } from '@/src/types/learning-unit';
 import type { UserProgress } from '@/src/types/lesson';
+import { canonicalizeLessonProgressForRead } from '@/src/utils/lessonProgress';
 import { isLessonDocumentData, normalizeLearningUnit } from './domain';
 import { parseLearningPathSnapshot } from './learning-path-service';
 import {
@@ -62,33 +63,46 @@ async function isUnitSequenceUnlockedInTransaction(
   const effectiveTargetIndex = units.findIndex(unit => unit.id === targetId);
   if (effectiveTargetIndex < 0) return false;
 
-  const progressByUnitId = new Map(
-    progressSnapshot.docs.flatMap(snapshot => {
-      const data = snapshot.data() as Partial<UserProgress>;
-      const unitId =
-        typeof data.lessonId === 'string'
-          ? data.lessonId
-          : snapshot.id.startsWith(`${studentId}_`)
-            ? snapshot.id.slice(studentId.length + 1)
-            : null;
-      return unitId ? [[unitId, data] as const] : [];
-    })
-  );
+  const progressByUnitId = new Map<string, Partial<UserProgress>>();
+  const progressSnapshotByUnitId = new Map<string, (typeof progressSnapshot.docs)[number]>();
+  for (const snapshot of progressSnapshot.docs) {
+    const data = snapshot.data() as Partial<UserProgress>;
+    const unitId =
+      typeof data.lessonId === 'string'
+        ? data.lessonId
+        : snapshot.id.startsWith(`${studentId}_`)
+          ? snapshot.id.slice(studentId.length + 1)
+          : null;
+    if (!unitId) continue;
+    progressByUnitId.set(unitId, data);
+    progressSnapshotByUnitId.set(unitId, snapshot);
+  }
   const attemptedTestIds = new Set<string>();
   const activity = { progressByUnitId, attemptedTestIds };
   if (isProgressionUnitUnlocked(units, effectiveTargetIndex, activity)) return true;
 
-  // Page counts were masked out above; load the previous unit's pages only
-  // when its legacy completion fallback could still unlock the target.
+  // Full lesson and progress data are loaded only for the previous lesson whose
+  // canonical completion could unlock the target.
   const previous = units[effectiveTargetIndex - 1];
   const previousProgress = progressByUnitId.get(previous.id);
-  if (previous.kind === 'lesson' && previousProgress) {
-    const previousUnitSnapshot = await transaction.get(db.collection(LEARNING_UNITS_COLLECTION).doc(previous.id));
-    if (previousUnitSnapshot.exists) {
+  const previousProgressSnapshot = progressSnapshotByUnitId.get(previous.id);
+  if (previous.kind === 'lesson' && previousProgress && previousProgressSnapshot) {
+    const [previousUnitSnapshot, fullProgressSnapshot] = await Promise.all([
+      transaction.get(db.collection(LEARNING_UNITS_COLLECTION).doc(previous.id)),
+      transaction.get(previousProgressSnapshot.ref),
+    ]);
+    if (previousUnitSnapshot.exists && fullProgressSnapshot.exists) {
       try {
         const previousUnit = normalizeLearningUnit(previousUnitSnapshot.data(), previous.id);
         if (previousUnit.kind === 'lesson') {
           previous.totalPages = previousUnit.pages.length;
+          progressByUnitId.set(
+            previous.id,
+            canonicalizeLessonProgressForRead(
+              { pages: previousUnit.pages, version: previousUnit.version },
+              fullProgressSnapshot.data() as Partial<UserProgress>
+            )
+          );
           if (isProgressionUnitUnlocked(units, effectiveTargetIndex, activity)) return true;
         }
       } catch {

--- a/src/lib/learning-units/student-dashboard-service.ts
+++ b/src/lib/learning-units/student-dashboard-service.ts
@@ -22,7 +22,9 @@ import type { LearningUnit, LessonUnitType } from '@/src/types/learning-unit';
 import type { TestAttemptOriginSummary, TestUnitSummary, TestVersionSummary } from '@/src/types/test';
 import {
   calculateStoredProgress,
+  canonicalizeLessonProgressForRead,
   getFurthestPageIndex,
+  hasTrustedExerciseProgressSummary,
   isStoredLessonComplete,
   summarizeLessonCompletion,
 } from '@/src/utils/lessonProgress';
@@ -67,9 +69,9 @@ const LESSON_SUMMARY_FIELDS = [
 const LEARNING_UNIT_SUMMARY_FIELDS = [...LESSON_SUMMARY_FIELDS, 'rotationVersions', 'passingPercentage'] as const;
 
 /**
- * The dashboard projection never consumes per-exercise history, so the
- * progress read excludes the unbounded `exerciseProgress` arrays that grow
- * with student activity. `getLesson` still reads full progress documents.
+ * The normal dashboard path consumes only bounded progress summaries. Legacy
+ * or lesson-version-stale records are canonically recomputed from full history
+ * by `hydrateCanonicalProgressSummaries` below.
  */
 const PROGRESS_SUMMARY_FIELDS = [
   'userId',
@@ -80,7 +82,11 @@ const PROGRESS_SUMMARY_FIELDS = [
   'currentPageIndex',
   'score',
   'lastAccessedAt',
+  'progress',
+  'completedExerciseCount',
+  'requiredExerciseCount',
   'progressSchemaVersion',
+  'progressLessonVersion',
 ] as const;
 
 const PRACTICE_TYPE_ORDER: LessonUnitType[] = ['vocab', 'sentence-diagramming', 'listening'];
@@ -388,7 +394,11 @@ export class StudentDashboardService {
     const progress =
       status === 'locked'
         ? 0
-        : calculateStoredProgress(storedProgress, lesson.totalPages);
+        : calculateStoredProgress(storedProgress, {
+            totalPages: lesson.totalPages,
+            totalExercises: lesson.totalExercises,
+            lessonVersion: lesson.version,
+          });
 
     return {
       ...lesson,
@@ -402,7 +412,79 @@ export class StudentDashboardService {
       score: storedProgress?.score,
       lastAccessedAt: storedProgress?.lastAccessedAt,
       progressSchemaVersion: storedProgress?.progressSchemaVersion,
+      progressLessonVersion: storedProgress?.progressLessonVersion,
     };
+  }
+
+  private async hydrateCanonicalProgressSummaries(
+    userId: string,
+    lessons: LessonSummary[],
+    projectedProgress: Map<string, UserProgress>,
+    progressDocumentsAreFull = false
+  ): Promise<Map<string, UserProgress>> {
+    const staleLessons = lessons.filter(lesson => {
+      const progress = projectedProgress.get(lesson.id);
+      if (!progress || progress.status === 'completed' || lesson.totalExercises === 0) return false;
+      return !hasTrustedExerciseProgressSummary(progress, {
+        totalPages: lesson.totalPages,
+        totalExercises: lesson.totalExercises,
+        lessonVersion: lesson.version,
+      });
+    });
+    if (staleLessons.length === 0) return projectedProgress;
+
+    const [lessonSnapshots, fullProgressSnapshots] = await Promise.all([
+      this.db.getAll(...staleLessons.map(lesson => this.units.doc(lesson.id))),
+      progressDocumentsAreFull
+        ? Promise.resolve([])
+        : this.db.getAll(...staleLessons.map(lesson => this.progress.doc(`${userId}_${lesson.id}`))),
+    ]);
+    const fullProgressByLessonId = progressDocumentsAreFull ? projectedProgress : new Map<string, UserProgress>();
+    if (!progressDocumentsAreFull) {
+      for (const document of fullProgressSnapshots) {
+        const lessonId = progressLessonId(document);
+        if (lessonId) fullProgressByLessonId.set(lessonId, document.data() as UserProgress);
+      }
+    }
+
+    const hydrated = new Map(projectedProgress);
+    for (const snapshot of lessonSnapshots) {
+      const fullProgress = fullProgressByLessonId.get(snapshot.id);
+      const data = snapshot.data();
+      if (!fullProgress || !snapshot.exists || !isLessonDocumentData(data) || data._deletionPending === true) {
+        continue;
+      }
+      try {
+        const lesson = fullLessonFromSnapshot(snapshot);
+        hydrated.set(snapshot.id, canonicalizeLessonProgressForRead(lesson, fullProgress) as UserProgress);
+      } catch (error) {
+        console.error(`Unable to canonicalize progress for invalid lesson ${snapshot.id}; skipping it`, error);
+      }
+    }
+
+    for (const lesson of staleLessons) {
+      const progress = hydrated.get(lesson.id);
+      if (!progress || progress.status === 'completed' || lesson.totalExercises === 0) continue;
+      if (
+        hasTrustedExerciseProgressSummary(progress, {
+          totalPages: lesson.totalPages,
+          totalExercises: lesson.totalExercises,
+          lessonVersion: lesson.version,
+        })
+      ) {
+        continue;
+      }
+      console.error(
+        `Unable to trust hydrated progress for lesson ${lesson.id}; dashboard will show 0% until the lesson summary matches authored exercises`,
+        {
+          requiredExerciseCount: progress.requiredExerciseCount,
+          totalExercises: lesson.totalExercises,
+          progressLessonVersion: progress.progressLessonVersion,
+          lessonVersion: lesson.version,
+        }
+      );
+    }
+    return hydrated;
   }
 
   private unlockedStatus(
@@ -575,23 +657,28 @@ export class StudentDashboardService {
       this.getProgressByLessonId(userId, PROGRESS_SUMMARY_FIELDS),
     ]);
     const testUnits = normalUnits.filter((unit): unit is TestUnitSummary => unit.kind === 'test');
+    const lessonSummaries = [
+      ...normalUnits.filter((unit): unit is CanonicalLessonSummary => unit.kind === 'lesson'),
+      ...rawPracticeLessons,
+    ];
 
     // Attempt summaries, practice enrichment, and mock listing are independent
     // of each other, so they all run concurrently instead of one-after-another.
     // The past-result projection runs unfiltered here and is reconciled against
     // the live cards below, which keeps it off the mock listing's critical path.
-    const [attemptSummaries, practiceLessons, mockTests, pastMockResults] = await Promise.all([
+    const [attemptSummaries, practiceLessons, mockTests, pastMockResults, canonicalProgressByLessonId] = await Promise.all([
       this.getAttemptSummaries(testUnits, userId),
       this.enrichPracticeLessons(rawPracticeLessons),
       this.mocks.listStudentLiveMocks(userId),
       this.mocks.listPastStudentMockResults(userId),
+      this.hydrateCanonicalProgressSummaries(userId, lessonSummaries, progressByLessonId),
     ]);
 
     const liveMockTests = mockTests ?? [];
     const liveMockIds = new Set(liveMockTests.map(mock => mock.id));
     const reviewablePastMockResults = pastMockResults.filter(result => !liveMockIds.has(result.id));
 
-    const learningPath = this.processNormalUnits(normalUnits, progressByLessonId, attemptSummaries);
+    const learningPath = this.processNormalUnits(normalUnits, canonicalProgressByLessonId, attemptSummaries);
     await Promise.all(
       learningPath.map(async unit => {
         // The frozen attempt outcome, rather than the test's current settings,
@@ -603,7 +690,7 @@ export class StudentDashboardService {
     );
     return {
       learningPath,
-      practiceLessons: this.processPracticeLessons(practiceLessons, progressByLessonId),
+      practiceLessons: this.processPracticeLessons(practiceLessons, canonicalProgressByLessonId),
       ...(liveMockTests.length ? { mockTests: liveMockTests } : {}),
       ...(reviewablePastMockResults.length ? { pastMockResults: reviewablePastMockResults } : {}),
     };
@@ -657,13 +744,26 @@ export class StudentDashboardService {
     lessonId: string,
     progressByLessonId: Map<string, UserProgress>
   ): Promise<void> {
-    const units = (await this.getNormalUnitSummaries()).map(toProgressionUnit);
+    const unitSummaries = await this.getNormalUnitSummaries();
+    const lessonSummaries = unitSummaries.filter(
+      (unit): unit is CanonicalLessonSummary => unit.kind === 'lesson'
+    );
+    const canonicalProgressByLessonId = await this.hydrateCanonicalProgressSummaries(
+      userId,
+      lessonSummaries,
+      progressByLessonId,
+      true
+    );
+    const units = unitSummaries.map(toProgressionUnit);
     const targetIndex = units.findIndex(unit => unit.id === lessonId);
     if (targetIndex < 0) {
       throw new StudentDashboardServiceError('LESSON_NOT_FOUND', 'Lesson not found', 404);
     }
 
-    const activity: ProgressionActivity = { progressByUnitId: progressByLessonId, attemptedTestIds: new Set() };
+    const activity: ProgressionActivity = {
+      progressByUnitId: canonicalProgressByLessonId,
+      attemptedTestIds: new Set(),
+    };
     const isUnlocked =
       isProgressionUnitUnlocked(units, targetIndex, activity) ||
       (units.some(unit => unit.kind === 'test') &&
@@ -693,6 +793,7 @@ export class StudentDashboardService {
     const totalPages = lesson.pages.length;
     const furthestPageIndex = getFurthestPageIndex(storedProgress, totalPages);
     const summary = summarizeLessonCompletion(lesson, storedProgress);
+    const canonicalProgress = storedProgress ? canonicalizeLessonProgressForRead(lesson, storedProgress) : undefined;
     return {
       ...lesson,
       progress: summary.progress,
@@ -706,6 +807,7 @@ export class StudentDashboardService {
       score: storedProgress?.score,
       lastAccessedAt: storedProgress?.lastAccessedAt,
       progressSchemaVersion: storedProgress?.progressSchemaVersion,
+      progressLessonVersion: canonicalProgress?.progressLessonVersion,
       ...(practice
         ? {
             practiceCategories: practice.practiceCategories,

--- a/src/types/lesson.d.ts
+++ b/src/types/lesson.d.ts
@@ -52,6 +52,7 @@ export type StudentLessonSummary = Omit<LessonSummary, 'kind'> & {
   score?: number;
   lastAccessedAt?: string;
   progressSchemaVersion?: number;
+  progressLessonVersion?: number;
 };
 
 export type StudentTestSummary = TestUnitSummary & {
@@ -91,6 +92,7 @@ export type LessonWithProgress = Lesson & {
   score?: number;
   lastAccessedAt?: string;
   progressSchemaVersion?: number;
+  progressLessonVersion?: number;
 };
 
 export interface ExerciseProgress {
@@ -114,6 +116,10 @@ export interface UserProgress {
   lastAccessedAt: string;
   progress?: number;
   progressSchemaVersion?: number;
+  progressLessonVersion?: number;
+  progressMigrationId?: string;
+  progressMigratedAt?: string;
+  progressMigratedBy?: string;
 }
 
 export type { Page } from './page';

--- a/src/utils/lessonProgress.ts
+++ b/src/utils/lessonProgress.ts
@@ -1,7 +1,7 @@
 import { ExerciseProgress, Lesson, UserProgress } from '@/src/types/lesson';
 import { isExerciseType, parsePageIndex } from './lessonUtils';
 
-export const PROGRESS_SCHEMA_VERSION = 3;
+export const PROGRESS_SCHEMA_VERSION = 4;
 export const STABLE_ID_PROGRESS_SCHEMA_VERSION = 2;
 
 export interface RequiredExercise {
@@ -171,6 +171,41 @@ export interface LessonCompletionSummary {
   missingExercises: RequiredExercise[];
 }
 
+export interface StoredProgressCalculationOptions {
+  totalPages: number;
+  totalExercises?: number;
+  lessonVersion?: number;
+}
+
+function normalizedLessonVersion(version: unknown): number {
+  return Number.isSafeInteger(version) && (version as number) >= 0 ? (version as number) : 0;
+}
+
+function exerciseCompletionPercentage(completedExerciseCount: number, requiredExerciseCount: number): number {
+  if (requiredExerciseCount <= 0) return 0;
+  if (completedExerciseCount >= requiredExerciseCount) return 100;
+  return Math.min(99, Math.round((completedExerciseCount / requiredExerciseCount) * 100));
+}
+
+export function hasTrustedExerciseProgressSummary(
+  progress: Partial<UserProgress> | undefined,
+  options: StoredProgressCalculationOptions
+): boolean {
+  const totalExercises = options.totalExercises ?? 0;
+  return Boolean(
+    progress &&
+      totalExercises > 0 &&
+      typeof progress.progressSchemaVersion === 'number' &&
+      progress.progressSchemaVersion === PROGRESS_SCHEMA_VERSION &&
+      progress.progressLessonVersion === normalizedLessonVersion(options.lessonVersion) &&
+      Number.isSafeInteger(progress.requiredExerciseCount) &&
+      progress.requiredExerciseCount === totalExercises &&
+      Number.isSafeInteger(progress.completedExerciseCount) &&
+      (progress.completedExerciseCount as number) >= 0 &&
+      (progress.completedExerciseCount as number) <= totalExercises
+  );
+}
+
 export function summarizeLessonCompletion(
   lesson: Pick<Lesson, 'pages'>,
   stored: Partial<UserProgress> | undefined
@@ -187,9 +222,11 @@ export function summarizeLessonCompletion(
   const furthestPageIndex = getFurthestPageIndex(stored, totalPages);
   const progress = isCompleted
     ? 100
-    : furthestPageIndex < 0
-      ? 0
-      : Math.min(99, Math.round(((furthestPageIndex + 1) / totalPages) * 100));
+    : requiredExerciseCount > 0
+      ? exerciseCompletionPercentage(completedExerciseCount, requiredExerciseCount)
+      : furthestPageIndex < 0
+        ? 0
+        : Math.min(99, Math.round(((furthestPageIndex + 1) / totalPages) * 100));
 
   return {
     exerciseProgress,
@@ -201,16 +238,35 @@ export function summarizeLessonCompletion(
   };
 }
 
+export function canonicalizeLessonProgressForRead(
+  lesson: Pick<Lesson, 'pages' | 'version'>,
+  stored: Partial<UserProgress>
+): Partial<UserProgress> {
+  const summary = summarizeLessonCompletion(lesson, stored);
+  return {
+    ...stored,
+    exerciseProgress: summary.exerciseProgress,
+    completedExerciseCount: summary.completedExerciseCount,
+    requiredExerciseCount: summary.requiredExerciseCount,
+    progress: summary.progress,
+    status: summary.isCompleted ? 'completed' : 'in-progress',
+    progressSchemaVersion: PROGRESS_SCHEMA_VERSION,
+    progressLessonVersion: normalizedLessonVersion(lesson.version),
+  };
+}
+
 export function toPersistedProgressSummary(
   summary: LessonCompletionSummary,
   existing: Partial<UserProgress> | undefined,
-  now: string
+  now: string,
+  lessonVersion: number | undefined
 ) {
   return {
     exerciseProgress: summary.exerciseProgress,
     progress: summary.progress,
     completedExerciseCount: summary.completedExerciseCount,
     requiredExerciseCount: summary.requiredExerciseCount,
+    progressLessonVersion: normalizedLessonVersion(lessonVersion),
     status: summary.isCompleted ? ('completed' as const) : ('in-progress' as const),
     ...(summary.isCompleted ? { completedAt: existing?.completedAt || now } : {}),
     progressSchemaVersion: PROGRESS_SCHEMA_VERSION,
@@ -219,12 +275,21 @@ export function toPersistedProgressSummary(
 
 export function calculateStoredProgress(
   progress: Partial<UserProgress> | undefined,
-  totalPagesOrOptions: number | { totalPages: number; totalExercises?: number }
+  totalPagesOrOptions: number | StoredProgressCalculationOptions
 ): number {
-  const totalPages =
-    typeof totalPagesOrOptions === 'number' ? totalPagesOrOptions : totalPagesOrOptions.totalPages;
+  const options =
+    typeof totalPagesOrOptions === 'number'
+      ? { totalPages: totalPagesOrOptions, totalExercises: 0, lessonVersion: 0 }
+      : totalPagesOrOptions;
+  const totalPages = options.totalPages;
   if (!progress || totalPages <= 0) return 0;
   if (isStoredLessonComplete(progress, totalPages)) return 100;
+
+  const totalExercises = options.totalExercises ?? 0;
+  if (totalExercises > 0) {
+    if (!hasTrustedExerciseProgressSummary(progress, options)) return 0;
+    return exerciseCompletionPercentage(progress.completedExerciseCount as number, totalExercises);
+  }
 
   const furthestPageIndex = getFurthestPageIndex(progress, totalPages);
   if (furthestPageIndex < 0) return 0;

--- a/src/utils/progressMigration.ts
+++ b/src/utils/progressMigration.ts
@@ -5,6 +5,8 @@ import {
   isStoredLessonComplete,
   resolveExerciseId,
   STABLE_ID_PROGRESS_SCHEMA_VERSION,
+  summarizeLessonCompletion,
+  toPersistedProgressSummary,
 } from './lessonProgress';
 
 export interface ProgressMigrationResult {
@@ -44,10 +46,11 @@ export function migrateUserProgress(
     }
 
     mappedExerciseRecords++;
+    const completedAt = typeof record.completedAt === 'string' ? record.completedAt : '';
     const previous = normalizedRecords.get(stableId);
     if (previous) deduplicatedExerciseRecords++;
-    if (!previous || record.completedAt >= previous.completedAt) {
-      normalizedRecords.set(stableId, { ...record, exerciseId: stableId });
+    if (!previous || completedAt >= previous.completedAt) {
+      normalizedRecords.set(stableId, { ...record, exerciseId: stableId, completedAt });
     }
   }
 
@@ -69,5 +72,33 @@ export function migrateUserProgress(
     unmappedExerciseRecords,
     deduplicatedExerciseRecords,
     derivedCompletion: isCompleted && !wasExplicitlyCompleted,
+  };
+}
+
+export interface ExerciseProgressV4MigrationResult extends Omit<ProgressMigrationResult, 'progress'> {
+  progress: Partial<UserProgress>;
+  resetIncompleteProgressToZero: boolean;
+}
+
+export function migrateUserProgressToExerciseBasis(
+  lesson: Lesson,
+  existing: Partial<UserProgress>,
+  now: string
+): ExerciseProgressV4MigrationResult {
+  const stable = migrateUserProgress(lesson, existing, now);
+  const summary = summarizeLessonCompletion(lesson, stable.progress);
+  const furthestPageIndex = getFurthestPageIndex(stable.progress, lesson.pages.length);
+  const persisted = toPersistedProgressSummary(summary, existing, now, lesson.version);
+
+  return {
+    ...stable,
+    progress: {
+      ...existing,
+      furthestPageIndex,
+      currentPageIndex: furthestPageIndex,
+      ...persisted,
+    },
+    resetIncompleteProgressToZero:
+      !summary.isCompleted && summary.requiredExerciseCount > 0 && summary.completedExerciseCount === 0,
   };
 }

--- a/tests/lessonProgress.test.ts
+++ b/tests/lessonProgress.test.ts
@@ -155,8 +155,8 @@ const passiveLesson = {
   ],
 } as unknown as Lesson;
 
-describe('schema-v3 lesson completion', () => {
-  it('keeps page progress separate from required exercise completion', () => {
+describe('schema-v4 lesson completion', () => {
+  it('derives exercise lesson progress from completed required exercises', () => {
     const none = summarizeLessonCompletion(threeExerciseLesson, { status: 'in-progress', exerciseProgress: [] });
     expect(none).toMatchObject({
       completedExerciseCount: 0,
@@ -169,7 +169,7 @@ describe('schema-v3 lesson completion', () => {
       status: 'in-progress',
       exerciseProgress: [{ exerciseId: 'exercise-a', score: 0, completedAt: '2026-01-01T00:00:00.000Z' }],
     });
-    expect(one.progress).toBe(0);
+    expect(one.progress).toBe(33);
     expect(one.isCompleted).toBe(false);
 
     const two = summarizeLessonCompletion(threeExerciseLesson, {
@@ -194,7 +194,38 @@ describe('schema-v3 lesson completion', () => {
     expect(all).toMatchObject({ progress: 100, isCompleted: true, missingExercises: [] });
   });
 
-  it('keeps passive-only lessons at 0 until the final page is reached', () => {
+  it('caps an incomplete rounded exercise percentage at 99', () => {
+    const manyExerciseLesson = {
+      ...lesson,
+      pages: [
+        {
+          id: 'page-many',
+          items: Array.from({ length: 200 }, (_, index) => ({
+            id: `exercise-${index}`,
+            type: 'fill',
+            title: `Exercise ${index}`,
+          })),
+        },
+      ],
+    } as unknown as Lesson;
+    const summary = summarizeLessonCompletion(manyExerciseLesson, {
+      status: 'in-progress',
+      exerciseProgress: Array.from({ length: 199 }, (_, index) => ({
+        exerciseId: `exercise-${index}`,
+        score: 0,
+        completedAt: '2026-01-01T00:00:00.000Z',
+      })),
+    });
+
+    expect(summary).toMatchObject({
+      completedExerciseCount: 199,
+      requiredExerciseCount: 200,
+      progress: 99,
+      isCompleted: false,
+    });
+  });
+
+  it('keeps passive-only lessons page-based', () => {
     expect(summarizeLessonCompletion(passiveLesson, { furthestPageIndex: 1, status: 'in-progress' })).toMatchObject({
       progress: 67,
       isCompleted: false,
@@ -228,13 +259,15 @@ describe('schema-v3 lesson completion', () => {
     expect(hasLegacyCompletion({ currentPageIndex: 3, progressSchemaVersion: '1' as never }, 3)).toBe(false);
   });
 
-  it('always derives stored progress from the furthest authored page', () => {
+  it('trusts only current schema-v4 exercise summaries and keeps passive progress page-based', () => {
     expect(
       calculateStoredProgress(
         {
-          progressSchemaVersion: 3,
+          progressSchemaVersion: 4,
           progress: 33,
+          completedExerciseCount: 1,
           requiredExerciseCount: 3,
+          progressLessonVersion: 0,
           furthestPageIndex: 0,
           status: 'in-progress',
         },
@@ -244,15 +277,29 @@ describe('schema-v3 lesson completion', () => {
     expect(
       calculateStoredProgress(
         {
-          progressSchemaVersion: 3,
+          progressSchemaVersion: 5,
+          completedExerciseCount: 1,
+          requiredExerciseCount: 3,
+          progressLessonVersion: 0,
+          status: 'in-progress',
+        },
+        { totalPages: 3, totalExercises: 3 }
+      )
+    ).toBe(0);
+    expect(
+      calculateStoredProgress(
+        {
+          progressSchemaVersion: 4,
           progress: 66,
+          completedExerciseCount: 2,
           requiredExerciseCount: 2,
+          progressLessonVersion: 0,
           furthestPageIndex: 2,
           status: 'in-progress',
         },
         { totalPages: 4, totalExercises: 3 }
       )
-    ).toBe(75);
+    ).toBe(0);
     expect(
       calculateStoredProgress(
         { progressSchemaVersion: 1, currentPageIndex: 0, status: 'in-progress' },
@@ -279,13 +326,15 @@ describe('schema-v3 lesson completion', () => {
 
   it('can display numeric 100 without treating the lesson as unlocked', () => {
     const stored = {
-      progressSchemaVersion: 3,
+      progressSchemaVersion: 4,
       progress: 100,
+      completedExerciseCount: 0,
       requiredExerciseCount: 1,
+      progressLessonVersion: 0,
       status: 'in-progress' as const,
       furthestPageIndex: 0,
     };
-    expect(calculateStoredProgress(stored, { totalPages: 2, totalExercises: 1 })).toBe(50);
+    expect(calculateStoredProgress(stored, { totalPages: 2, totalExercises: 1 })).toBe(0);
     expect(isStoredLessonComplete(stored, 2)).toBe(false);
     expect(
       isProgressionUnitComplete(

--- a/tests/lessonSidebarMixedPath.test.tsx
+++ b/tests/lessonSidebarMixedPath.test.tsx
@@ -133,7 +133,16 @@ describe('lesson sidebar mixed Learning Path', () => {
     render(<LessonSidebar currentLessonId="lesson-1" isCollapsed />);
 
     expect(screen.queryByRole('button', { name: /^Chapter test TEST Pass/ })).not.toBeInTheDocument();
+    expect(screen.getByText('Your Learning Path')).not.toBeVisible();
+    expect(screen.getByText('Path')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Close lessons sidebar' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Expand lessons sidebar' })).toBeInTheDocument();
+  });
+
+  it('does not paint the collapsed path rail over the expanded sidebar', () => {
+    render(<LessonSidebar currentLessonId="lesson-1" />);
+
+    expect(screen.getByText('Your Learning Path')).toBeInTheDocument();
+    expect(screen.getByText('Path')).not.toBeVisible();
   });
 });

--- a/tests/practiceSidebarWordSearchVisibility.test.tsx
+++ b/tests/practiceSidebarWordSearchVisibility.test.tsx
@@ -47,5 +47,17 @@ describe('PracticeSidebar word-search visibility', () => {
 
     expect(screen.getByPlaceholderText('Search Latin words...')).toBeInTheDocument();
     expect(mockUseSearchWordsQuery).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('heading', { name: 'Practice' })).toBeVisible();
+    expect(screen.getByText('Practice', { selector: 'span' })).not.toBeVisible();
+  });
+
+  it('renders only the compact practice rail while collapsed', () => {
+    render(<PracticeSidebar currentLessonId="lesson-1" showWordSearch isCollapsed />);
+
+    expect(screen.getByText('Practice', { selector: 'span' })).toBeVisible();
+    expect(screen.getByRole('heading', { name: 'Practice', hidden: true })).not.toBeVisible();
+    expect(screen.getByPlaceholderText('Search Latin words...')).not.toBeVisible();
+    expect(screen.getByText('Vocabulary')).not.toBeVisible();
+    expect(screen.getByRole('button', { name: 'Expand practice sidebar' })).toBeInTheDocument();
   });
 });

--- a/tests/progressRoutes.test.ts
+++ b/tests/progressRoutes.test.ts
@@ -42,6 +42,7 @@ jest.mock('@/src/lib/learning-units/progression-access', () => ({
 const lesson = {
   title: 'Lesson',
   type: 'normal',
+  version: 7,
   pages: [
     {
       id: 'page-1',
@@ -54,6 +55,7 @@ const lesson = {
 const passiveLesson = {
   title: 'Passive',
   type: 'normal',
+  version: 7,
   pages: [
     { id: 'page-1', items: [{ id: 'text-1', type: 'text', content: 'Read' }] },
     { id: 'page-2', items: [{ id: 'text-2', type: 'text', content: 'End' }] },
@@ -164,7 +166,8 @@ describe('progress update route', () => {
       expect.anything(),
       expect.objectContaining({
         status: 'completed',
-        progressSchemaVersion: 3,
+        progressSchemaVersion: 4,
+        progressLessonVersion: 7,
         progress: 100,
         completedExerciseCount: 1,
         requiredExerciseCount: 1,
@@ -246,7 +249,7 @@ describe('progress update route', () => {
     });
     expect(mockTransactionSet).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ status: 'completed', progressSchemaVersion: 3, progress: 100 }),
+      expect.objectContaining({ status: 'completed', progressSchemaVersion: 4, progressLessonVersion: 7, progress: 100 }),
       { merge: true }
     );
   });
@@ -267,7 +270,7 @@ describe('progress update route', () => {
     expect(response.body.progress).toBe(100);
     expect(mockTransactionSet).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ status: 'completed', progressSchemaVersion: 3 }),
+      expect.objectContaining({ status: 'completed', progressSchemaVersion: 4, progressLessonVersion: 7 }),
       { merge: true }
     );
   });
@@ -286,10 +289,10 @@ describe('progress update route', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.lessonCompleted).toBe(false);
-    expect(response.body.progress).toBe(50);
+    expect(response.body.progress).toBe(0);
     expect(mockTransactionSet).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ status: 'in-progress', progressSchemaVersion: 3, progress: 50 }),
+      expect.objectContaining({ status: 'in-progress', progressSchemaVersion: 4, progressLessonVersion: 7, progress: 0 }),
       { merge: true }
     );
   });
@@ -304,7 +307,7 @@ describe('progress update route', () => {
     expect(response.body.furthestPageIndex).toBe(1);
     expect(mockTransactionSet).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ furthestPageIndex: 1, progressSchemaVersion: 3 }),
+      expect.objectContaining({ furthestPageIndex: 1, progressSchemaVersion: 4, progressLessonVersion: 7 }),
       { merge: true }
     );
   });
@@ -361,7 +364,7 @@ describe('finish route', () => {
     });
     expect(mockTransactionSet).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ status: 'completed', completedAt: '2026-01-01', progressSchemaVersion: 3 }),
+      expect.objectContaining({ status: 'completed', completedAt: '2026-01-01', progressSchemaVersion: 4, progressLessonVersion: 7 }),
       { merge: true }
     );
   });

--- a/tests/progressV4MigrationRoute.test.ts
+++ b/tests/progressV4MigrationRoute.test.ts
@@ -1,0 +1,396 @@
+type Data = Record<string, unknown>;
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const mockCollections = new Map<string, Map<string, Data>>();
+const mockVerifyAdminAccess = jest.fn(async (_request?: unknown) => ({ uid: 'admin-1' }));
+const mockRunTransaction = jest.fn();
+let mockBeforeTransaction: (() => void) | undefined;
+
+class FakeDocumentRef {
+  constructor(
+    readonly collectionName: string,
+    readonly id: string
+  ) {}
+
+  async get() {
+    return snapshot(this, mockCollections.get(this.collectionName)?.get(this.id));
+  }
+}
+
+function snapshot(ref: FakeDocumentRef, data?: Data) {
+  return {
+    id: ref.id,
+    ref,
+    exists: data !== undefined,
+    data: () => data,
+  };
+}
+
+class FakeQuery {
+  private after?: string;
+  private max = Number.MAX_SAFE_INTEGER;
+
+  constructor(readonly collectionName: string) {}
+
+  doc(id: string) {
+    return new FakeDocumentRef(this.collectionName, id);
+  }
+
+  orderBy() {
+    return this;
+  }
+
+  startAfter(cursor: string) {
+    this.after = cursor;
+    return this;
+  }
+
+  limit(limit: number) {
+    this.max = limit;
+    return this;
+  }
+
+  async get() {
+    const entries = [...(mockCollections.get(this.collectionName)?.entries() ?? [])]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .filter(([id]) => !this.after || id > this.after)
+      .slice(0, this.max);
+    return { docs: entries.map(([id, data]) => snapshot(this.doc(id), data)) };
+  }
+}
+
+jest.mock('next/server', () => jest.requireActual('./helpers/routeMocks'));
+jest.mock('firebase-admin/firestore', () => ({ FieldPath: { documentId: () => '__name__' } }));
+jest.mock('@/src/services/firebase-admin', () => ({
+  adminDb: {
+    collection: (name: string) => new FakeQuery(name),
+    runTransaction: (...args: unknown[]) => mockRunTransaction(...args),
+  },
+}));
+jest.mock('@/src/lib/verifyAdminAccess', () => {
+  class AdminAccessError extends Error {
+    status = 401;
+  }
+
+  return {
+    AdminAccessError,
+    verifyAdminAccess: (request: unknown) => mockVerifyAdminAccess(request),
+  };
+});
+
+import { POST as migrateExerciseProgress } from '@/src/app/api/admin/progress/migrate-exercise-progress-v4/route';
+import { AdminAccessError } from '@/src/lib/verifyAdminAccess';
+
+const exerciseLesson = {
+  id: 'lesson-1',
+  kind: 'lesson',
+  title: 'Exercise lesson',
+  description: '',
+  type: 'normal',
+  version: 7,
+  pages: [{ id: 'page-1', items: [{ id: 'exercise-1', type: 'fill', title: 'Exercise' }] }],
+  totalPages: 1,
+  totalItems: 1,
+  totalExercises: 1,
+  isLive: true,
+  liveOrder: 0,
+  publishedAt: 'now',
+  publishedBy: 'admin',
+};
+
+function seed(collection: string, id: string, data: Data) {
+  if (!mockCollections.has(collection)) mockCollections.set(collection, new Map());
+  mockCollections.get(collection)!.set(id, clone(data));
+}
+
+function stored(collection: string, id: string) {
+  return mockCollections.get(collection)?.get(id);
+}
+
+function request(body: unknown) {
+  return { json: async () => body } as never;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCollections.clear();
+  mockBeforeTransaction = undefined;
+  mockVerifyAdminAccess.mockResolvedValue({ uid: 'admin-1' });
+  mockRunTransaction.mockImplementation(async callback => {
+    mockBeforeTransaction?.();
+    mockBeforeTransaction = undefined;
+    const writes: Array<() => void> = [];
+    const result = await callback({
+      get: async (ref: FakeDocumentRef) => ref.get(),
+      create: (ref: FakeDocumentRef, data: Data) => {
+        writes.push(() => {
+          const collection = mockCollections.get(ref.collectionName) ?? new Map<string, Data>();
+          if (collection.has(ref.id)) throw new Error('already exists');
+          collection.set(ref.id, clone(data));
+          mockCollections.set(ref.collectionName, collection);
+        });
+      },
+      set: (ref: FakeDocumentRef, data: Data, options?: { merge?: boolean }) => {
+        writes.push(() => {
+          const collection = mockCollections.get(ref.collectionName) ?? new Map<string, Data>();
+          const next = options?.merge ? { ...(collection.get(ref.id) ?? {}), ...clone(data) } : clone(data);
+          collection.set(ref.id, next);
+          mockCollections.set(ref.collectionName, collection);
+        });
+      },
+    });
+    writes.forEach(write => write());
+    return result;
+  });
+});
+
+describe('exercise progress v4 migration route', () => {
+  it('rejects malformed JSON without scanning progress', async () => {
+    const response = (await migrateExerciseProgress({
+      json: async () => {
+        throw new SyntaxError('Invalid JSON');
+      },
+    } as never)) as unknown as { status: number };
+
+    expect(response.status).toBe(400);
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+  });
+
+  it('defaults to a read-only dry run and reports an incomplete zero reset', async () => {
+    const original = {
+      userId: 'user-1',
+      lessonId: 'lesson-1',
+      status: 'in-progress',
+      furthestPageIndex: 0,
+      exerciseProgress: [],
+      progressSchemaVersion: 2,
+      updatedAt: 'student-update',
+      lastAccessedAt: 'student-access',
+    };
+    seed('lessons', 'lesson-1', exerciseLesson);
+    seed('userProgress', 'user-1_lesson-1', original);
+
+    const response = (await migrateExerciseProgress(request({}))) as unknown as {
+      status: number;
+      body: Record<string, number | string | boolean | null>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      action: 'dry-run',
+      documentsScanned: 1,
+      documentsWouldMigrate: 1,
+      resetIncompleteProgressToZero: 1,
+      hasMore: false,
+      nextCursor: null,
+    });
+    expect(stored('userProgress', 'user-1_lesson-1')).toEqual(original);
+    expect(stored('userProgressMigrationV4Backups', 'user-1_lesson-1')).toBeUndefined();
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+  });
+
+  it('requires explicit confirmation before apply or rollback', async () => {
+    const apply = (await migrateExerciseProgress(request({ action: 'apply' }))) as unknown as { status: number };
+    const rollback = (await migrateExerciseProgress(request({ action: 'rollback' }))) as unknown as { status: number };
+
+    expect(apply.status).toBe(400);
+    expect(rollback.status).toBe(400);
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+  });
+
+  it('backs up, migrates the latest transactional state, preserves activity timestamps, and reruns idempotently', async () => {
+    const original = {
+      userId: 'user-1',
+      lessonId: 'lesson-1',
+      status: 'in-progress',
+      furthestPageIndex: 0,
+      exerciseProgress: [],
+      progressSchemaVersion: 2,
+      updatedAt: 'before-query',
+      lastAccessedAt: 'before-query',
+    };
+    const concurrent = {
+      ...original,
+      exerciseProgress: [{ exerciseId: 'exercise-1', score: 100, completedAt: 'concurrent' }],
+      updatedAt: 'concurrent-update',
+      lastAccessedAt: 'concurrent-access',
+    };
+    seed('lessons', 'lesson-1', exerciseLesson);
+    seed('userProgress', 'user-1_lesson-1', original);
+    mockBeforeTransaction = () => seed('userProgress', 'user-1_lesson-1', concurrent);
+
+    const applied = (await migrateExerciseProgress(
+      request({ action: 'apply', confirmWrite: true })
+    )) as unknown as { body: Record<string, number> };
+    const migrated = stored('userProgress', 'user-1_lesson-1');
+    const backup = stored('userProgressMigrationV4Backups', 'user-1_lesson-1');
+
+    expect(applied.body.documentsMigrated).toBe(1);
+    expect(migrated).toMatchObject({
+      status: 'completed',
+      progress: 100,
+      completedExerciseCount: 1,
+      requiredExerciseCount: 1,
+      progressSchemaVersion: 4,
+      progressLessonVersion: 7,
+      progressMigrationId: 'exercise-progress-v4',
+      updatedAt: 'concurrent-update',
+      lastAccessedAt: 'concurrent-access',
+    });
+    expect(backup?.data).toEqual(concurrent);
+
+    const rerun = (await migrateExerciseProgress(
+      request({ action: 'apply', confirmWrite: true })
+    )) as unknown as { body: Record<string, number> };
+    expect(rerun.body.documentsAlreadyCurrent).toBe(1);
+    expect(stored('userProgressMigrationV4Backups', 'user-1_lesson-1')?.data).toEqual(concurrent);
+  });
+
+  it('does not overwrite or migrate past an unexpected existing backup', async () => {
+    const original = {
+      userId: 'user-1',
+      lessonId: 'lesson-1',
+      status: 'in-progress',
+      exerciseProgress: [],
+      updatedAt: 'student-update',
+      lastAccessedAt: 'student-access',
+    };
+    seed('lessons', 'lesson-1', exerciseLesson);
+    seed('userProgress', 'user-1_lesson-1', original);
+    seed('userProgressMigrationV4Backups', 'user-1_lesson-1', {
+      migrationId: 'other-migration',
+      progressDocumentId: 'user-1_lesson-1',
+      data: { doNotOverwrite: true },
+    });
+
+    const response = (await migrateExerciseProgress(
+      request({ action: 'apply', confirmWrite: true })
+    )) as unknown as { body: Record<string, number> };
+
+    expect(response.body.documentsSkippedBackupConflict).toBe(1);
+    expect(stored('userProgress', 'user-1_lesson-1')).toEqual(original);
+    expect(stored('userProgressMigrationV4Backups', 'user-1_lesson-1')?.data).toEqual({
+      doNotOverwrite: true,
+    });
+  });
+
+  it('reports missing, invalid, and deletion-pending lessons without writing', async () => {
+    seed('lessons', 'deleted', { ...exerciseLesson, id: 'deleted', _deletionPending: true });
+    seed('lessons', 'invalid', { ...exerciseLesson, id: 'invalid', pages: 'not-an-array' });
+    seed('userProgress', 'user-1_deleted', {
+      userId: 'user-1', lessonId: 'deleted', status: 'in-progress', exerciseProgress: [], lastAccessedAt: 'now',
+    });
+    seed('userProgress', 'user-1_invalid', {
+      userId: 'user-1', lessonId: 'invalid', status: 'in-progress', exerciseProgress: [], lastAccessedAt: 'now',
+    });
+    seed('userProgress', 'user-1_missing', {
+      userId: 'user-1', lessonId: 'missing', status: 'in-progress', exerciseProgress: [], lastAccessedAt: 'now',
+    });
+    seed('userProgress', 'user-1_mismatched', {
+      userId: 'user-1', lessonId: 'lesson-1', status: 'in-progress', exerciseProgress: [], lastAccessedAt: 'now',
+    });
+
+    const response = (await migrateExerciseProgress(request({}))) as unknown as { body: Record<string, number> };
+
+    expect(response.body.documentsSkippedDeletionPendingLesson).toBe(1);
+    expect(response.body.documentsSkippedInvalidLesson).toBe(1);
+    expect(response.body.documentsSkippedMissingLesson).toBe(1);
+    expect(response.body.documentsSkippedInvalidProgress).toBe(1);
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+  });
+
+  it('paginates deterministically with a resumable document cursor', async () => {
+    for (const lessonId of ['lesson-a', 'lesson-b', 'lesson-c']) {
+      seed('lessons', lessonId, { ...exerciseLesson, id: lessonId });
+      seed('userProgress', `user-1_${lessonId}`, {
+        userId: 'user-1',
+        lessonId,
+        status: 'in-progress',
+        exerciseProgress: [],
+        lastAccessedAt: 'now',
+      });
+    }
+
+    const firstPage = (await migrateExerciseProgress(request({ limit: 2 }))) as unknown as {
+      body: { documentsScanned: number; hasMore: boolean; nextCursor: string | null };
+    };
+    expect(firstPage.body).toMatchObject({
+      documentsScanned: 2,
+      hasMore: true,
+      nextCursor: 'user-1_lesson-b',
+    });
+
+    const secondPage = (await migrateExerciseProgress(
+      request({ limit: 2, cursor: firstPage.body.nextCursor })
+    )) as unknown as {
+      body: { documentsScanned: number; hasMore: boolean; nextCursor: string | null };
+    };
+    expect(secondPage.body).toMatchObject({
+      documentsScanned: 1,
+      hasMore: false,
+      nextCursor: null,
+    });
+  });
+
+  it('refuses rollback after student activity and restores the exact pre-image when unchanged', async () => {
+    const original = {
+      userId: 'user-1', lessonId: 'lesson-1', status: 'in-progress', exerciseProgress: [],
+      furthestPageIndex: 0, progressSchemaVersion: 2, updatedAt: 'original-update', lastAccessedAt: 'original-access',
+    };
+    seed('lessons', 'lesson-1', exerciseLesson);
+    seed('userProgress', 'user-1_lesson-1', original);
+    await migrateExerciseProgress(request({ action: 'apply', confirmWrite: true }));
+
+    stored('userProgress', 'user-1_lesson-1')!.updatedAt = 'student-wrote-after-migration';
+    const conflict = (await migrateExerciseProgress(
+      request({ action: 'rollback', confirmWrite: true })
+    )) as unknown as { body: Record<string, number> };
+    expect(conflict.body.documentsSkippedConflict).toBe(1);
+
+    stored('userProgress', 'user-1_lesson-1')!.updatedAt = 'original-update';
+    const rolledBack = (await migrateExerciseProgress(
+      request({ action: 'rollback', confirmWrite: true })
+    )) as unknown as { body: Record<string, number> };
+    expect(rolledBack.body.documentsRolledBack).toBe(1);
+    expect(stored('userProgress', 'user-1_lesson-1')).toEqual(original);
+  });
+
+  it('refuses a rollback backup whose document ID does not match its restore target', async () => {
+    const original = {
+      userId: 'user-1',
+      lessonId: 'lesson-1',
+      status: 'in-progress',
+      exerciseProgress: [],
+      updatedAt: 'original-update',
+      lastAccessedAt: 'original-access',
+    };
+    seed('userProgressMigrationV4Backups', 'wrong-backup-id', {
+      migrationId: 'exercise-progress-v4',
+      progressDocumentId: 'user-1_lesson-1',
+      data: original,
+    });
+    seed('userProgress', 'user-1_lesson-1', {
+      ...original,
+      progressMigrationId: 'exercise-progress-v4',
+    });
+
+    const response = (await migrateExerciseProgress(
+      request({ action: 'rollback', confirmWrite: true })
+    )) as unknown as { body: Record<string, number> };
+
+    expect(response.body.documentsSkippedMissingBackup).toBe(1);
+    expect(stored('userProgress', 'user-1_lesson-1')).toMatchObject({
+      progressMigrationId: 'exercise-progress-v4',
+    });
+  });
+
+  it('returns the admin authorization error before reading migration data', async () => {
+    mockVerifyAdminAccess.mockRejectedValueOnce(new AdminAccessError('Unauthorized', 401));
+
+    const response = (await migrateExerciseProgress(request({}))) as unknown as { status: number };
+
+    expect(response.status).toBe(401);
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/progressionAccessExerciseCompletion.test.ts
+++ b/tests/progressionAccessExerciseCompletion.test.ts
@@ -1,0 +1,146 @@
+jest.mock('@/src/services/firebase-admin', () => ({ adminDb: {} }));
+
+import { getLessonProgressAccessInTransaction } from '@/src/lib/learning-units/progression-access';
+
+type Data = Record<string, unknown>;
+
+interface FakeDocumentRef {
+  kind: 'document';
+  collection: string;
+  id: string;
+}
+
+class FakeQuery {
+  readonly kind = 'query';
+  private filter?: { field: string; value: unknown };
+  private selectedFields?: string[];
+
+  constructor(
+    readonly collection: string,
+    private readonly collections: Record<string, Record<string, Data>>
+  ) {}
+
+  doc(id: string): FakeDocumentRef {
+    return { kind: 'document', collection: this.collection, id };
+  }
+
+  where(field: string, _operator: string, value: unknown) {
+    this.filter = { field, value };
+    return this;
+  }
+
+  select(...fields: string[]) {
+    this.selectedFields = fields;
+    return this;
+  }
+
+  documents() {
+    return Object.entries(this.collections[this.collection] ?? {})
+      .filter(([, data]) => !this.filter || data[this.filter.field] === this.filter.value)
+      .map(([id, data]) => {
+        const selected = this.selectedFields
+          ? Object.fromEntries(
+              this.selectedFields.filter(field => data[field] !== undefined).map(field => [field, data[field]])
+            )
+          : data;
+        return fakeSnapshot(this.doc(id), selected);
+      });
+  }
+}
+
+function fakeSnapshot(ref: FakeDocumentRef, data?: Data) {
+  return {
+    id: ref.id,
+    ref,
+    exists: data !== undefined,
+    data: () => data,
+  };
+}
+
+describe('transactional lesson progression access', () => {
+  it('unlocks from canonical legacy exercise evidence', async () => {
+    const collections: Record<string, Record<string, Data>> = {
+      lessons: {
+        first: {
+          id: 'first',
+          kind: 'lesson',
+          title: 'First',
+          description: '',
+          type: 'normal',
+          version: 2,
+          pages: [{ id: 'page-1', items: [{ id: 'exercise-a', type: 'fill', title: 'A' }] }],
+          totalPages: 1,
+          totalItems: 1,
+          totalExercises: 1,
+          isLive: true,
+          liveOrder: 0,
+          publishedAt: 'before',
+          publishedBy: 'admin',
+        },
+        second: {
+          id: 'second',
+          kind: 'lesson',
+          title: 'Second',
+          description: '',
+          type: 'normal',
+          pages: [{ id: 'page-1', items: [] }],
+          isLive: true,
+          liveOrder: 1,
+          publishedAt: 'before',
+          publishedBy: 'admin',
+        },
+      },
+      learningPaths: {
+        default: {
+          id: 'default',
+          revision: 1,
+          unitIds: ['first', 'second'],
+          updatedAt: 'before',
+          updatedBy: 'admin',
+        },
+      },
+      userProgress: {
+        user_first: {
+          userId: 'user',
+          lessonId: 'first',
+          status: 'in-progress',
+          progressSchemaVersion: 2,
+          exerciseProgress: [{ exerciseId: 'exercise-a', score: 100, completedAt: 'before' }],
+          lastAccessedAt: 'before',
+        },
+      },
+    };
+    const db = {
+      collection: (name: string) => new FakeQuery(name, collections),
+    };
+    const transaction = {
+      get: async (reference: FakeDocumentRef | FakeQuery) => {
+        if (reference instanceof FakeQuery) return { docs: reference.documents() };
+        return fakeSnapshot(reference, collections[reference.collection]?.[reference.id]);
+      },
+      getAll: async (...inputs: Array<FakeDocumentRef | { fieldMask: string[] }>) => {
+        const options = inputs.at(-1);
+        const fieldMask = options && 'fieldMask' in options ? options.fieldMask : undefined;
+        const refs = (fieldMask ? inputs.slice(0, -1) : inputs) as FakeDocumentRef[];
+        return refs.map(ref => {
+          const data = collections[ref.collection]?.[ref.id];
+          const selected =
+            data && fieldMask
+              ? Object.fromEntries(fieldMask.filter(field => data[field] !== undefined).map(field => [field, data[field]]))
+              : data;
+          return fakeSnapshot(ref, selected);
+        });
+      },
+    };
+
+    await expect(
+      getLessonProgressAccessInTransaction(
+        transaction as never,
+        db as never,
+        { id: 'second', type: 'normal', isLive: true },
+        'user',
+        false
+      )
+    ).resolves.toBe('allowed');
+  });
+});

--- a/tests/studentDashboardService.test.ts
+++ b/tests/studentDashboardService.test.ts
@@ -311,9 +311,10 @@ describe('StudentDashboardService summary projection', () => {
     const progressFields = selectedFieldLog.find(fields => fields.includes('lessonId'));
     expect(progressFields).toBeDefined();
     expect(progressFields).not.toContain('exerciseProgress');
-    expect(progressFields).not.toContain('progress');
-    expect(progressFields).not.toContain('completedExerciseCount');
-    expect(progressFields).not.toContain('requiredExerciseCount');
+    expect(progressFields).toContain('progress');
+    expect(progressFields).toContain('completedExerciseCount');
+    expect(progressFields).toContain('requiredExerciseCount');
+    expect(progressFields).toContain('progressLessonVersion');
     expect(JSON.stringify(dashboard)).not.toContain('"exerciseProgress"');
   });
 
@@ -980,11 +981,33 @@ describe('StudentDashboardService Phase 6 mixed Learning Path', () => {
     expect(dashboard.pastMockResults).toEqual([{ id: 'past-mock', title: 'Past' }]);
   });
 
-  it('derives dashboard progress from the furthest page regardless of stored exercise counters', async () => {
+  it('uses trusted exercise summaries and canonically refreshes stale lesson versions', async () => {
     const collections = {
       lessons: {
-        trusted: lesson({ title: 'Trusted', liveOrder: 0, totalPages: 4, totalExercises: 3 }),
-        mismatched: lesson({ title: 'Mismatched', liveOrder: 1, totalPages: 4, totalExercises: 3 }),
+        trusted: lesson({
+          title: 'Trusted',
+          liveOrder: 0,
+          version: 2,
+          pages: [
+            { id: 'page-1', items: [{ id: 'trusted-a', type: 'fill', title: 'A' }] },
+            { id: 'page-2', items: [{ id: 'trusted-b', type: 'fill', title: 'B' }] },
+            { id: 'page-3', items: [{ id: 'trusted-c', type: 'fill', title: 'C' }] },
+          ],
+          totalPages: 3,
+          totalExercises: 3,
+        }),
+        mismatched: lesson({
+          title: 'Mismatched',
+          liveOrder: 1,
+          version: 2,
+          pages: [
+            { id: 'page-1', items: [{ id: 'mismatch-a', type: 'fill', title: 'A' }] },
+            { id: 'page-2', items: [{ id: 'mismatch-b', type: 'fill', title: 'B' }] },
+            { id: 'page-3', items: [{ id: 'mismatch-c', type: 'fill', title: 'C' }] },
+          ],
+          totalPages: 3,
+          totalExercises: 3,
+        }),
         locked: lesson({ title: 'Locked', liveOrder: 2, totalPages: 2, totalExercises: 1 }),
       },
       learningPaths: {
@@ -1005,7 +1028,8 @@ describe('StudentDashboardService Phase 6 mixed Learning Path', () => {
           progress: 33,
           completedExerciseCount: 1,
           requiredExerciseCount: 3,
-          progressSchemaVersion: 3,
+          progressSchemaVersion: 4,
+          progressLessonVersion: 2,
           lastAccessedAt: 'now',
         },
         user_mismatched: {
@@ -1016,7 +1040,12 @@ describe('StudentDashboardService Phase 6 mixed Learning Path', () => {
           progress: 66,
           completedExerciseCount: 2,
           requiredExerciseCount: 2,
-          progressSchemaVersion: 3,
+          progressSchemaVersion: 4,
+          progressLessonVersion: 1,
+          exerciseProgress: [
+            { exerciseId: 'mismatch-a', score: 100, completedAt: 'before' },
+            { exerciseId: 'mismatch-b', score: 100, completedAt: 'before' },
+          ],
           lastAccessedAt: 'now',
         },
       },
@@ -1029,17 +1058,24 @@ describe('StudentDashboardService Phase 6 mixed Learning Path', () => {
 
     const dashboard = await service.getDashboard('user');
     const lessonPath = dashboard.learningPath.filter((item): item is StudentLessonSummary => item.kind === 'lesson');
-    expect(lessonPath.map(item => [item.id, item.status, item.progress])).toEqual([
-      ['trusted', 'in-progress', 25],
-      ['mismatched', 'in-progress', 75],
-      ['locked', 'locked', 0],
+    expect(lessonPath.map(item => [item.id, item.status, item.progress, item.progressLessonVersion])).toEqual([
+      ['trusted', 'in-progress', 33, 2],
+      ['mismatched', 'in-progress', 67, 2],
+      ['locked', 'locked', 0, undefined],
     ]);
   });
 
   it('does not unlock the next lesson from numeric 100 without completed status', async () => {
     const collections = {
       lessons: {
-        first: lesson({ title: 'First', liveOrder: 0, totalPages: 2, totalExercises: 1 }),
+        first: lesson({
+          title: 'First',
+          liveOrder: 0,
+          version: 1,
+          pages: [{ id: 'page-1', items: [{ id: 'exercise-a', type: 'fill', title: 'A' }] }],
+          totalPages: 1,
+          totalExercises: 1,
+        }),
         second: lesson({ title: 'Second', liveOrder: 1, totalPages: 2, totalExercises: 1 }),
       },
       learningPaths: {
@@ -1074,9 +1110,115 @@ describe('StudentDashboardService Phase 6 mixed Learning Path', () => {
     const dashboard = await service.getDashboard('user');
     const lessonPath = dashboard.learningPath.filter((item): item is StudentLessonSummary => item.kind === 'lesson');
     expect(lessonPath.map(item => [item.id, item.status, item.progress])).toEqual([
-      ['first', 'in-progress', 50],
+      ['first', 'in-progress', 0],
       ['second', 'locked', 0],
     ]);
+  });
+
+  it('uses canonical exercise evidence consistently for dashboard and lesson access', async () => {
+    const collections = {
+      lessons: {
+        first: lesson({
+          title: 'First',
+          liveOrder: 0,
+          version: 2,
+          pages: [{ id: 'page-1', items: [{ id: 'exercise-a', type: 'fill', title: 'A' }] }],
+          totalPages: 1,
+          totalItems: 1,
+          totalExercises: 1,
+        }),
+        second: lesson({ title: 'Second', liveOrder: 1 }),
+      },
+      learningPaths: {
+        default: {
+          id: 'default',
+          revision: 1,
+          unitIds: ['first', 'second'],
+          updatedAt: 'now',
+          updatedBy: 'admin',
+        },
+      },
+      userProgress: {
+        user_first: {
+          userId: 'user',
+          lessonId: 'first',
+          status: 'in-progress',
+          furthestPageIndex: 0,
+          progressSchemaVersion: 2,
+          exerciseProgress: [{ exerciseId: 'exercise-a', score: 100, completedAt: 'before' }],
+          lastAccessedAt: 'before',
+        },
+      },
+    };
+    const { db } = createFakeDb(collections);
+    const service = new StudentDashboardService(
+      db as never,
+      { getAssignmentsForLessonIds: jest.fn(async () => new Map()) } as never
+    );
+
+    const dashboard = await service.getDashboard('user');
+    expect(
+      dashboard.learningPath
+        .filter((item): item is StudentLessonSummary => item.kind === 'lesson')
+        .map(item => [item.id, item.status, item.progress])
+    ).toEqual([
+      ['first', 'completed', 100],
+      ['second', 'available', 0],
+    ]);
+    await expect(service.getLesson('user', 'second')).resolves.toMatchObject({
+      id: 'second',
+      status: 'available',
+    });
+  });
+
+  it('isolates an invalid lesson during canonical dashboard hydration', async () => {
+    const collections = {
+      lessons: {
+        broken: lesson({
+          title: 'Broken',
+          liveOrder: 0,
+          version: 2,
+          pages: 'not-an-array',
+          totalPages: 1,
+          totalItems: 1,
+          totalExercises: 1,
+        }),
+      },
+      learningPaths: {
+        default: {
+          id: 'default',
+          revision: 1,
+          unitIds: ['broken'],
+          updatedAt: 'now',
+          updatedBy: 'admin',
+        },
+      },
+      userProgress: {
+        user_broken: {
+          userId: 'user',
+          lessonId: 'broken',
+          status: 'in-progress',
+          progressSchemaVersion: 2,
+          exerciseProgress: [],
+          lastAccessedAt: 'before',
+        },
+      },
+    };
+    const { db } = createFakeDb(collections);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const service = new StudentDashboardService(
+      db as never,
+      { getAssignmentsForLessonIds: jest.fn(async () => new Map()) } as never
+    );
+
+    await expect(service.getDashboard('user')).resolves.toMatchObject({
+      learningPath: [{ id: 'broken', status: 'in-progress', progress: 0 }],
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Unable to canonicalize progress for invalid lesson broken; skipping it',
+      expect.any(StudentDashboardServiceError)
+    );
+    errorSpy.mockRestore();
   });
 
   it('uses canonical completion from full exercise history on getLesson', async () => {
@@ -1121,9 +1263,63 @@ describe('StudentDashboardService Phase 6 mixed Learning Path', () => {
     );
 
     const detail = await service.getLesson('user', 'first');
-    expect(detail.progress).toBe(99);
+    expect(detail.progress).toBe(50);
     expect(detail.completedExerciseCount).toBe(1);
     expect(detail.requiredExerciseCount).toBe(2);
     expect(detail.status).toBe('in-progress');
+    expect(detail.progressLessonVersion).toBe(0);
+  });
+
+  it('logs when hydrated counts still disagree with the persisted lesson summary', async () => {
+    const collections = {
+      lessons: {
+        drifted: lesson({
+          title: 'Drifted',
+          liveOrder: 0,
+          version: 2,
+          pages: [{ id: 'page-1', items: [{ id: 'exercise-a', type: 'fill', title: 'A' }] }],
+          totalPages: 1,
+          totalItems: 1,
+          totalExercises: 2,
+        }),
+      },
+      learningPaths: {
+        default: {
+          id: 'default',
+          revision: 1,
+          unitIds: ['drifted'],
+          updatedAt: 'now',
+          updatedBy: 'admin',
+        },
+      },
+      userProgress: {
+        user_drifted: {
+          userId: 'user',
+          lessonId: 'drifted',
+          status: 'in-progress',
+          furthestPageIndex: 0,
+          progressSchemaVersion: 4,
+          progressLessonVersion: 2,
+          completedExerciseCount: 1,
+          requiredExerciseCount: 1,
+          progress: 100,
+          lastAccessedAt: 'before',
+        },
+      },
+    };
+    const { db } = createFakeDb(collections);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const service = new StudentDashboardService(
+      db as never,
+      { getAssignmentsForLessonIds: jest.fn(async () => new Map()) } as never
+    );
+
+    const dashboard = await service.getDashboard('user');
+    expect(dashboard.learningPath).toMatchObject([{ id: 'drifted', status: 'in-progress', progress: 0 }]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Unable to trust hydrated progress for lesson drifted; dashboard will show 0% until the lesson summary matches authored exercises',
+      expect.objectContaining({ requiredExerciseCount: 1, totalExercises: 2 })
+    );
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- calculate lesson progress from equal-weight authored exercise completion (schema v4)
- stamp bounded v4 summaries on progress writes and recompute stale dashboard/unlock state from exercise evidence
- add a guarded admin dry-run/apply/rollback migration for production backfill
- prevent expanded and collapsed lesson sidebars from rendering at the same time
- stop compact Path/Practice labels and full-width lesson content from leaking across sidebar states
- bump the application version to 1.0.5 (includes everything from 1.0.4)

## Verification
- visually verified both sidebar states in Edge
- production Firestore dry-run reviewed (read-only; apply not run)
- targeted Jest, TypeScript, ESLint, and git diff checks passed for the progress work