### PR TITLE
Filter invalid morphology placeholders during selection

### DIFF
--- a/src/app/api/admin/words/route.ts
+++ b/src/app/api/admin/words/route.ts
@@ -7,6 +7,7 @@ import { TABLE_TYPE_CONFIG, type TableType } from '@/src/utils/schema-helpers';
 import type { FormIdentificationStep } from '@/src/types/exercises/schemas/form-identification';
 import { scanTableForMatchingForms, categorizeMatchingPaths } from '@/src/utils/tableScanner';
 import { getApplicableStepsForFormPath } from '@/src/utils/exercises/formIdentificationCompatibility';
+import { isSelectableMorphologyForm } from '@/src/utils/morphologyForms';
 import { AdminAccessError, verifyAdminAccess, verifyAuthenticatedAccess } from '@/src/lib/verifyAdminAccess';
 import {
   requireVocabularyWordsCollection,
@@ -762,12 +763,11 @@ function getCellValueAtPathServer(obj: Record<string, unknown>, path: string): s
   }
 
   if (typeof value === 'string') {
-    return [value];
+    return isSelectableMorphologyForm(value) ? [value] : [];
   }
 
   if (Array.isArray(value)) {
-    const filtered = value.filter((v): v is string => v !== null && v !== undefined && typeof v === 'string');
-    return filtered;
+    return value.filter(isSelectableMorphologyForm);
   }
   return [];
 }

--- a/src/lib/tests/generated-word-composition.server.ts
+++ b/src/lib/tests/generated-word-composition.server.ts
@@ -13,6 +13,7 @@ import { getApplicableStepsForFormPath } from '@/src/utils/exercises/formIdentif
 import { getExerciseDisplayForm } from '@/src/utils/exercises/formSelection';
 import { prepareGeneratedFormIdentificationWord } from '@/src/utils/exercises/formIdentificationPreparation';
 import { isRejectedBySpecAwarePronounOverlap } from '@/src/utils/generated/pronounParadigmFiltering';
+import { isSelectableMorphologyForm } from '@/src/utils/morphologyForms';
 import type { GeneratedExercisePreviewDiagnostics } from './generated-preview-schema';
 import {
   isUsableGeneratedTranslationWord,
@@ -147,8 +148,8 @@ const getPathValues = (value: Record<string, unknown>, path: string): string[] =
     if (!current || typeof current !== 'object' || !(key in current)) return [];
     current = (current as Record<string, unknown>)[key];
   }
