### PR TITLE
Expose question count for vocabulary-pool exercises

### DIFF
--- a/src/components/ui/admin/content-editor/GeneratedFormIdentificationEditor.tsx
+++ b/src/components/ui/admin/content-editor/GeneratedFormIdentificationEditor.tsx
@@ -28,6 +28,7 @@ import { prepareGeneratedFormIdentificationWord } from '@/src/utils/exercises/fo
 import { formatGeneratedPreviewDiagnostics } from '@/src/utils/generated/generatedExercisePreview';
 import { getApiErrorMessage } from '@/src/store/api/baseQuery';
 import { AlertTriangle, Loader2 } from 'lucide-react';
+import { GeneratedQuestionCountField } from './GeneratedQuestionCountField';
 
 export const GeneratedFormIdentificationEditor: React.FC = () => {
   const editingContent = useAppSelector(
@@ -121,6 +122,12 @@ const GeneratedFormIdentificationEditorView: React.FC<{
       <VocabularyPoolSelector
         selectedPoolId={editor.config.poolId || undefined}
         onPoolSelect={poolId => editor.updateConfig({ poolId: poolId || null })}
+      />
+
+      <GeneratedQuestionCountField
+        id="form-identification-question-count"
+        count={editor.config.count}
+        onChange={count => editor.updateConfig({ count })}
       />
 
       <div className="space-y-2">

--- a/src/components/ui/admin/content-editor/GeneratedQuestionCountField.tsx
+++ b/src/components/ui/admin/content-editor/GeneratedQuestionCountField.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Checkbox } from '@/src/components/ui/checkbox';
+import { Input } from '@/src/components/ui/input';
+import { Label } from '@/src/components/ui/label';
+import { MAX_GENERATED_WORD_COUNT } from '@/src/config/generatedExerciseLimits';
+
+const DEFAULT_GENERATED_QUESTION_COUNT = 5;
+
+interface GeneratedQuestionCountFieldProps {
+  id: string;
+  count: number | 'all';
+  onChange: (count: number | 'all') => void;
+}
+
+export const GeneratedQuestionCountField: React.FC<GeneratedQuestionCountFieldProps> = ({ id, count, onChange }) => {
+  const numericCount = typeof count === 'number' ? count : null;
+  const [inputValue, setInputValue] = useState(numericCount === null ? '' : String(numericCount));
+  const lastNumericCount = useRef(numericCount ?? DEFAULT_GENERATED_QUESTION_COUNT);
+  const useAllWords = count === 'all';
+
+  useEffect(() => {
+    if (numericCount === null) {
+      setInputValue('');
+      return;
+    }
+
+    lastNumericCount.current = numericCount;
+    setInputValue(String(numericCount));
+  }, [numericCount]);
+
+  const commitInputValue = () => {
+    const parsed = Number.parseInt(inputValue, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      setInputValue(String(lastNumericCount.current));
+      return;
+    }
+
+    const nextCount = Math.min(parsed, MAX_GENERATED_WORD_COUNT);
+    lastNumericCount.current = nextCount;
+    setInputValue(String(nextCount));
+    onChange(nextCount);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>Number of Questions</Label>
+      <Input
+        id={id}
+        type="number"
+        min={1}
+        max={MAX_GENERATED_WORD_COUNT}
+        inputMode="numeric"
+        value={inputValue}
+        disabled={useAllWords}
+        placeholder={useAllWords ? 'Using all eligible words' : 'Number of questions'}
+        onChange={event => setInputValue(event.target.value)}
+        onBlur={commitInputValue}
+      />
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id={`${id}-all`}
+          checked={useAllWords}
+          onCheckedChange={checked => onChange(checked === true ? 'all' : lastNumericCount.current)}
+        />
+        <Label htmlFor={`${id}-all`} className="text-sm font-normal text-gray-700">
+          Use all eligible pool words
+        </Label>
+      </div>
+      <p className="text-xs text-gray-500">
+        Controls how many unique words become questions. Choose all to follow the full pool as it changes.
+      </p>
+    </div>
+  );
+};

--- a/src/components/ui/admin/content-editor/GeneratedTranslationEditor.tsx
+++ b/src/components/ui/admin/content-editor/GeneratedTranslationEditor.tsx
@@ -20,6 +20,7 @@ import { parseMultiFilterValue, serializeMultiFilterValue } from '@/src/utils/wo
 import { getExerciseDisplayForm, hasSelectedForm } from '@/src/utils/exercises/formSelection';
 import { formatGeneratedPreviewDiagnostics } from '@/src/utils/generated/generatedExercisePreview';
 import { getApiErrorMessage } from '@/src/store/api/baseQuery';
+import { GeneratedQuestionCountField } from './GeneratedQuestionCountField';
 
 export const GeneratedTranslationEditor: React.FC = () => {
   const editingContent = useAppSelector(
@@ -102,6 +103,12 @@ const GeneratedTranslationEditorView: React.FC<{ editingContent: GeneratedTransl
       <VocabularyPoolSelector
         selectedPoolId={editor.config.poolId || undefined}
         onPoolSelect={poolId => editor.updateConfig({ poolId: poolId || null })}
+      />
+
+      <GeneratedQuestionCountField
+        id="translation-question-count"
+        count={editor.config.count}
+        onChange={count => editor.updateConfig({ count })}
       />
 
       <div className="space-y-2">

--- a/tests/generatedPoolQuestionCount.test.tsx
+++ b/tests/generatedPoolQuestionCount.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GeneratedTranslationEditor } from '@/src/components/ui/admin/content-editor/GeneratedTranslationEditor';
+import { GeneratedFormIdentificationEditor } from '@/src/components/ui/admin/content-editor/GeneratedFormIdentificationEditor';
+
+const mockTranslationUpdateConfig = jest.fn();
+const mockFormUpdateConfig = jest.fn();
+let mockEditingContent: Record<string, unknown>;
+
+jest.mock('@/src/store/hooks', () => ({
+  useAppSelector: () => mockEditingContent,
+}));
+
+jest.mock('@/src/hooks/useGeneratedExerciseEditor', () => ({
+  useGeneratedExerciseEditor: () => ({
+    config: {
+      collection: 'vocabulary_words_v5',
+      wordSource: 'pool',
+      poolId: 'pool-1',
+      poolWordLimit: null,
+      count: 5,
+    },
+    activePOS: undefined,
+    derivedFilters: { partOfSpeech: 'all' },
+    derivedFormSelection: undefined,
+    formSelectionControls: {},
+    handleFiltersChange: jest.fn(),
+    handleResetFilters: jest.fn(),
+    handleTogglePOS: jest.fn(),
+    handleUpdatePosConfig: jest.fn(),
+    isPoolWordSource: true,
+    isPreviewFetching: false,
+    isPreviewOpen: false,
+    posSummary: { availablePOS: [], summary: undefined },
+    previewData: undefined,
+    previewError: undefined,
+    setIsPreviewOpen: jest.fn(),
+    updateConfig: mockTranslationUpdateConfig,
+    updateContent: jest.fn(),
+  }),
+}));
+
+jest.mock('@/src/hooks/useFormIdentificationEditor', () => ({
+  useFormIdentificationEditor: () => ({
+    config: {
+      collection: 'vocabulary_words_v5',
+      wordSource: 'pool',
+      poolId: 'pool-1',
+      poolWordLimit: null,
+      count: 5,
+    },
+    derivedFilters: { partOfSpeech: 'all' },
+    derivedFormSelection: undefined,
+    handleGlobalFiltersChange: jest.fn(),
+    handleToggleParadigm: jest.fn(),
+    handleUpdateParadigmConfig: jest.fn(),
+    isPreviewFetching: false,
+    isPreviewOpen: false,
+    paradigmConfigs: {},
+    paradigmInfo: { availableParadigms: [], isLoading: false },
+    previewData: undefined,
+    previewError: undefined,
+    setIsPreviewOpen: jest.fn(),
+    updateConfig: mockFormUpdateConfig,
+    updateContent: jest.fn(),
+  }),
+}));
+
+jest.mock('@/src/components/ui/admin/content-editor/WordSourceSection', () => ({
+  WordSourceSection: ({ poolContent }: { poolContent: React.ReactNode }) => <div>{poolContent}</div>,
+}));
+
+jest.mock('@/src/components/ui/admin/vocabulary-pools/VocabularyPoolSelector', () => ({
+  VocabularyPoolSelector: () => <div>Selected pool</div>,
+}));
+
+jest.mock('@/src/components/ui/form-components', () => ({
+  SimpleInput: () => null,
+  SimpleTextarea: () => null,
+  SimpleSelect: () => null,
+}));
+
+jest.mock('@/src/components/ui/admin/content-editor/AudioUploadSection', () => ({
+  AudioUploadSection: () => null,
+}));
+
+jest.mock('@/src/components/ui/admin/content-editor/ExerciseFeedbackSection', () => ({
+  ExerciseFeedbackSection: () => null,
+}));
+
+jest.mock('@/src/components/ui/admin/content-editor/MultiPosConfigSection', () => ({
+  MultiPosConfigSection: () => null,
+}));
+
+jest.mock('@/src/components/ui/admin/content-editor/MultiParadigmConfigSection', () => ({
+  MultiParadigmConfigSection: () => null,
+}));
+
+jest.mock('@/src/components/ui/admin/vocabulary/AdvancedFiltersPanel', () => ({
+  AdvancedFiltersPanel: () => null,
+}));
+
+jest.mock('@/src/utils/exercises/formIdentificationConfiguration', () => ({
+  getGeneratedFormIdentificationConfigurationMessages: () => [],
+}));
+
+const translationExercise = {
+  id: 'translation-1',
+  type: 'generated-translation',
+  title: 'Definitions',
+  instructions: '',
+  translationDirection: 'latin-to-english',
+  feedbackConfig: { escalationLevels: [] },
+  data: { generatorConfig: {}, posConfigs: {} },
+};
+
+const formExercise = {
+  id: 'form-1',
+  type: 'generated-form-identification',
+  title: 'Morphology',
+  instructions: '',
+  feedbackConfig: { escalationLevels: [] },
+  data: { mode: 'step-by-step', generatorConfig: {}, paradigmConfigs: {} },
+};
+
+describe.each([
+  ['generated translation', GeneratedTranslationEditor, translationExercise, mockTranslationUpdateConfig],
+  ['generated morphology', GeneratedFormIdentificationEditor, formExercise, mockFormUpdateConfig],
+] as const)('%s pool question count', (_label, Editor, exercise, updateConfig) => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEditingContent = exercise;
+  });
+
+  it('lets an admin choose a numeric count or every eligible pool word', () => {
+    render(<Editor />);
+
+    const countInput = screen.getByLabelText('Number of Questions');
+    expect(countInput).toHaveValue(5);
+
+    fireEvent.change(countInput, { target: { value: '10' } });
+    fireEvent.blur(countInput);
+    expect(updateConfig).toHaveBeenCalledWith({ count: 10 });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Use all eligible pool words' }));
+    expect(updateConfig).toHaveBeenCalledWith({ count: 'all' });
+  });
+});


### PR DESCRIPTION
## Summary
- show Number of Questions in Vocabulary Pool mode for generated translation and morphology exercises
- let admins choose a numeric count or use every eligible pool word
- share the control between both editors and preserve the last numeric count when toggling All
- add regression coverage for both affected editor paths

## Testing
- `npx tsc --noEmit`
- `npx eslint src/components/ui/admin/content-editor/GeneratedQuestionCountField.tsx src/components/ui/admin/content-editor/GeneratedTranslationEditor.tsx src/components/ui/admin/content-editor/GeneratedFormIdentificationEditor.tsx tests/generatedPoolQuestionCount.test.tsx`
- `npm test -- --runInBand tests/generatedExerciseEditorPreview.test.ts tests/generatedExercisePreviewRoute.test.ts tests/generatedPoolQuestionCount.test.tsx` (14 tests passed)
- `git diff --check`

## Repository lint baseline
- `npm run lint` still reports the existing `@typescript-eslint/no-require-imports` errors in `next.config.js` and the existing anonymous-default-export warning in `tests/helpers/sentryMock.ts`; changed files pass targeted ESLint.