### PR TITLE
Fix adjacent sentence-diagram label grading

### DIFF
--- a/src/features/sentence-diagramming/model.ts
+++ b/src/features/sentence-diagramming/model.ts
@@ -533,14 +533,20 @@ export const canonicalizeDiagramAnnotations = (
 
   tokenCoverageByKind.forEach((intervals, kind) => {
     mergeIntervals(intervals).forEach(interval => {
-      const span = {
-        startTokenIndex: interval.start,
-        endTokenIndex: interval.end - 1,
-        startCharOffset: 0,
-        endCharOffset: getTokenLength(tokens[interval.end - 1]),
-      };
-      const id = createAnnotationId(kind, span);
-      canonical.set(id, { id, kind, span });
+      // Token labels describe every covered word independently. Expanding the
+      // merged coverage back into token-sized annotations keeps a combined
+      // selection equivalent to separate selections while allowing partial
+      // answers on adjacent words to receive precise credit and feedback.
+      for (let tokenIndex = interval.start; tokenIndex < interval.end; tokenIndex += 1) {
+        const span = {
+          startTokenIndex: tokenIndex,
+          endTokenIndex: tokenIndex,
+          startCharOffset: 0,
+          endCharOffset: getTokenLength(tokens[tokenIndex]),
+        };
+        const id = createAnnotationId(kind, span);
+        canonical.set(id, { id, kind, span });
+      }
     });
   });
 

--- a/tests/sentence-diagramming/model.test.ts
+++ b/tests/sentence-diagramming/model.test.ts
@@ -15,6 +15,42 @@ const createAnnotation = (kind: DiagramAnnotation['kind'], span: DiagramSpan): D
 });
 
 describe('compareDiagramAnnotationSets', () => {
+  it('credits a tagged verb when the adjacent verb is still missing the same label', () => {
+    const tokens = tokenizeDiagramSentence('perīrent, audiēt');
+    const firstVerb = {
+      startTokenIndex: 0,
+      endTokenIndex: 0,
+      startCharOffset: 0,
+      endCharOffset: tokens[0].text.length,
+    };
+    const secondVerb = {
+      startTokenIndex: 1,
+      endTokenIndex: 1,
+      startCharOffset: 0,
+      endCharOffset: tokens[1].text.length,
+    };
+    const solution = [createAnnotation('active', firstVerb), createAnnotation('active', secondVerb)];
+    const student = [createAnnotation('active', firstVerb)];
+
+    expect(compareDiagramAnnotationSets(student, solution, tokens)).toMatchObject({
+      matched: 1,
+      expected: 2,
+      extra: 0,
+      isComplete: false,
+      matchedIds: [createAnnotationId('active', firstVerb)],
+      missingIds: [createAnnotationId('active', secondVerb)],
+      extraIds: [],
+      differences: [
+        {
+          type: 'missing',
+          span: secondVerb,
+          text: 'audiēt',
+          expectedKind: 'active',
+        },
+      ],
+    });
+  });
+
   it('treats adjacent token annotations of the same kind as equivalent to one combined span', () => {
     const tokens = tokenizeDiagramSentence('puella bona currit celeriter');
     const solution = [
@@ -41,10 +77,11 @@ describe('compareDiagramAnnotationSets', () => {
     ];
 
     expect(compareDiagramAnnotationSets(student, solution, tokens)).toMatchObject({
-      matched: 1,
-      expected: 1,
+      matched: 2,
+      expected: 2,
       extra: 0,
       isComplete: true,
+      differences: [],
     });
   });
 


### PR DESCRIPTION
## Summary

- canonicalize non-wrapper token labels per covered word
- preserve equivalence between one combined selection and separate adjacent selections
- give partial credit and precise feedback when only one adjacent verb is tagged
- add a regression using the production-reported `perīrent, audiēt` case

## Verification

- `npm test -- --runInBand` — 145 suites, 1,027 tests passed
- `npx tsc --noEmit`
- `npx eslint src/features/sentence-diagramming/model.ts tests/sentence-diagramming/model.test.ts`
- `git diff --check`

## Lint baseline

The repository-wide `npm run lint` still reports the existing two `@typescript-eslint/no-require-imports` errors in `next.config.js` and one warning in `tests/helpers/sentryMock.ts`. The changed files pass ESLint.