-  if (typeof current === 'string') return [current];
-  return Array.isArray(current) ? current.filter((entry): entry is string => typeof entry === 'string') : [];
+  if (typeof current === 'string') return isSelectableMorphologyForm(current) ? [current] : [];
+  return Array.isArray(current) ? current.filter(isSelectableMorphologyForm) : [];
 };
 
 function selectForm(

--- a/src/utils/form-selection.ts
+++ b/src/utils/form-selection.ts
@@ -1,4 +1,5 @@
 import type { VocabularyWordWithId } from '@/src/types/vocabulary/index';
+import { isSelectableMorphologyForm } from '@/src/utils/morphologyForms';
 import { type TableType, getTableFieldName } from '@/src/utils/schema-helpers';
 
 export function getCellValueAtPath(word: VocabularyWordWithId, tableType: TableType, path: string): string[] {
@@ -21,11 +22,11 @@ export function getCellValueAtPath(word: VocabularyWordWithId, tableType: TableT
   }
 
   if (typeof value === 'string') {
-    return [value];
+    return isSelectableMorphologyForm(value) ? [value] : [];
   }
 
   if (Array.isArray(value)) {
-    return value.filter((v): v is string => v !== null && v !== undefined && typeof v === 'string');
+    return value.filter(isSelectableMorphologyForm);
   }
 
   return [];

--- a/src/utils/morphologyForms.ts
+++ b/src/utils/morphologyForms.ts
@@ -1,0 +1,12 @@
+const EMPTY_MORPHOLOGY_FORM_PLACEHOLDER = '—';
+
+/**
+ * Returns whether a persisted morphology-table value can be shown as a form.
+ * Empty cells are canonically null, but older records may contain blank strings
+ * or the admin grid's visual em-dash placeholder.
+ */
+export function isSelectableMorphologyForm(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed !== EMPTY_MORPHOLOGY_FORM_PLACEHOLDER;
+}

--- a/src/utils/tableScanner.ts
+++ b/src/utils/tableScanner.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { TableType } from '@/src/utils/schema-helpers';
+import { isSelectableMorphologyForm } from '@/src/utils/morphologyForms';
 import {
   ConjugationTableSchema,
   DeclensionTableSchema,
@@ -24,9 +25,9 @@ function isLeafNode(value: unknown): value is string[] | string | null {
 }
 
 function leafContainsForm(leaf: string[] | string | null, targetForm: string): boolean {
-  if (leaf === null) return false;
-  if (typeof leaf === 'string') return leaf === targetForm;
-  return leaf.includes(targetForm);
+  if (!isSelectableMorphologyForm(targetForm) || leaf === null) return false;
+  if (typeof leaf === 'string') return isSelectableMorphologyForm(leaf) && leaf === targetForm;
+  return leaf.some(form => isSelectableMorphologyForm(form) && form === targetForm);
 }
 
 function scanObjectForForm(
@@ -68,7 +69,7 @@ export function scanConjugationTable(table: ConjugationTable, targetForm: string
 }
 
 export function scanTableForMatchingForms(table: unknown, targetForm: string, tableType: TableType): MatchingPath[] {
-  if (!table || !targetForm) return [];
+  if (!table || !isSelectableMorphologyForm(targetForm)) return [];
 
   switch (tableType) {
     case 'conjugation':

--- a/tests/generatedVocabularyRoute.test.ts
+++ b/tests/generatedVocabularyRoute.test.ts
@@ -165,6 +165,37 @@ describe('student generated vocabulary route', () => {
     );
   });
 
+  it('filters placeholder forms before selecting from morphology cells', async () => {
+    mockVerifyAuthenticatedAccess.mockResolvedValue({ uid: 'student-1' });
+    mockCollection.mockReturnValue(query);
+    const verb = (id: string, forms: string[]) => ({
+      id,
+      data: () => ({
+        word: id,
+        part_of_speech: 'verb',
+        conjugation: '1',
+        conjugation_table: {
+          indicative: { active: { present: { singular: { first: forms } } } },
+        },
+      }),
+    });
+    query.get.mockResolvedValue({
+      docs: [verb('dash-only', ['—']), verb('blank-only', ['   ', '']), verb('amo', ['—', 'amo', ''])],
+      size: 3,
+      empty: false,
+    });
+
+    const response = await GET({
+      url: 'http://localhost/api/words/generated?collection=vocabulary_words_v5&exerciseMode=true&limit=3&tableType=conjugation&cellPaths=indicative.active.present.singular.first&steps=person',
+      headers: new Headers({ authorization: 'Bearer student-token' }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    const payload = (response as unknown as { body: { data: { words: Array<Record<string, unknown>> } } }).body;
+    expect(payload.data.words).toHaveLength(1);
+    expect(payload.data.words[0]).toMatchObject({ id: 'amo', selected_form: 'amo' });
+  });
+
   it.each([
     ['fetchAll', 'exerciseMode=true&fetchAll=true'],
     ['oversized limit', 'exerciseMode=true&limit=201'],

--- a/tests/morphologyForms.test.ts
+++ b/tests/morphologyForms.test.ts
@@ -1,0 +1,17 @@
+import { isSelectableMorphologyForm } from '@/src/utils/morphologyForms';
+
+describe('morphology form selection', () => {
+  it.each([
+    [null, false],
+    [undefined, false],
+    ['', false],
+    ['   ', false],
+    ['—', false],
+    [' — ', false],
+    ['-', true],
+    ['–', true],
+    ['amat', true],
+  ])('classifies %p as selectable: %p', (value, expected) => {
+    expect(isSelectableMorphologyForm(value)).toBe(expected);
+  });
+});

--- a/tests/morphologyWordReplenishment.test.ts
+++ b/tests/morphologyWordReplenishment.test.ts
@@ -134,6 +134,54 @@ describe('generated exercise word replenishment', () => {
     expect(result.diagnostics[0].scanned).toBeGreaterThan(10);
   });
 
+  it('filters placeholder forms and replenishes words with no usable selected forms', async () => {
+    const selectedPath = 'indicative.active.present.singular.first';
+    const formSelection = { tableType: 'conjugation' as const, selectedCellPaths: [selectedPath] };
+    const conjugationTable = (forms: string[]) => ({
+      indicative: { active: { present: { singular: { first: forms } } } },
+    });
+    const db = createFakeGeneratedWordDb({
+      words: [
+        verbDoc('aaa-dash-only', { conjugation_table: conjugationTable(['—']) }),
+        verbDoc('aab-blank-only', { conjugation_table: conjugationTable(['   ']) }),
+        verbDoc('real-form', { conjugation_table: conjugationTable(['—', 'amat', '']) }),
+      ],
+    });
+    const exercise = morphologyExercise(
+      {
+        'verb-conjugation': {
+          enabled: true,
+          filters: {},
+          steps: ['person'],
+          formSelection,
+        },
+      },
+      1
+    );
+    const result = await collectGeneratedExerciseWords({
+      db: db as never,
+      collection: 'vocabulary_words_v5',
+      specs: [
+        {
+          id: 'verb-conjugation',
+          paradigm: 'verb-conjugation',
+          partOfSpeech: 'verb',
+          filters: {},
+          tableType: 'conjugation',
+          steps: ['person'],
+          formSelection,
+        },
+      ],
+      count: 1,
+      exercise,
+      rng: createGeneratedExerciseRng(101),
+    });
+
+    expect(result.words).toHaveLength(1);
+    expect(result.words[0]).toMatchObject({ id: 'real-form', selected_form: 'amat' });
+    expect(result.diagnostics[0].scanned).toBeGreaterThan(1);
+  });
+
   it('returns all eligible words when the source is smaller than count', async () => {
     const db = createFakeGeneratedWordDb({
       words: [nounDoc('n1'), nounDoc('n2'), verbDoc('v1')],


### PR DESCRIPTION
## Summary
- treat blank strings and the standalone em dash placeholder as unavailable morphology forms
- filter contaminated leaves before random form selection in both generated-exercise paths
- skip and replenish words when none of their configured cells contain a usable form
- keep hyphen and en-dash values untouched

## Tests
- npm test -- --runInBand tests/morphologyForms.test.ts tests/morphologyWordReplenishment.test.ts tests/generatedVocabularyRoute.test.ts tests/generatedExercisePreviewRoute.test.ts tests/generatedExercisePlaybackRoute.test.ts tests/nonFiniteVerbFormIdentification.test.ts tests/generatedFormIdentificationFailureModes.test.ts
  - 84 tests passed
- npx tsc --noEmit
- targeted ESLint on all changed files
- git diff --check

## Lint baseline
The full npm run lint command still reports the existing require-style import errors in next.config.js and the existing anonymous-default-export warning in tests/helpers/sentryMock.ts. No changed file has an ESLint error.