### PR TITLE
Keep lesson progress when revisiting earlier pages

### DIFF
--- a/src/components/ui/exercises/lesson-navigation.tsx
+++ b/src/components/ui/exercises/lesson-navigation.tsx
@@ -9,6 +9,7 @@ import { stripHtmlTags } from '@/src/utils/exercises';
 
 interface LessonNavigationProps {
   currentPageIndex: number;
+  furthestPageIndex?: number;
   totalPages: number;
   isLessonCompleted?: boolean;
   pageTitles?: (string | undefined)[];
@@ -26,6 +27,7 @@ interface LessonNavigationProps {
 
 export const LessonNavigation: React.FC<LessonNavigationProps> = ({
   currentPageIndex,
+  furthestPageIndex = currentPageIndex,
   totalPages,
   isLessonCompleted = false,
   pageTitles = [],
@@ -44,7 +46,8 @@ export const LessonNavigation: React.FC<LessonNavigationProps> = ({
 
   const canGoPrevious = currentPageIndex > 0;
   const canGoNext = currentPageIndex < totalPages - 1;
-  const progressPercentage = totalPages > 0 ? Math.round(((currentPageIndex + 1) / totalPages) * 100) : 0;
+  const progressPageIndex = Math.max(currentPageIndex, furthestPageIndex);
+  const progressPercentage = totalPages > 0 ? Math.round(((progressPageIndex + 1) / totalPages) * 100) : 0;
   const isContained = placement === 'contained';
   const clampedProgress = Math.max(0, Math.min(100, Number.isFinite(progressPercentage) ? progressPercentage : 0));
   const isFinalActionDisabled = !canGoNext && (isFinishing || isLessonCompleted || isFinishBlocked);

--- a/src/components/ui/lesson/lesson-player.tsx
+++ b/src/components/ui/lesson/lesson-player.tsx
@@ -33,6 +33,7 @@ const PENDING_WRITE_FINISH_GRACE_MS = 8_000;
 
 interface ProgressMutationSummary {
   progress?: number;
+  furthestPageIndex?: number;
   lessonCompleted?: boolean;
   completedExerciseCount?: number;
   requiredExerciseCount?: number;
@@ -160,6 +161,9 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
   const [currentPageIndex, setCurrentPageIndex] = useState(
     Math.max(0, Math.min(lesson.furthestPageIndex ?? lesson.currentPageIndex ?? 0, lesson.pages.length - 1))
   );
+  const [furthestPageIndex, setFurthestPageIndex] = useState(
+    Math.max(0, Math.min(lesson.furthestPageIndex ?? lesson.currentPageIndex ?? 0, lesson.pages.length - 1))
+  );
 
   const currentPage = lesson.pages[currentPageIndex];
   const totalPages = lesson.pages.length;
@@ -167,6 +171,9 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
 
   const applyProgressMutation = useCallback((result: ProgressMutationSummary, requestLessonId: string) => {
     if (!mountedRef.current || requestLessonId !== lessonIdRef.current) return;
+    if (typeof result.furthestPageIndex === 'number' && Number.isFinite(result.furthestPageIndex)) {
+      setFurthestPageIndex(current => Math.max(current, Math.trunc(result.furthestPageIndex as number)));
+    }
     if (typeof result.requiredExerciseCount === 'number' && Number.isFinite(result.requiredExerciseCount)) {
       setRequiredExerciseCount(current => Math.max(current, Math.trunc(result.requiredExerciseCount as number)));
     }
@@ -205,6 +212,9 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
     );
     setRequiredExerciseCount(Math.max(safeCount(lesson.requiredExerciseCount), requiredExercises.length));
     setCurrentPageIndex(
+      Math.max(0, Math.min(lesson.furthestPageIndex ?? lesson.currentPageIndex ?? 0, lesson.pages.length - 1))
+    );
+    setFurthestPageIndex(
       Math.max(0, Math.min(lesson.furthestPageIndex ?? lesson.currentPageIndex ?? 0, lesson.pages.length - 1))
     );
   }, [lesson.id]); // eslint-disable-line react-hooks/exhaustive-deps -- reset local completion only when switching lessons
@@ -297,6 +307,7 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
     if (currentPageIndex < totalPages - 1) {
       const newPageIndex = currentPageIndex + 1;
       setCurrentPageIndex(newPageIndex);
+      setFurthestPageIndex(current => Math.max(current, newPageIndex));
     }
   }, [currentPageIndex, totalPages]);
 
@@ -314,6 +325,7 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
     (newPageIndex: number) => {
       if (newPageIndex < 0 || newPageIndex >= totalPages || newPageIndex === currentPageIndex) return;
       setCurrentPageIndex(newPageIndex);
+      setFurthestPageIndex(current => Math.max(current, newPageIndex));
     },
     [currentPageIndex, totalPages]
   );
@@ -594,6 +606,7 @@ export const LessonPlayer: React.FC<LessonPlayerProps> = ({
 
         <LessonNavigation
           currentPageIndex={currentPageIndex}
+          furthestPageIndex={furthestPageIndex}
           totalPages={totalPages}
           isLessonCompleted={lessonCompleted}
           pageTitles={lesson.pages.map(page => page.title)}

--- a/tests/lessonNavigation.test.tsx
+++ b/tests/lessonNavigation.test.tsx
@@ -18,9 +18,11 @@ beforeEach(() => {
 });
 
 describe('LessonNavigation completion action', () => {
-  it('derives the bar solely from the current page', () => {
-    const { container } = render(<LessonNavigation {...baseProps} currentPageIndex={1} />);
-    expect(container.querySelector('[style="width: 67%;"]')).toBeInTheDocument();
+  it('keeps the bar at the furthest page while showing the page being revisited', () => {
+    const { container } = render(<LessonNavigation {...baseProps} currentPageIndex={0} furthestPageIndex={2} />);
+
+    expect(container.querySelector('[style="width: 100%;"]')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /page 1 \/ 3/i })).toBeInTheDocument();
   });
 
   it('uses Next before the final page', () => {

--- a/tests/lessonPlayerCompletionTracking.test.tsx
+++ b/tests/lessonPlayerCompletionTracking.test.tsx
@@ -89,6 +89,7 @@ jest.mock('@/src/components/ui/exercises/lesson-navigation', () => ({
   __esModule: true,
   default: ({
     currentPageIndex,
+    furthestPageIndex,
     totalPages,
     isLessonCompleted,
     onPrevious,
@@ -98,6 +99,7 @@ jest.mock('@/src/components/ui/exercises/lesson-navigation', () => ({
     isFinishBlocked,
   }: {
     currentPageIndex: number;
+    furthestPageIndex: number;
     totalPages: number;
     isLessonCompleted?: boolean;
     onPrevious: () => void;
@@ -107,7 +109,7 @@ jest.mock('@/src/components/ui/exercises/lesson-navigation', () => ({
     isFinishBlocked?: boolean;
   }) => {
     const canGoNext = currentPageIndex < totalPages - 1;
-    const progressPercentage = Math.round(((currentPageIndex + 1) / totalPages) * 100);
+    const progressPercentage = Math.round(((furthestPageIndex + 1) / totalPages) * 100);
     const label = canGoNext
       ? 'Next page'
       : isFinishing
@@ -207,6 +209,19 @@ describe('LessonPlayer accepted completion tracking', () => {
     expect(screen.getByText('Progress 100%')).toBeInTheDocument();
     expect(screen.getByText('Page content: page-2')).toBeInTheDocument();
     expect(screen.queryByText('Page content: page-1')).not.toBeInTheDocument();
+  });
+
+  it('does not reduce tracked progress when a student revisits a previous page', () => {
+    render(<LessonPlayer lesson={createLesson(3)} trackProgress={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getByText('Progress 100%')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous page' }));
+
+    expect(screen.getByText('Page content: page-2')).toBeInTheDocument();
+    expect(screen.getByText('Progress 100%')).toBeInTheDocument();
   });
 
   it('renders a noninteractive ring from server counts and applies successful updates', async () => {


### PR DESCRIPTION
## Summary
- track the furthest lesson page separately from the page currently being viewed
- keep the visual progress bar monotonic when students revisit earlier pages
- preserve the current Page X / Y location indicator
- add component and integrated player regression tests

## Verification
- npm test -- --runInBand tests/lessonNavigation.test.tsx tests/lessonPlayerCompletionTracking.test.tsx (33 tests passed)
- npx tsc --noEmit
- targeted ESLint for all touched files
- git diff --check

## Repository lint note
The full npm run lint remains blocked by pre-existing no-require-imports errors in next.config.js and an unrelated warning in tests/helpers/sentryMock.ts.